### PR TITLE
Remove all pyvista/post reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,13 +202,10 @@ jobs:
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
-      - name: Install pyvistaqt requirements
-        run: make install-pyvistaqt-requirements
-
       - name: Add version information
         run: make version-info
 
-      - name: Install pyfluent with post
+      - name: Install pyfluent
         run: make install
 
       - name: Login to GitHub Container Registry

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ version-info:
 	@bash -c "date -u +'Build date: %B %d, %Y %H:%M UTC ShaID: <id>' | xargs -I date sed -i 's/_VERSION_INFO = .*/_VERSION_INFO = \"date\"/g' src/ansys/fluent/core/__init__.py"
 	@bash -c "git --no-pager log -n 1 --format='%h' | xargs -I hash sed -i 's/<id>/hash/g' src/ansys/fluent/core/__init__.py"
 
-install-pyvistaqt-requirements:
-	@sudo apt update
-	@sudo apt install libegl1 -y
-
 docker-pull:
 	@pip install docker
 	@python .ci/pull_fluent_image.py

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ with:
    cd pyfluent
    pip install pip -U
    pip install -e .
-   pip install -e .[post]  # If you want to use pyvista
    python codegen/allapigen.py  # Generates the API files, requires Fluent
 
 Dependencies

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,33 +1,14 @@
 """Sphinx documentation configuration file."""
 from datetime import datetime
-import os
 import platform
 import subprocess
 
 from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black
-import numpy as np
-import pyvista
 from sphinx_gallery.sorting import FileNameSortKey
 
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import __version__
 
-# Manage errors
-pyvista.set_error_output_file("errors.txt")
-
-# Ensure that offscreen rendering is used for docs generation
-pyvista.OFF_SCREEN = True
-
-# must be less than or equal to the XVFB window size
-pyvista.rcParams["window_size"] = np.array([1024, 768])
-
-# Save figures in specified directory
-pyvista.FIGURE_PATH = os.path.join(os.path.abspath("./images/"), "auto-generated/")
-if not os.path.exists(pyvista.FIGURE_PATH):
-    os.makedirs(pyvista.FIGURE_PATH)
-
-# necessary when building the sphinx gallery
-pyvista.BUILDING_GALLERY = True
 pyfluent.BUILDING_GALLERY = True
 
 # -- Project information -----------------------------------------------------
@@ -162,7 +143,6 @@ sphinx_gallery_conf = {
     "backreferences_dir": None,
     # Modules for which function level galleries are created.  In
     "doc_module": "ansys-fluent-core",
-    "image_scrapers": ("pyvista", "matplotlib"),
     "ignore_pattern": "flycheck*",
     "thumbnail_size": (350, 350),
     "reset_modules_order": "after",

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -23,7 +23,6 @@ mode:
     cd pyfluent
     pip install pip -U
     pip install -e .
-    pip install -e .[post] # If you want to use pyvista
 
 Building Documentation
 ----------------------

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -11,9 +11,3 @@ sphinx-gallery==0.10.1
 sphinx-notfound-page==0.8
 sphinxcontrib-websupport==1.2.4
 sphinxemoji==0.2.0
-pandas==1.4.1
-vtk==9.1.0
-pyvista==0.33.2
-pyvistaqt==0.7.0
-pyside6==6.2.3
-matplotlib==3.5.1


### PR DESCRIPTION
Currently we are using static images for core repo's documentation. So removing the pyvista dependency for docs.