### PR TITLE
Fix product version in launch remote fluent.

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -649,11 +649,17 @@ def launch_fluent(
             logger.info(
                 "Starting Fluent remotely. The startup configuration will be ignored."
             )
+
+            if product_version:
+                fluent_product_version = "".join(product_version.split("."))[:-1]
+            else:
+                fluent_product_version = "latest"
+
             return launch_remote_fluent(
                 session_cls=new_session,
                 start_timeout=start_timeout,
                 start_transcript=start_transcript,
-                product_version="".join(get_ansys_version().split("."))[:-1],
+                product_version=fluent_product_version,
                 cleanup_on_exit=cleanup_on_exit,
                 meshing_mode=meshing_mode,
                 dimensionality=version,

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -52,10 +52,7 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     # Assert: PyFluent went through the pypim workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    # if os.getenv("FLUENT_IMAGE_TAG"):
-    #     product_version = docker_image_version.get_version_for_filepath()
-    # else:
-    #     product_version = "".join(launcher.get_ansys_version().split("."))[:-1]
+
     mock_client.create_instance.assert_called_with(
         "fluent-3ddp", product_version="latest"
     )

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -52,12 +52,12 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     # Assert: PyFluent went through the pypim workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    if os.getenv("FLUENT_IMAGE_TAG"):
-        product_version = docker_image_version.get_version_for_filepath()
-    else:
-        product_version = "".join(launcher.get_ansys_version().split("."))[:-1]
+    # if os.getenv("FLUENT_IMAGE_TAG"):
+    #     product_version = docker_image_version.get_version_for_filepath()
+    # else:
+    #     product_version = "".join(launcher.get_ansys_version().split("."))[:-1]
     mock_client.create_instance.assert_called_with(
-        "fluent-3ddp", product_version=product_version
+        "fluent-3ddp", product_version="latest"
     )
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with()


### PR DESCRIPTION
"launch_remote_fluent" does not use the "get_ansys_version()" as a corrected behavior. Instead, we use the product version provided as launch argument. If product version is not set, we use the version "latest".