### PR TITLE
Remove FLUENT_LAUNCHED_FROM_PYFLUENT env var setting while launching …

### DIFF
--- a/ansys/fluent/core/launcher/launcher.py
+++ b/ansys/fluent/core/launcher/launcher.py
@@ -64,7 +64,6 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any]) -> Dict[str, Any]:
         kwargs.update(shell=True, start_new_session=True)
     fluent_env = os.environ.copy()
     fluent_env.update({k: str(v) for k, v in env.items()})
-    fluent_env["FLUENT_LAUNCHED_FROM_PYFLUENT"] = "1"
     kwargs.update(env=fluent_env)
     return kwargs
 


### PR DESCRIPTION
…Fluent from PyFluent.

The env var is not required as we read the server-info file in that mode.