### PR TITLE
Fix tuigen append file locking issue + typos

### DIFF
--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -130,7 +130,7 @@ class TUIGenerator:
                 self._write_menu_to_tui_file(v, indent)
 
     def generate(self):
-        with open(self._tui_file, "a", encoding="utf8") as self.__writer:
+        with open(self._tui_file, "w", encoding="utf8") as self.__writer:
             self._populate_menu(self._main_menu)
             self._write_code_to_tui_file(
                 '"""\n'


### PR DESCRIPTION
- The tuigen had a few typos from attribute changes and could not run
- The output file was opened/appended/closed for each new line, on some machine the antivirus keeps that locked and the operation fail.  Optimized by having a single file open for the whole tui file writing.