### PR TITLE
Run pytest with Fluent docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,20 @@ jobs:
       - name: Install pyvistaqt requirements
         run: make install-pyvistaqt-requirements
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.REPO_DOWNLOAD_PAT }}
+
+      - name: Pull Fluent docker image
+        run: make docker-pull
+
       - name: Unit Testing
         run: make unittest
+        env:
+          LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
 
       - name: Check package
         run: |

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ install-pyvistaqt-requirements:
 test-import:
 	@python -c "import ansys.fluent.core as pyfluent"
 
+docker-pull:
+	@docker pull ghcr.io/pyansys/pyfluent:latest
+
 unittest:
 	@echo "Running unittest"
 	@pip install -r requirements_test.txt

--- a/tests/docker/test_server.py
+++ b/tests/docker/test_server.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+from time import sleep
+
+
+def test_fluent_server():
+    license_server = os.getenv("LICENSE_SERVER", "leblnxlic64.ansys.com")
+    subprocess.run(["docker", "run", "-d", "--rm", "-p", "63084:63084",
+                    "-e", f"ANSYSLMD_LICENSE_FILE=1055@{license_server}",
+                    "-e", "REMOTING_PORTS=63084/portspan=2",
+                    "-e", "FLUENT_LAUNCHED_FROM_PYFLUENT=1",
+                    "ghcr.io/pyansys/pyfluent", "3ddp", "-g",
+                    "-sifile=server.txt"])
+    sleep(60)
+    from ansys.fluent.core.session import Session
+    session = Session("localhost", 63084)
+    assert session.check_health() == "SERVING"
+    session.exit()


### PR DESCRIPTION
Demonstrate usage of pytest with a custom docker image that runs a test grpc server. This PR is for figuring out what is needed to run pytest with a docker image. For the Fluent image, following additional items will be needed:

1. Login id and PAT for `ghcr.io`.
2. Fluent license server specification (not sure how this will work in github machines)

Update: Everything is in place to connect to Fluent docker container within github CI.