### PR TITLE
wait for data model commands to execute

### DIFF
--- a/ansys/api/fluent/v0/scheme_eval_pb2.py
+++ b/ansys/api/fluent/v0/scheme_eval_pb2.py
@@ -11,8 +11,8 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-import ansys.api.fluent.v0.scheme_pointer_pb2 as scheme__pointer__pb2
 import ansys.api.fluent.v0.common_pb2 as common__pb2
+import ansys.api.fluent.v0.scheme_pointer_pb2 as scheme__pointer__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -21,9 +21,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x11scheme_eval.proto\x12\x0cgrpcRemoting\x1a\x14scheme_pointer.proto\x1a\x0c\x63ommon.proto\"<\n\x0b\x45xecRequest\x12\x0f\n\x07\x63ommand\x18\x01 \x03(\t\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0e\n\x06silent\x18\x03 \x01(\x08\"\x1e\n\x0c\x45xecResponse\x12\x0e\n\x06output\x18\x01 \x01(\t\"\"\n\x11StringEvalRequest\x12\r\n\x05input\x18\x01 \x01(\t\"$\n\x12StringEvalResponse\x12\x0e\n\x06output\x18\x01 \x01(\t2\xde\x01\n\nSchemeEval\x12@\n\x04\x45val\x12\x1b.grpcRemoting.SchemePointer\x1a\x1b.grpcRemoting.SchemePointer\x12=\n\x04\x45xec\x12\x19.grpcRemoting.ExecRequest\x1a\x1a.grpcRemoting.ExecResponse\x12O\n\nStringEval\x12\x1f.grpcRemoting.StringEvalRequest\x1a .grpcRemoting.StringEvalResponseb\x06proto3'
+  serialized_pb=b'\n\x11scheme_eval.proto\x12\x0cgrpcRemoting\x1a\x0c\x63ommon.proto\x1a\x14scheme_pointer.proto\"<\n\x0b\x45xecRequest\x12\x0f\n\x07\x63ommand\x18\x01 \x03(\t\x12\x0c\n\x04wait\x18\x02 \x01(\x08\x12\x0e\n\x06silent\x18\x03 \x01(\x08\"\x1e\n\x0c\x45xecResponse\x12\x0e\n\x06output\x18\x01 \x01(\t\"\"\n\x11StringEvalRequest\x12\r\n\x05input\x18\x01 \x01(\t\"$\n\x12StringEvalResponse\x12\x0e\n\x06output\x18\x01 \x01(\t2\xde\x01\n\nSchemeEval\x12@\n\x04\x45val\x12\x1b.grpcRemoting.SchemePointer\x1a\x1b.grpcRemoting.SchemePointer\x12=\n\x04\x45xec\x12\x19.grpcRemoting.ExecRequest\x1a\x1a.grpcRemoting.ExecResponse\x12O\n\nStringEval\x12\x1f.grpcRemoting.StringEvalRequest\x1a .grpcRemoting.StringEvalResponseb\x06proto3'
   ,
-  dependencies=[scheme__pointer__pb2.DESCRIPTOR,common__pb2.DESCRIPTOR,])
+  dependencies=[common__pb2.DESCRIPTOR,scheme__pointer__pb2.DESCRIPTOR,])
 
 
 

--- a/ansys/fluent/services/datamodel_se.py
+++ b/ansys/fluent/services/datamodel_se.py
@@ -598,6 +598,7 @@ class PyCommand:
         request.rules = self.rules
         request.path = _convert_path_to_se_path(self.path)
         request.command = self.command
+        request.wait = True
         _convert_value_to_variant(kwds, request.args)
         response = self.service.execute_command(request)
         return _convert_variant_to_value(response.result)


### PR DESCRIPTION
set wait=True for data model commands. Otherwise the response result is not assigned. The change fixes this issue: https://github.com/pyansys/pyfluent/issues/101.

e.g.
```
>>> import ansys.fluent as pyfluent
>>> session = pyfluent.launch_fluent(meshing_mode=True)
>>> w = session.workflow
>>> status=w.initialize_workflow(WorkflowType="Fault-tolerant Meshing")
>>> print(status)
True
>>> status=w.initialize_workflow(WorkflowType="Fault-Tolerant Meshing")
>>> print(status)
False
```

Before changes:
```
>>> import ansys.fluent as pyfluent
>>> session = pyfluent.launch_fluent(meshing_mode=True)
>>> w = session.workflow
>>> status=w.initialize_workflow(WorkflowType="Fault-tolerant Meshing")
>>> print(status)
>>> status=w.initialize_workflow(WorkflowType="Fault-Tolerant Meshing")
>>> print(status)
```
