### PR TITLE
allow specific path to find fluent install/build other than AWP one s…

### DIFF
--- a/ansys/fluent/launcher/launcher.py
+++ b/ansys/fluent/launcher/launcher.py
@@ -15,16 +15,17 @@ _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
 FLUENT_VERSION = "22.2"
 
 
-def _get_awp_path():
-    if "AWP_ROOT" in os.environ:
-        awp_path = os.environ["AWP_ROOT"]
+def _get_fluent_path():
+    if "PYFLUENT_FLUENT_ROOT" in os.environ:
+        path = os.environ["PYFLUENT_FLUENT_ROOT"]
+    elif "AWP_ROOT" in os.environ:
+        path = os.environ["AWP_ROOT"]
     else:
-        awp_path = os.environ["AWP_ROOT" + "".join(FLUENT_VERSION.split("."))]
-    return Path(awp_path)
-
+        path = os.environ["AWP_ROOT" + "".join(FLUENT_VERSION.split("."))]
+    return Path(path)
 
 def _get_fluent_exe_path():
-    exe_path = _get_awp_path() / "fluent"
+    exe_path = _get_fluent_path() / "fluent"
     if platform.system() == "Windows":
         exe_path = exe_path / "ntbin" / "win64" / "fluent.exe"
     else:


### PR DESCRIPTION
…o that I can run local build with AWP runtime dependencies

Means I can do this with the new env var pointing to my local build and still pick up the CAD reader from AWP path.
```
>>> import ansys.fluent as pyfluent
>>> session = pyfluent.launch_fluent(meshing_mode=True)
>>> w = session.workflow
>>> status=w.initialize_workflow(WorkflowType="Watertight Geometry")
>>> w.task_object['Import Geometry'].arguments = {"FileName":"E:/x.scdoc.pmdb","AppendMesh":False}
>>> w.task_object['Import Geometry'].execute()
```
