### PR TITLE
Add Fluent as an alias of Session under ansys.fluent.core namespace

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -7,6 +7,7 @@ import appdirs
 
 from ansys.fluent.core._version import __version__  # noqa: F401
 from ansys.fluent.core.launcher.launcher import launch_fluent  # noqa: F401
+from ansys.fluent.core.session import Session as Fluent  # noqa: F401
 from ansys.fluent.core.utils.logging import LOG
 
 _VERSION_INFO = None


### PR DESCRIPTION
PyFluent will now support the following:
```python
from ansys.fluent.core import Fluent
fluent = Fluent(ip=<ip>, port=<port>)
```
similar to PyMAPDL:
```python
from ansys.mapdl.core import Mapdl
mapdl = Mapdl(ip=<ip>, port=<port>)
```