### PR TITLE
Add note about documentation builds to contributing guide

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -33,7 +33,8 @@ if errorlevel 9009 (
 goto end
 
 :clean
-rmdir /s /q %BUILDDIR% > /NUL 2>&1 
+rmdir /s /q %BUILDDIR% > /NUL 2>&1
+rmdir /s /q %SOURCEDIR%\examples > /NUL 2>&1
 for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -19,11 +19,29 @@ mode:
 
 .. code::
 
-    git clone https://github.com/pyansys/pyfluent
+    git clone https://github.com/pyansys/pyfluent.git
     cd pyfluent
     pip install pip -U
     pip install -e .
 
+Building Documentation
+----------------------
+To build the documentation locally you need to follow these steps at the root
+directory of the repository:
+
+.. code:: 
+
+    pip install -r requirements_docs.txt
+    cd doc
+    make html
+
+After the build completes the html documentaion is located in the
+``_builds/html`` directory and you can load the ``index.html`` into a web
+browser.  To clean the documentation you can execute this command:
+
+.. code::
+
+    make clean
 
 Posting Issues
 --------------


### PR DESCRIPTION
Thought this might be helpful for anyone needing to build the documentation locally.  Also clean up the examples when running `make clean` on windows.