### PR TITLE
Format using Google style, add clang format options

### DIFF
--- a/protos/ansys/api/fluent/v0/.clang_format
+++ b/protos/ansys/api/fluent/v0/.clang_format
@@ -1,0 +1,4 @@
+{BasedOnStyle: Google,
+ Language: Proto,
+ IndentWidth: 2,
+ ColumnLimit: 0}

--- a/protos/ansys/api/fluent/v0/fielddata.proto
+++ b/protos/ansys/api/fluent/v0/fielddata.proto
@@ -8,303 +8,266 @@ import "common.proto";
 
 package grpcRemoting;
 
-service FieldData
-{  
+service FieldData {
   /* Get fields e.g. scalar, vector, surfaces etc in a single request.*/
   rpc GetFields(GetFieldsRequest) returns (stream GetFieldsResponse);
-  
+
   /* Get scalar field range.*/
   rpc GetRange(GetRangeRequest) returns (GetRangeResponse) {}
-  
+
   /* Get surfaces info.*/
   rpc GetSurfacesInfo(GetSurfacesInfoRequest) returns (GetSurfacesInfoResponse) {}
-  
+
   /* Get vector fields info.*/
   rpc GetVectorFieldsInfo(GetVectorFieldsInfoRequest) returns (GetVectorFieldsInfoResponse) {}
-  
+
   /* Get scalar fields info.*/
   rpc GetFieldsInfo(GetFieldsInfoRequest) returns (GetFieldsInfoResponse) {}
-  
+
   /* Get surfaces data.*/
   rpc GetSurfaces(GetSurfacesRequest) returns (stream GetSurfacesResponse) {}
-  
+
   /* Get scalar field data.*/
   rpc GetScalarField(GetScalarFieldRequest) returns (stream GetScalarFieldResponse) {}
-  
+
   /* Get vector field data.*/
   rpc GetVectorField(GetVectorFieldRequest) returns (stream GetVectorFieldResponse) {}
-  
+
   /* Get pathlines field data.*/
   rpc GetPathlinesField(GetPathlinesFieldRequest) returns (stream GetPathlinesFieldResponse) {}
-  
+
   /* Get particle tracks field data.*/
-  rpc GetParticleTracksField(GetParticleTracksFieldRequest) returns (stream GetParticleTracksFieldResponse) {}  
-  
+  rpc GetParticleTracksField(GetParticleTracksFieldRequest) returns (stream GetParticleTracksFieldResponse) {}
+
   /*Check if boundary values are on.*/
   rpc IsBoundaryValuesOn(IsBoundaryValuesOnRequest) returns (IsBoundaryValuesOnResponse) {}
 }
 
-message DoublePayload
-{
+message DoublePayload {
   repeated double payload = 1;
 }
 
-message FloatPayload
-{
+message FloatPayload {
   repeated float payload = 1;
 }
 
-message IntPayload
-{
-  repeated sint32 payload = 1; 
+message IntPayload {
+  repeated sint32 payload = 1;
 }
 
-message LongPayload
-{
- repeated sint64 payload = 1; 
+message LongPayload {
+  repeated sint64 payload = 1;
 }
-/** 
+
+/**
  * Field Type
  */
-enum FieldType
-{        
-  INT_ARRAY = 0;    //Integer array.
-  LONG_ARRAY = 1;   //Long array.
-  FLOAT_ARRAY = 2;  //Float array.
-  DOUBLE_ARRAY = 3; //Double array.
+enum FieldType {
+  INT_ARRAY = 0;     // Integer array.
+  LONG_ARRAY = 1;    // Long array.
+  FLOAT_ARRAY = 2;   // Float array.
+  DOUBLE_ARRAY = 3;  // Double array.
 }
 
-/** 
+/**
  * Information about payload
  */
-message PayloadInfo
-{
-  uint64 surfaceId = 1;    //Surface id corresponding to field data. 
-  string fieldName = 2;    //Field name e.g. vertices, faces, temperature, vector etc.
-  FieldType fieldType = 3; //Field type.  
-  uint64 fieldSize = 4;    //Field size. For bytes it will be number of bytes otherwise array size. 
+message PayloadInfo {
+  uint64 surfaceId = 1;     // Surface id corresponding to field data.
+  string fieldName = 2;     // Field name e.g. vertices, faces, temperature, vector etc.
+  FieldType fieldType = 3;  // Field type.
+  uint64 fieldSize = 4;     // Field size. For bytes it will be number of bytes otherwise array size.
 }
 
-/** 
+/**
  * GetFieldsResponse can be either bytePayload or one of double/float/long/int payload.
- * Whether data is sent as bytes or as arrays of double/float/long/int depends upon value of provideBytesStream in GetFieldsRequest.
- * During streaming first payloadInfo is streamed and then corresponding data is streamed.
+ * Whether data is sent as bytes or as arrays of double/float/long/int depends upon value
+ * of provideBytesStream in GetFieldsRequest. During streaming first payloadInfo is
+ * streamed and then corresponding data is streamed.
  */
-message GetFieldsResponse{
-  oneof chunk
-  {
-    bytes bytePayload = 1;           //Bytes payload.
-    DoublePayload doublePayload = 2; //Double payload.
-    FloatPayload floatPayload = 3;   //Float payload.
-    LongPayload longPayload = 4;     //Long payload. 
-    IntPayload intPayload = 5;       //Int payload.
-    PayloadInfo payloadInfo = 6;     //Payload info. 
-  } 
+message GetFieldsResponse {
+  oneof chunk {
+    bytes bytePayload = 1;            // Bytes payload.
+    DoublePayload doublePayload = 2;  // Double payload.
+    FloatPayload floatPayload = 3;    // Float payload.
+    LongPayload longPayload = 4;      // Long payload.
+    IntPayload intPayload = 5;        // Int payload.
+    PayloadInfo payloadInfo = 6;      // Payload info.
+  }
 }
-/** 
+
+/**
  * Request for surface data.
- * Surface data consists of information about vertices and their connectivity. 
+ * Surface data consists of information about vertices and their connectivity.
  * Connectivity information is provided only if provideFaces is True.
- */ 
-message SurfaceRequest
-{
-  uint64 surfaceId = 1;  //Surface id. 
-  bool oversetMesh = 2;  //Provide overset mesh. 
-  bool provideFaces = 3; //Provide faces information i.e. vertices connectivity.
+ */
+message SurfaceRequest {
+  uint64 surfaceId = 1;   // Surface id.
+  bool oversetMesh = 2;   // Provide overset mesh.
+  bool provideFaces = 3;  // Provide faces information i.e. vertices connectivity.
 }
 
-enum DataLocation
-{
+enum DataLocation {
   Nodes = 0;
-  Elements = 1;        
+  Elements = 1;
 }
 
-/** 
+/**
  * Request for scalar field data
- */  
-message ScalarFieldRequest
-{
-  uint64 surfaceId = 1;           //Surface id for scalar field.
-  string scalarFieldName = 2;     //Scalar field name.
-  DataLocation dataLocation = 3;   //Scalar Field location (Nodes/Elements).
-  bool provideBoundaryValues = 4; //Provide boundary values.
+ */
+message ScalarFieldRequest {
+  uint64 surfaceId = 1;            // Surface id for scalar field.
+  string scalarFieldName = 2;      // Scalar field name.
+  DataLocation dataLocation = 3;   // Scalar Field location (Nodes/Elements).
+  bool provideBoundaryValues = 4;  // Provide boundary values.
 }
 
-/** 
+/**
  * Request for vector field data.
- */  
-message VectorFieldRequest
-{
-  uint64 surfaceId = 1;            //Surface id for vector field. 
-  string vectorFieldName = 2;      //Vector field name. 
-  bool provideFacesCentroid = 3;   //Provide faces centroid.
-  bool provideFacesAreaNormal = 4; //Provide faces area normal.  
+ */
+message VectorFieldRequest {
+  uint64 surfaceId = 1;             // Surface id for vector field.
+  string vectorFieldName = 2;       // Vector field name.
+  bool provideFacesCentroid = 3;    // Provide faces centroid.
+  bool provideFacesAreaNormal = 4;  // Provide faces area normal.
 }
 
-/** 
+/**
  * Request for fields.
- */  
-message GetFieldsRequest{
-  uint32 chunkSize = 1;      //Chunk size. Default chunk size is 256kb. Minimum chunk size is 8b and Maximum is 4Mb.
-  //If true chunks of bytes will be streamed. Otherwise chunks of int/long/float or double array will be streamed.
-  bool provideBytesStream = 2;   
-  repeated SurfaceRequest surfaceRequest = 3;         //Surface request. 
-  repeated ScalarFieldRequest scalarFieldRequest = 4; //Scalar field request. 
-  repeated VectorFieldRequest vectorFieldRequest = 5; //Vector field request.
+ * - Default chunk size is 256kb. Minimum chunk size is 8b and Maximum is 4Mb.
+ * - If true chunks of bytes will be streamed. Otherwise chunks of int/long/float or double array will be streamed.
+ */
+message GetFieldsRequest {
+  uint32 chunkSize = 1;                                // Chunk size.
+  bool provideBytesStream = 2;                         // Bytes are streamed if true
+  repeated SurfaceRequest surfaceRequest = 3;          // Surface request.
+  repeated ScalarFieldRequest scalarFieldRequest = 4;  // Scalar field request.
+  repeated VectorFieldRequest vectorFieldRequest = 5;  // Vector field request.
 }
 
-enum DataStampingType
-{
+enum DataStampingType {
   IterationIndex = 0;
-  TimeStepIndex = 1;        
+  TimeStepIndex = 1;
   FlowTime = 2;
-  SolidTime = 3; 
+  SolidTime = 3;
   CaseID = 4;
   MeshID = 5;
   DataID = 6;
 }
 
-message DataStamping
-{
+message DataStamping {
   DataStampingType datastampingtype = 1;
-  oneof as
-  {
+  oneof as {
     double doublevalue = 2;
     sint64 intvalue = 3;
-  }   
+  }
 }
 
-message UnitInfo
-{
+message UnitInfo {
   string name = 1;
-  string unit = 2;  
+  string unit = 2;
   double factor = 3;
-  double offset = 4;  
+  double offset = 4;
   string label = 5;
 }
 
-message DataStampingInfo
-{
+message DataStampingInfo {
   repeated DataStamping datastamping = 1;
 }
 
-message SurfaceId 
-{
+message SurfaceId {
   sint64 id = 1;
 }
 
-message GetSurfacesRequest
-{
+message GetSurfacesRequest {
   repeated SurfaceId surfaceid = 1;
   bool oversetMesh = 2;
   DataStampingInfo datastampinginfo = 3;
   repeated SurfaceId availablesurfaces = 4;
 }
 
-message SurfaceMetaData
-{
+message SurfaceMetaData {
   DataStampingInfo datastampinginfo = 1;
   UnitInfo lengthunit = 2;
 }
 
-message Coordinate
-{
+message Coordinate {
   double x = 1;
   double y = 2;
   double z = 3;
 }
 
-message Facet
-{
+message Facet {
   repeated sint32 node = 1;
 }
-  
-message SurfaceInfo
-{
+
+message SurfaceInfo {
   repeated SurfaceId surfaceId = 1;
   SurfaceId zoneId = 2;
   string surfaceName = 3;
   string zoneType = 4;
-  string type = 5;  
+  string type = 5;
 }
 
-message SurfaceData
-{
+message SurfaceData {
   SurfaceId surfaceid = 1;
   repeated Coordinate point = 2;
   repeated Facet facet = 3;
-  oneof as
-  {
+  oneof as {
     Empty empty_state = 5;
     SurfaceMetaData surfacemetadata = 6;
-  }   
-}
-  
-message GetSurfacesResponse
-{
-   SurfaceData surfacedata = 1;  
+  }
 }
 
-message GetRangeRequest
-{
+message GetSurfacesResponse {
+  SurfaceData surfacedata = 1;
+}
+
+message GetRangeRequest {
   string fieldName = 1;
   repeated SurfaceId surfaceid = 2;
   bool nodeValue = 3;
 }
 
-message GetRangeResponse
-{
+message GetRangeResponse {
   double minimum = 1;
   double maximum = 2;
 }
 
-message FieldInfo
-{
+message FieldInfo {
   string displayName = 1;
   string solverName = 2;
   string section = 3;
   string domain = 4;
 }
 
-message GetFieldsInfoRequest
-{
-
+message GetFieldsInfoRequest {
 }
 
-message GetFieldsInfoResponse
-{
+message GetFieldsInfoResponse {
   repeated FieldInfo fieldInfo = 1;
 }
 
-message GetVectorFieldsInfoRequest
-{
-
+message GetVectorFieldsInfoRequest {
 }
-message VectorFieldInfo
-{
+message VectorFieldInfo {
   string displayName = 1;
   string xComponent = 2;
   string yComponent = 3;
   string zComponent = 4;
 }
 
-message GetVectorFieldsInfoResponse
-{
+message GetVectorFieldsInfoResponse {
   repeated VectorFieldInfo vectorFieldInfo = 1;
 }
 
-message GetSurfacesInfoRequest
-{
-
-
+message GetSurfacesInfoRequest {
 }
-message GetSurfacesInfoResponse
-{
-  repeated SurfaceInfo surfaceInfo = 1;  
+message GetSurfacesInfoResponse {
+  repeated SurfaceInfo surfaceInfo = 1;
 }
 
-message GetScalarFieldRequest
-{
+message GetScalarFieldRequest {
   repeated SurfaceId surfaceid = 1;
   string scalarfield = 2;
   bool nodevalue = 3;
@@ -312,114 +275,97 @@ message GetScalarFieldRequest
   DataStampingInfo datastampinginfo = 4;
   repeated SurfaceId availablesurfaces = 5;
   repeated SurfaceId availablescalarfield = 6;
-
 }
 
-message GlobalRange
-{
+message GlobalRange {
   double globalmin = 1;
   double globalmax = 2;
 }
 
-message ScalarFieldMetaData
-{
+message ScalarFieldMetaData {
   DataStampingInfo datastampinginfo = 1;
   UnitInfo lengthunit = 2;
   GlobalRange scalarFieldrange = 3;
   UnitInfo scalarfieldunit = 4;
 }
 
-message VectorComponents
-{
+message VectorComponents {
   double x = 1;
   double y = 2;
   double z = 3;
 }
 
-message ScalarField
-{  
+message ScalarField {
   repeated double data = 1;
 }
 
-message VectorField
-{
+message VectorField {
   repeated VectorComponents vectorComponents = 1;
 }
 
-message ActiveField
-{
+message ActiveField {
   repeated sint64 active = 1;
 }
 
-message ScalarFieldData
-{
-  SurfaceId  surfaceid = 1;
+message ScalarFieldData {
+  SurfaceId surfaceid = 1;
   SurfaceData surfacedata = 2;
   ScalarField scalarfield = 3;
-  ActiveField activefield = 4;  
-  
-  oneof as
-  {
+  ActiveField activefield = 4;
+
+  oneof as {
     Empty empty_state = 5;
     ScalarFieldMetaData scalarfieldmetadata = 6;
-  }  
+  }
 }
 
-message GetScalarFieldResponse
-{
- ScalarFieldData scalarfielddata = 1;
+message GetScalarFieldResponse {
+  ScalarFieldData scalarfielddata = 1;
 }
 
-message GetVectorFieldRequest
-{
+message GetVectorFieldRequest {
   repeated SurfaceId surfaceid = 1;
   string scalarfield = 2;
-  bool nodevalue = 3;  
+  bool nodevalue = 3;
   string vectorfield = 4;
-  
+
   DataStampingInfo datastampinginfo = 6;
   repeated SurfaceId availablesurfaces = 7;
-  repeated SurfaceId availablescalarfield = 8;  
-  repeated SurfaceId availablevectorfield = 9;    
+  repeated SurfaceId availablescalarfield = 8;
+  repeated SurfaceId availablevectorfield = 9;
 }
-  
-message VectorFieldMetaData
-{
+
+message VectorFieldMetaData {
   DataStampingInfo datastampinginfo = 1;
   UnitInfo lengthunit = 2;
   GlobalRange scalarFieldrange = 3;
   UnitInfo scalarfieldunit = 4;
 }
 
-message VectorScale
-{
+message VectorScale {
   double data = 1;
 }
 
-message VectorFieldData
-{
+message VectorFieldData {
   SurfaceId surfaceid = 1;
   SurfaceData surfacedata = 2;
   ScalarField scalarfield = 3;
-  ActiveField activefield = 4;  
-  oneof as 
-  {
+  ActiveField activefield = 4;
+  oneof as {
     Empty empty_state = 5;
     VectorFieldMetaData vectorfieldmetadata = 6;
-  }     
+  }
   VectorField base = 7;
   VectorField vector = 8;
-  VectorField normal = 9 ;    
-  VectorScale vectorscale = 10;  
+  VectorField normal = 9;
+  VectorScale vectorscale = 10;
 }
 
-message GetVectorFieldResponse
-{
+message GetVectorFieldResponse {
   VectorFieldData vectorfielddata = 1;
 }
 
-message GetPathlinesFieldRequest
-{
+message GetPathlinesFieldRequest {
   repeated SurfaceId releaseFrom = 1;
   string field1 = 2;
   string field2 = 3;
@@ -427,18 +373,17 @@ message GetPathlinesFieldRequest
   sint32 steps = 5;
   double stepSize = 6;
   sint32 skip = 8;
-  bool reverse = 9;  
-  bool accuracyControlOn = 10;  
+  bool reverse = 9;
+  bool accuracyControlOn = 10;
   double tolerance = 11;
   sint32 coarsen = 12;
-  string zone = 13 [deprecated=true];  
+  string zone = 13 [deprecated = true];
   string velocityDomain = 14;
   DataStampingInfo dataStampingInfo = 15;
-  repeated string zones =16;
+  repeated string zones = 16;
 }
 
-message PathlineMetaData
-{
+message PathlineMetaData {
   DataStampingInfo dataStampingInfo = 1;
   UnitInfo lengthUnit = 2;
   GlobalRange scalarFieldRange = 3;
@@ -447,50 +392,43 @@ message PathlineMetaData
   UnitInfo timeUnit = 6;
 }
 
-message PathlineFieldData
-{
-  sint64 particleId = 1;  
-  repeated double particlePositions = 2;  
+message PathlineFieldData {
+  sint64 particleId = 1;
+  repeated double particlePositions = 2;
   repeated double particleTime = 3;
   repeated double field1 = 4;
   repeated double field2 = 5;
   sint64 beginStep = 6;
-  sint64 endStep = 7;    
+  sint64 endStep = 7;
 }
 
-message PathlineData
-{
-  oneof as 
-  {
+message PathlineData {
+  oneof as {
     PathlineFieldData pathlineFieldData = 1;
     PathlineMetaData pathlineMetaData = 2;
   }
-  
 }
 
-message GetPathlinesFieldResponse
-{
+message GetPathlinesFieldResponse {
   PathlineData pathlineData = 1;
 }
 
-message ParticleTracksFilter
-{
+message ParticleTracksFilter {
   string field = 1;
   GlobalRange filterRange = 2;
   bool insideRange = 3;
 }
 
-message GetParticleTracksFieldRequest
-{
+message GetParticleTracksFieldRequest {
   repeated string releaseFrom = 1;
-  string field1 = 2; // to color
-  string field2 = 3;  // either spehere[only particle variable] or ribbon[non particle]
-  string field3 = 4;  // vector
-  string vectorsOf = 5;// vector
+  string field1 = 2;     // to color
+  string field2 = 3;     // either spehere[only particle variable] or ribbon[non particle]
+  string field3 = 4;     // vector
+  string vectorsOf = 5;  // vector
   bool nodeValue = 6;
   sint32 skip = 7;
-  sint32 singleStreamId = 8; // if < 0 all stream will tracked. Otherwise single stream will be tracked
-  sint32 coarsen =9;
+  sint32 singleStreamId = 8;  // if < 0 all stream will tracked. Otherwise single stream will be tracked
+  sint32 coarsen = 9;
   bool freeStreamParticles = 10;
   bool wallFilmParticles = 11;
   bool pdfParticles = 12;
@@ -498,8 +436,7 @@ message GetParticleTracksFieldRequest
   DataStampingInfo dataStampingInfo = 14;
 }
 
-message ParticleTrackMetaData
-{
+message ParticleTrackMetaData {
   DataStampingInfo dataStampingInfo = 1;
   UnitInfo lengthUnit = 2;
   GlobalRange scalarFieldRange = 3;
@@ -508,39 +445,32 @@ message ParticleTrackMetaData
   UnitInfo timeUnit = 6;
 }
 
-message ParticleTrackFieldData
-{
-  sint64 particleId = 1;  
-  ScalarField particlePosition = 2;  
+message ParticleTrackFieldData {
+  sint64 particleId = 1;
+  ScalarField particlePosition = 2;
   ScalarField particleTime = 3;
-  ScalarField field1= 4;
-  ScalarField field2= 5;
-  ScalarField field3= 6;
+  ScalarField field1 = 4;
+  ScalarField field2 = 5;
+  ScalarField field3 = 6;
   VectorField particleVelocity = 7;
   double particleStartTime = 8;
-  double particleEndTime = 9;    
+  double particleEndTime = 9;
 }
 
-message ParticleTrackData
-{
-  oneof as 
-  {
+message ParticleTrackData {
+  oneof as {
     ParticleTrackFieldData particleTrackFieldData = 1;
     ParticleTrackMetaData particleTrackMetaData = 2;
   }
-  
 }
 
-message GetParticleTracksFieldResponse
-{
-  ParticleTrackData particleTrackData = 1;   
+message GetParticleTracksFieldResponse {
+  ParticleTrackData particleTrackData = 1;
 }
 
-message IsBoundaryValuesOnRequest
-{
+message IsBoundaryValuesOnRequest {
 }
 
-message IsBoundaryValuesOnResponse
-{
+message IsBoundaryValuesOnResponse {
   bool isboundaryvalueson = 1;
 }

--- a/protos/ansys/api/fluent/v0/scheme_eval.proto
+++ b/protos/ansys/api/fluent/v0/scheme_eval.proto
@@ -9,17 +9,16 @@ import "common.proto";
 
 package grpcRemoting;
 
-service SchemeEval
-{
-  rpc Eval (SchemePointer) returns (SchemePointer);
-  rpc Exec (ExecRequest) returns (ExecResponse);
-  rpc StringEval (StringEvalRequest) returns (StringEvalResponse);
+service SchemeEval {
+  rpc Eval(SchemePointer) returns (SchemePointer);
+  rpc Exec(ExecRequest) returns (ExecResponse);
+  rpc StringEval(StringEvalRequest) returns (StringEvalResponse);
 }
 
 message ExecRequest {
-  repeated string  command = 1;
-  bool wait =2;
-  bool silent = 3; // if true, input won't be printed
+  repeated string command = 1;
+  bool wait = 2;
+  bool silent = 3;  // if true, input won't be printed
 }
 
 message ExecResponse {
@@ -33,4 +32,3 @@ message StringEvalRequest {
 message StringEvalResponse {
   string output = 1;
 }
-

--- a/protos/ansys/api/fluent/v0/scheme_pointer.proto
+++ b/protos/ansys/api/fluent/v0/scheme_pointer.proto
@@ -10,18 +10,18 @@ package grpcRemoting;
 
 message SchemePointer {
   message SchemePair {
-      SchemePointer car = 1;
-      SchemePointer cdr = 2;
+    SchemePointer car = 1;
+    SchemePointer cdr = 2;
   }
 
   oneof val {
-      Empty empty = 1;
-      string sym = 2;
-      SchemePair pair = 3;
-      double flonum = 4;
-      sint64 fixednum = 5;
-      string c = 6;
-      string str = 7;
-      bool b = 8;
+    Empty empty = 1;
+    string sym = 2;
+    SchemePair pair = 3;
+    double flonum = 4;
+    sint64 fixednum = 5;
+    string c = 6;
+    string str = 7;
+    bool b = 8;
   }
 }

--- a/protos/ansys/api/fluent/v0/settings.proto
+++ b/protos/ansys/api/fluent/v0/settings.proto
@@ -6,48 +6,46 @@ syntax = "proto3";
 
 package ansys.api.fluent.v0.settings;
 
-service Settings
-{
-  /* Static info about objects (type, children, commands, arguments,
-     object-type) in a recursive manner.
+service Settings {
+  /* Static info about objects (type, children, commands, arguments, object-type) in a recursive manner.
      This rpc is deprecated, use GetStaticInfo instead */
-  rpc GetObjectStaticInfo (GetObjectStaticInfoRequest) returns (GetObjectStaticInfoResponse) {
+  rpc GetObjectStaticInfo(GetObjectStaticInfoRequest) returns (GetObjectStaticInfoResponse) {
     option deprecated = true;
   };
 
   /* Static info about objects (type, children, commands, arguments,
      object-type) in a recursive manner. */
-  rpc GetStaticInfo (GetStaticInfoRequest) returns (GetStaticInfoResponse);
+  rpc GetStaticInfo(GetStaticInfoRequest) returns (GetStaticInfoResponse);
 
   /* Get the value of a path */
-  rpc GetVar (GetVarRequest) returns (GetVarResponse);
+  rpc GetVar(GetVarRequest) returns (GetVarResponse);
 
   /* Set the value of a path */
-  rpc SetVar (SetVarRequest) returns (SetVarResponse);
+  rpc SetVar(SetVarRequest) returns (SetVarResponse);
 
   /* Rename an object */
-  rpc Rename (RenameRequest) returns (RenameResponse);
+  rpc Rename(RenameRequest) returns (RenameResponse);
 
   /* Create a new object */
-  rpc Create (CreateRequest) returns (CreateResponse);
+  rpc Create(CreateRequest) returns (CreateResponse);
 
   /* Delete an object */
-  rpc Delete (DeleteRequest) returns (DeleteResponse);
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
 
   /* Get the current list of object names */
-  rpc GetObjectNames (GetObjectNamesRequest) returns (GetObjectNamesResponse);
+  rpc GetObjectNames(GetObjectNamesRequest) returns (GetObjectNamesResponse);
 
   /* Get the number of elements in a list object */
-  rpc GetListSize (GetListSizeRequest) returns (GetListSizeResponse);
+  rpc GetListSize(GetListSizeRequest) returns (GetListSizeResponse);
 
   /* Resize a list object */
-  rpc ResizeListObject (ResizeListObjectRequest) returns (ResizeListObjectResponse);
+  rpc ResizeListObject(ResizeListObjectRequest) returns (ResizeListObjectResponse);
 
   /* Execute a command */
-  rpc ExecuteCommand (ExecuteCommandRequest) returns (ExecuteCommandResponse);
+  rpc ExecuteCommand(ExecuteCommandRequest) returns (ExecuteCommandResponse);
 
   /* Attribute access */
-  rpc GetAttrs (GetAttrsRequest) returns (GetAttrsResponse);
+  rpc GetAttrs(GetAttrsRequest) returns (GetAttrsResponse);
 }
 
 /* Represents value of an object -- return value of GetVar */

--- a/protos/ansys/api/fluent/v0/transcript.proto
+++ b/protos/ansys/api/fluent/v0/transcript.proto
@@ -7,20 +7,11 @@ syntax = "proto3";
 option objc_class_prefix = "HLW";
 
 package grpcRemoting;
-service Transcript
-{
 
-  rpc BeginStreaming (TranscriptRequest) returns (stream TranscriptResponse) {}
-
-}
-message TranscriptRequest
-{
+service Transcript {
+  rpc BeginStreaming(TranscriptRequest) returns (stream TranscriptResponse) {}
 }
 
-message TranscriptResponse
-{
-  string  transcript   = 1;
-}
+message TranscriptRequest {}
 
-
-
+message TranscriptResponse { string transcript = 1; }

--- a/protos/ansys/api/fluent/v0/variant.proto
+++ b/protos/ansys/api/fluent/v0/variant.proto
@@ -4,50 +4,36 @@
 
 syntax = "proto3";
 
-
-
 package utils;
 
-message Empty {
-}
-message StringVector {
-  repeated string item = 1;
-}
+message Empty {}
 
-message DoubleVector {
-  repeated double item = 1;
-}
+message StringVector { repeated string item = 1; }
 
-message BoolVector {
-  repeated bool item = 1;
-}
+message DoubleVector { repeated double item = 1; }
 
-message Int64Vector {
-  repeated sint64 item = 1;
-}
-message VariantMap {
-  map<string, Variant> item = 1;
-}
+message BoolVector { repeated bool item = 1; }
 
+message Int64Vector { repeated sint64 item = 1; }
 
-message VariantVector {
-  repeated Variant item = 1;
-}
+message VariantMap { map<string, Variant> item = 1; }
+
+message VariantVector { repeated Variant item = 1; }
 
 message Variant {
   oneof as {
-      utils.Empty empty_state = 1;
+    utils.Empty empty_state = 1;
 
-      bool bool_state = 2;
-      sint64 int64_state = 3;
-      double double_state = 5;
-      string string_state = 6;
+    bool bool_state = 2;
+    sint64 int64_state = 3;
+    double double_state = 5;
+    string string_state = 6;
 
-      BoolVector bool_vector_state = 7;
-      Int64Vector int64_vector_state = 8;
-      DoubleVector double_vector_state = 9;
-      StringVector string_vector_state = 10;
-      VariantVector variant_vector_state = 11;
-      VariantMap variant_map_state = 12;
+    BoolVector bool_vector_state = 7;
+    Int64Vector int64_vector_state = 8;
+    DoubleVector double_vector_state = 9;
+    StringVector string_vector_state = 10;
+    VariantVector variant_vector_state = 11;
+    VariantMap variant_map_state = 12;
   }
 }


### PR DESCRIPTION
This is using Google style for the protobuf files.  I used clang format 13 to reformat them, options are in the .clang_format file.  If you run clang format in that directory the options file is automatically picked up.