### PR TITLE
Disabling the CI runs for solver-latest image tag till release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        image-tag: [latest, solver-latest]
+        #image-tag: [latest, solver-latest]
+        image-tag: [latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -211,7 +212,8 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        image-tag: [latest, solver-latest]
+        #image-tag: [latest, solver-latest]
+        image-tag: [latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        image-tag: [latest, solver-latest]
+        #image-tag: [latest, solver-latest]
+        image-tag: [latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We don't need to run for the solver-latest image tag (23.1 version of Fluent) before release. This will reduce CI runtime for release PRs.