### PR TITLE
Ensure end of lines are handled automatically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto !eol
+*.sh         eol=lf
+*.bat        eol=crlf
+*.py         text
+*.json       text


### PR DESCRIPTION
Alex ran into some end of line issues with PR #388, this should help.

- `* text=auto` makes git decide on what files are text and force LF in the repo.  I added a couple explicit settings too.
- `!eol` forces it so your local settings (eg: core.autocrlf) determine what you see locally, LF or CRLF.