### PR TITLE
Plane surface creation.

### DIFF
--- a/ansys/fluent/post/matplotlib/matplot_windows_manager.py
+++ b/ansys/fluent/post/matplotlib/matplot_windows_manager.py
@@ -130,7 +130,9 @@ class MatplotWindow(PostWindow):
         surfaces_info = field_info.get_surfaces_info()
         surface_ids = [
             id
-            for surf in obj.surfaces_list()
+            for surf in map(
+                obj._data_extractor.remote_surface_name, obj.surfaces_list()
+            )
             for id in surfaces_info[surf]["surface_id"]
         ]
         # get scalar field data


### PR DESCRIPTION
Added plane surface creation.
Also refactored code and moved surface api commands i.e. create/delete surface under class SurfaceApi.

**Plane surface creation example**
```
from ansys.fluent.post.pyvista import  Graphics
#get the graphics objects for the session
graphics_session1 = Graphics(session)

# surface
surface1 = graphics_session1.Surfaces["surface-1"]
surface1.surface.type = "plane-surface"
surface1.surface.plane_surface.creation_method = "xy-plane"
surface1.surface.plane_surface.xy_plane.z =0

surface2 = graphics_session1.Surfaces["surface-2"]
surface2.surface.type = "plane-surface"
surface2.surface.plane_surface.creation_method = "yz-plane"
surface2.surface.plane_surface.yz_plane.x =0
```
