### PR TITLE
added ENTRYPOINT for docker image

### DIFF
--- a/docker/pyfluent/Dockerfile
+++ b/docker/pyfluent/Dockerfile
@@ -11,3 +11,4 @@ RUN yum install -y \
         libglvnd-glx-1.0.1-0.8.git5baa1e5.el7.x86_64 \
         libglvnd-1.0.1-0.8.git5baa1e5.el7.x86_64  && yum clean all
 COPY --from=builder /ansys_inc /ansys_inc/
+ENTRYPOINT ["/ansys_inc/v222/fluent/bin/fluent"]


### PR DESCRIPTION
Tested to confirm ENTRYPOINT

**docker run -it ghcr.io/pyansys/pyfluent:latest 3ddp -g**
/ansys_inc/v222/fluent/fluent22.2.0/bin/fluent -r22.2.0 3ddp -g
/ansys_inc/v222/fluent/fluent22.2.0/cortex/lnamd64/cortex.22.2.0 -f fluent -g (fluent "3ddp -pshmem  -host -r22.2.0 -t1 -mpi=intel -path/ansys_inc/v222/fluent -ssh")

Opening input/output transcript to file "//fluent-20220309-172121-243.trn".
Auto-Transcript Start Time:  17:21:21, 09 Mar 2022
