### PR TITLE
Add some content to main doc landing page

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,26 +1,5 @@
-
 .. _getting_started:
 
-************
-Introduction
-************
-Python is a portable, dynamically typed, interpreted programming language that
-is easy to learn, read, and write. It is free to use and distribute and is
-supported by a vast support library of thousands of available packages.
-
-PyFluent is part of the growing Ansys Python ecosystem that lets you use Ansys
-Fluent within or alongside any other Python environment, whether it is in
-conjunction with other Ansys Python libraries and packages or with other
-external Python products. 
-
-PyFluent launches or connects with a running Fluent process as a server using
-gRPC interfaces, but all you need to interact with is the Python interface of
-Ansys Fluent.
-
-You can use PyFluent to programmatically create, interact with and control an
-Ansys Fluent session to create your own customized workspace. In addition, you
-can use PyFluent to enhance your productivity with highly configurable,
-customized scripts.
 
 ************
 Installation
@@ -73,24 +52,6 @@ For example, if we wanted to ... <add a basic example>:
 .. code:: python
 
     <type some commands here>
-
-Features
-~~~~~~~~
-TUI and meshing workflows from Fluent meshing are available. See the
-:ref:`ref_meshing` module for examples and more information.
-
-Post processing Fluent results is possible using either Fluent directly or the
-PyVista module.  See the :ref:`ref_postprocessing` module for more information
-and examples.
-
-Beta Features
-~~~~~~~~~~~~~
-The settings object interface provides a more Pythonic way to access and modify
-settings than the TUI command interface.  These API calls group Fluent settings
-into a tree of objects where individal settings for material properties,
-boundary conditions are accessible without the need to pass parameter lists.
-
-More information is available in the :ref:`ref_settings` module documentation.
 
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,11 +17,51 @@ Ansys Fluent is a state-of-the-art computational fluid dynamics (CFD) software
 package for modeling fluid flow, heat transfer, and chemical reactions in
 complex geometries.
 
-PyFluent is a Python-based application programming interface for the Ansys
-Fluent CFD solver.
+Python is a portable, dynamically typed, interpreted programming language that
+is easy to learn, read, and write. It is free to use and distribute and is
+supported by a vast support library of thousands of available packages.
 
+PyFluent is part of the growing `PyAnsys <https://docs.pyansys.com>`_ ecosystem
+that lets you use Ansys Fluent within or alongside any other Python environment,
+whether it is in conjunction with other Ansys Python libraries and packages or
+with other external Python products.
+
+PyFluent launches or connects with a running Fluent process as a server using
+gRPC interfaces, but all you need to interact with is the Python interface.
+
+You can use PyFluent to programmatically create, interact with and control an
+Ansys Fluent session to create your own customized workspace. In addition, you
+can use PyFluent to enhance your productivity with highly configurable,
+customized scripts.
+
+Features
+--------
+The primary package, ``ansys-fluent``, provides features such as:
+
+- Scripting of Fluent's meshing capabilities. See the :ref:`ref_meshing` module
+  for more information.
+- Scripting using Fluent's TUI commands. See the :ref:`ref_solver_tui`  module for
+  more information about the available commands.
+- Script post processing using Fluent's in-built post processing capabilities.
+  See the :ref:`ref_postprocessing` module for more information.
+- Plotting of Fluent geometry and meshes using `PyVista
+  <https://docs.pyvista.org>`_ from within a Python script or an
+  interactive `Jupyter notebook <https://jupyter.org/>`_.
+- Access to Fluent surface based field data as Python objects via `NumPy
+  <https://numpy.org/>`_ arrays
+- and more...
+  
+Beta Features
+-------------
+The settings object interface provides a more Pythonic way to access and modify
+Fluent settings than the TUI command interface.  These API calls group Fluent
+settings into a tree of objects where individal settings for material
+properties, boundary conditions are accessible without the need to pass
+parameter lists.
+
+More information is available in the :ref:`ref_settings` module documentation.
 
 Project Index
-*************
+-------------
 
 * :ref:`genindex`


### PR DESCRIPTION
I thought some of the good content from the getting started guide would be better on the landing page.  i.e. so when you click on  [dev.fluentdocs.pyansys.com](https://dev.fluentdocs.pyansys.com/) on the main page of the repo you would see this content first.