### PR TITLE
Install correct dependency for Linux doc builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt update
-          sudo apt install zip pandoc libgl1-mesa-glx xvfb
+          sudo apt install zip pandoc libegl1
 
       - name: Cache pip
         uses: actions/cache@v2


### PR DESCRIPTION
Address this issue in the doc builds:
```
Possible hints:
* ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
```
which makes the failed pyvista module import work now as well: