### PR TITLE
part mgmt

### DIFF
--- a/ansys/fluent/session.py
+++ b/ansys/fluent/session.py
@@ -124,7 +124,7 @@ class Session:
         )
         self.meshing = PyMenu_SE(self.__datamodel_service_se, "meshing")
         self.workflow = PyMenu_SE(self.__datamodel_service_se, "workflow")
-        self.part_management = PyMenu_SE(self.__datamodel_service_se, 
+        self.part_management = PyMenu_SE(self.__datamodel_service_se,
                                          "PartManagement")
 
         self.__health_check_service = HealthCheckService(


### PR DESCRIPTION
Add part management for FTM workflows. See this issue: https://github.com/pyansys/pyfluent/issues/108

With this change, it is exposed:

```
>>> import ansys.fluent as pyfluent
>>> s = pyfluent.launch_fluent(meshing_mode=True)
>>> s.workflow.initialize_workflow(workflow_type='Fault-tolerant Meshing')
<Future at 0x1c8e5dd4910 state=running>
>>> s.part_management
<ansys.fluent.services.datamodel_se.PyMenu object at 0x000001C8E5DCF940>
>>> dir(s.part_management)
['append_fmd_files', 'assembly_node', 'change_file_length_unit', 'change_length_unit', 'create_obj_for_each_part', 'create_objects', 'delete', 'delete_paths', 'global_settings', 'initialize_template', 'input_file_changed', 'list_meshing_operations', 'load_fmd_file', 'load_template', 'meshing_operations', 'move_c_a_d_components_to_new_object', 'move_to_object', 'node', 'object_setting', 'object_setting_operations', 'redo_all_transforms', 'refaceting', 'refaceting_operations', 'reset_template', 'save_fmd_file', 'save_template', 'transform', 'transform_operations', 'undo_all_transforms']
```