### PR TITLE
Make some imports more specific

### DIFF
--- a/ansys/fluent/launcher/launcher.py
+++ b/ansys/fluent/launcher/launcher.py
@@ -10,8 +10,8 @@ from typing import Any, Dict
 from ansys.fluent.core import LOG
 from ansys.fluent.session import Session
 
-THIS_DIR = os.path.dirname(__file__)
-OPTIONS_FILE = os.path.join(THIS_DIR, "fluent_launcher_options.json")
+_THIS_DIR = os.path.dirname(__file__)
+_OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
 FLUENT_VERSION = "22.2"
 
 
@@ -112,7 +112,7 @@ def launch_fluent(
     launch_string = exe_path
     argvals = locals()
     all_options = None
-    with open(OPTIONS_FILE, encoding="utf-8") as fp:
+    with open(_OPTIONS_FILE, encoding="utf-8") as fp:
         all_options = json.load(fp)
     for k, v in all_options.items():
         argval = argvals.get(k)

--- a/ansys/fluent/services/error_handler.py
+++ b/ansys/fluent/services/error_handler.py
@@ -2,7 +2,7 @@ import functools
 
 import grpc
 
-from ansys.fluent import LOG
+from ansys.fluent.core import LOG
 
 
 def catch_grpc_error(f):

--- a/ansys/fluent/services/interceptors.py
+++ b/ansys/fluent/services/interceptors.py
@@ -4,7 +4,7 @@
 import grpc
 from google.protobuf.json_format import MessageToDict
 
-from ansys.fluent import LOG
+from ansys.fluent.core import LOG
 
 
 class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):

--- a/ansys/fluent/session.py
+++ b/ansys/fluent/session.py
@@ -19,7 +19,7 @@ from ansys.fluent.services.health_check import HealthCheckService
 from ansys.fluent.services.scheme_eval import SchemeEval, SchemeEvalService
 from ansys.fluent.services.settings import SettingsService
 from ansys.fluent.services.transcript import TranscriptService
-from ansys.fluent.solver import flobject
+from ansys.fluent.solver.flobject import get_root as settings_get_root
 
 
 def parse_server_info_file(filename: str):
@@ -143,7 +143,7 @@ class Session:
         """Return root settings object"""
         if self._settings_root is None:
             LOG.warning("The settings API is currently experimental.")
-            self._settings_root = flobject.get_root(
+            self._settings_root = settings_get_root(
                     flproxy = self.get_settings_service()
                     )
         return self._settings_root


### PR DESCRIPTION
The logger imports in the services packages caused circular dependency if ansys.fluent package is not initialized before the a service module dependent on ansys.fluent is imported.