### PR TITLE
Drop __init__ prefix from module classes, Sphinx works it out

### DIFF
--- a/doc/source/api/parametric.rst
+++ b/doc/source/api/parametric.rst
@@ -7,5 +7,5 @@ Addons - Parametric
 .. autosummary::
    :toctree: _autosummary
    
-   __init__.DesignPoint
-   __init__.ParametricStudy
+   DesignPoint
+   ParametricStudy


### PR DESCRIPTION
This prefix can be left out from package API classes and functions.  Not directly related to the CI pipeline issue, but noticed it while working on this.