### PR TITLE
Add test coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = */ansys/fluent/meshing/tui.py, */ansys/fluent/solver/tui.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,48 +69,12 @@ jobs:
       - name: Install pyfluent
         run: make install
 
+      - name: Install pyvistaqt requirements
+        if: matrix.os == 'ubuntu-latest'
+        run: make install-pyvistaqt-requirements
+
       - name: Test import
         run: make test-import
-        
-  test-post-import:
-    name: Post Import
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10'] 
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Linux pip cache
-        uses: actions/cache@v2
-        if: ${{ runner.os == 'Linux' }}
-        with:
-          path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
-          restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
-
-      - name: Window pip cache
-        uses: actions/cache@v2
-        if: ${{ runner.os == 'Windows' }}
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
-          restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
-
-      - name: Install pyfluent
-        run: make install
-
-      - name: Test post import
-        run: make test-post-import        
 
   build_test:
     name: Build and Unit Testing
@@ -135,6 +99,9 @@ jobs:
 
       - name: Install pyfluent
         run: make install
+
+      - name: Install pyvistaqt requirements
+        run: make install-pyvistaqt-requirements
 
       - name: Unit Testing
         run: make unittest

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,14 @@ install:
 	@python setup.py bdist_wheel
 	@pip install dist/*.whl
 
+install-pyvistaqt-requirements:
+	@sudo apt-get update
+	@sudo apt-get install libegl1 -y
+
 test-import:
 	@python -c "import ansys.fluent.solver as pyfluent"
 
-test-post-import:
-	@python -c "import ansys.fluent.postprocessing.pyvista as pv"
-  
 unittest:
 	@echo "Running unittest"
 	@pip install -r requirements_test.txt
-	@pytest -v
+	@pytest -v --cov=ansys.fluent --cov-report=term

--- a/ansys/fluent/__init__.py
+++ b/ansys/fluent/__init__.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     pass
 
+import ansys.fluent.postprocessing.pyvista as pv  # noqa: F401
+
 
 def set_log_level(level):
     """Set logging level

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-mock
+pytest-cov


### PR DESCRIPTION
Currently [printed](https://github.com/pyansys/pyfluent/runs/5229105359?check_suite_focus=true#step:7:103) in the console. We'll integrate with Codecov when we go public.

```
---------- coverage: platform linux, python 3.9.10-final-0 -----------
Name                                                                                                                 Stmts   Miss  Cover
----------------------------------------------------------------------------------------------------------------------------------------
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/__init__.py                             21      7    67%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/addons/parametric/__init__.py          236    148    37%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/addons/parametric_old/__init__.py      133     28    79%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/core/__init__.py                         3      0   100%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/core/_version.py                         2      0   100%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/core/core.py                            67     67     0%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/core/logging.py                         43     14    67%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/launcher/launcher.py                    94     76    19%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/postprocessing/pyvista/__init__.py       2      0   100%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/postprocessing/pyvista/graphics.py     193     69    64%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/postprocessing/pyvista/plotter.py      218    187    14%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/datamodel_se.py               280    197    30%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/datamodel_tui.py              153    119    22%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/field_data.py                  73     47    36%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/health_check.py                17      5    71%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/scheme_eval.py                102     21    79%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/settings.py                   129     90    30%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/services/transcript.py                  19     11    42%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/session.py                             126     72    43%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/solver/flobject.py                     320     57    82%
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/ansys/fluent/solver/meta.py                         284    128    55%
----------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                 2515   1343    47%
```