### PR TITLE
Avoid loading pyvista by default

### DIFF
--- a/ansys/fluent/__init__.py
+++ b/ansys/fluent/__init__.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     pass
 
-import ansys.fluent.postprocessing.pyvista as pv  # noqa: F401
-
 
 def set_log_level(level):
     """Set logging level

--- a/ansys/fluent/services/transcript.py
+++ b/ansys/fluent/services/transcript.py
@@ -4,7 +4,6 @@ import grpc
 
 from ansys.api.fluent.v0 import transcript_pb2 as TranscriptModule
 from ansys.api.fluent.v0 import transcript_pb2_grpc as TranscriptGrpcModule
-from ansys.fluent import LOG
 
 
 class TranscriptService:
@@ -39,8 +38,7 @@ class TranscriptService:
         while True:
             try:
                 yield next(self.__streams)
-            except Exception as e:
-                LOG.error(str(e))
+            except Exception:
                 break
 
     def end_streaming(self):


### PR DESCRIPTION
I changed to load pyvista by default to include the post-processing module in the testing coverage report, but that is problematic for optiSLang integration as pyvista/pyvistaqt will be required to be installed within optiSLang's Python. When we'll add unittests for postprocessing module it will be automatically covered.