### PR TITLE
Send additional arguments to Fluent launcher

### DIFF
--- a/ansys/fluent/session.py
+++ b/ansys/fluent/session.py
@@ -144,6 +144,7 @@ class Session:
             self.stop_transcript()
             self.__channel.close()
             self.__channel = None
+            Session.__all_sessions.remove(self)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
optiSLang needs to pass `-license` argument to Fluent. Passing it within additional arguments as license option should not be exposed.