### PR TITLE
Put back get started heading

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,5 +1,12 @@
 .. _getting_started:
 
+===============
+Getting Started
+===============
+To use PyFluent, you need to have a local installation of Ansys.
+
+Visit `Ansys <https://www.ansys.com/>`_ for more information on
+getting a licensed copy of Ansys.
 
 ************
 Installation


### PR DESCRIPTION
I got a little eager moving stuff from the getting started guide to the landing page.