### PR TITLE
Bump to 0.5.0 and add optiSLang release note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ as well as broad access to Fluent features including:
 - Ability to use Fluent TUI commands for both meshing and solver features
 - Ability to use Fluent's in-built post processing capabilities
 
+This version of PyFluent is supported for Ansys optiSLang 2022 R2 release.
+
 Documentation and Issues
 ------------------------
 Please see the latest release `documentation <https://fluentdocs.pyansys.com>`_

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 4, "dev0"
+version_info = 0, 5, 0
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Following the [pyansys branching model](https://dev.docs.pyansys.com/guidelines/dev_practices.html#branching-model), `release/0.5` is the release branch for optiSLang consumption. After this PR is merged, I'll push a tag `v0.5.0` to the `release/0.5` branch. Any new bug-fixes required for optiSLang will be merged to the `release/0.5` branch and the branch will be re-tagged as `v0.5.1` and so on.

The `main` branch will be continuously updated with all planned changes including the optiSLang bug-fixes. The next dev release version for the `main` branch will be `v0.6.dev0`.