### PR TITLE
Slight rewording change for version check

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -52,9 +52,9 @@ class FluentVersion(Enum):
                     return FluentVersion(version)
             else:
                 raise RuntimeError(
-                    f"The passed version '{version[:-2]}' does not exist."
-                    f" Available version strings are: "
-                    f"{[ver.value for ver in FluentVersion]} "
+                    f"The specified version '{version[:-2]}' is not supported."
+                    + f" Supported versions include: "
+                    + ", ".join([ver.value for ver in FluentVersion][::-1])
                 )
 
     def __str__(self):

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -53,7 +53,7 @@ class FluentVersion(Enum):
             else:
                 raise RuntimeError(
                     f"The specified version '{version[:-2]}' is not supported."
-                    + f" Supported versions include: "
+                    + f" Supported versions are: "
                     + ", ".join([ver.value for ver in FluentVersion][::-1])
                 )
 


### PR DESCRIPTION
Minor change. While testing different Fluent releases, I got this error message:
![image](https://github.com/ansys/pyfluent/assets/132297401/10503f65-ddcf-4eee-8b9a-9bfdb8d5da04)

However, Fluent version 24.1 does exist in my machine, so I got confused for a second there. I believe what the original dev meant is that it is not yet supported by pyfluent.

With the proposed changes, the message now reads:
![image](https://github.com/ansys/pyfluent/assets/132297401/371a181f-317e-498b-a20a-c58c1743df1c)

Additional thought probably for a different PR: do we need to block the execution of more recent versions than the latest fully supported Fluent release? Shouldn't more recent versions (always? usually?) work fine from now on? Perhaps just a warning that the recent/dev version is untested and subject to potential issues?
