### PR TITLE
Solve docs build issues - using different CI machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   docs_build:
     name: Build Documentation
-    runs-on: self-hosted
+    runs-on: [self-hosted, pyfluent]
     strategy:
       matrix:
         #image-tag: [latest, solver-latest]

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   nightly_docs_build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, pyfluent]
     strategy:
       matrix:
         #image-tag: [latest, solver-latest]


### PR DESCRIPTION
I have seen that the docs build was failing frequently lately.

This is due to the fact that your workflow is sometimes using the PyDIsco VM as a self-hosted runner. I have added a new tag to your pyfluent-ci-1 VM called "pyfluent". This has also occured with PyAEDT. By adding this tag to your workflow, we will force it to choose the adequate VM.

As new VMs appear as self-hosted runners for different projects, it is important that these self-hosted runners also have specific tags for each project: pyfluent, pymapdl, pyaedt, pydisco etc. And we should force the workflows to use their dedicated VMs (the PyDisco VM may not be suited for running your workflows and viceversa).