### PR TITLE
Use the generic class for TUI menus inserted at runtime

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -1,6 +1,7 @@
 """Wrappers over TUI-based datamodel grpc service of Fluent."""
 
 import keyword
+import types
 from typing import Any, Iterable, List, Tuple, Union
 
 import grpc
@@ -209,6 +210,15 @@ class TUIMenu:
             convert_tui_menu_to_func_name(x)
             for x in PyMenu(self.service, self.path).get_child_names()
         ]
+
+    def __getattribute__(self, name):
+        attr = super().__getattribute__(name)
+        if type(attr) == types.MethodType:
+            path = self.path + [name]
+            # if menus are inserted at runtime in Fluent
+            if PyMenu(self.service, path).get_child_names():
+                return TUIMenuGeneric(path, self.service)
+        return attr
 
 
 class TUIMenuGeneric(TUIMenu):


### PR DESCRIPTION
An example of dynamic menu is the `adjoint/observable` menu in Fluent. During the static class generation in codegen, it doesn't have any child, so a bound method is generated for it. During runtime, new child menus (like `create`, `edit`) are added at `adjoint/observable` level in Fluent. Earlier the only way to execute `/adjoint/observable/create` in Fluent was to pass the child menu `create` as argument of `adjoint.observbale` method from PyFluent, i.e. `session.solver.tui.adjoint.observable("create", '"<type>"', '"<name>"')`.

In this PR, dynamic menus are identified in Fluent and corresponding objects of generic type inserted in PyFluent at runtime:
```
>>> session.solver.tui.adjoint # object of explicit type encoded during codegen
<ansys.fluent.core.solver.tui.main_menu.adjoint object at 0x000002B468FF08B0>
>>> session.solver.tui.adjoint.observable # object of generic type created at runtime
<ansys.fluent.core.services.datamodel_tui.TUIMenuGeneric object at 0x000002B468FF0640>
>>> session.solver.tui.adjoint.observable.create('"<type>"', '"<name>"')
```
