### PR TITLE
Misc. fixes in settings API

### DIFF
--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -1,4 +1,5 @@
 """Wrapper to settings grpc service of Fluent."""
+import collections.abc
 from typing import Any, List
 
 import grpc
@@ -110,12 +111,14 @@ class SettingsService:
             state.real = value
         elif isinstance(value, str):
             state.string = value
-        elif isinstance(value, list):
-            for v in value:
-                self._set_state_from_value(state.value_list.lst.add(), v)
-        elif isinstance(value, dict):
+        elif isinstance(value, collections.abc.Mapping):
             for k, v in value.items():
                 self._set_state_from_value(state.value_map.m[k], v)
+        elif isinstance(value, collections.abc.Iterable):
+            for v in value:
+                self._set_state_from_value(state.value_list.lst.add(), v)
+        else:  # fall back to string (e.g. pathlib.Path)
+            state.string = str(value)
 
     @_trace
     def _get_state_from_value(self, state):


### PR DESCRIPTION
1. If a child object name clashes with existing property/method of class, find a new name.
2. Support arbitrary sequences (not just list objects) and mappings (not just dict objects)
3. When finding the gRPC type of an object, fall back to str(obj) if no other match works. This is useful if user wants to use pathlib.Path instead of string for a file path.