### PR TITLE
Pass correct CNAME entry to the doc builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ hashFiles('examples/**') }}
 
       - name: Build Documentation
-        run: make build-doc
+        run: make build-doc DOCS_CNAME=fluentdocs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -51,7 +51,7 @@ jobs:
           PYFLUENT_LAUNCH_CONTAINER: 1
 
       - name: Build Documentation
-        run: make build-doc
+        run: make build-doc DOCS_CNAME=dev.fluentdocs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ build-doc:
 	@pip install -r requirements_docs.txt
 	@xvfb-run make -C doc html
 	@touch doc/_build/html/.nojekyll
-	@echo "fluentdocs.pyansys.com" >> doc/_build/html/CNAME
+	@echo "$(DOCS_CNAME)" >> doc/_build/html/CNAME


### PR DESCRIPTION
Looks like the development documentation has been broken for a while.  The release and dev versions are hosted under different CNAMEs.