### PR TITLE
Fix multi-version documentation

### DIFF
--- a/.ci/pull_fluent_image.sh
+++ b/.ci/pull_fluent_image.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Image name
-_IMAGE_NAME="ghcr.io/pyansys/pyfluent:${FLUENT_IMAGE_TAG:-latest}"
+_IMAGE_NAME="ghcr.io/ansys/pyfluent:${FLUENT_IMAGE_TAG:-latest}"
 
 # Pull fluent image based on tag
 docker pull $_IMAGE_NAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,14 +207,13 @@ jobs:
       - name: Zip HTML Documentation before upload
         run: |
           sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
+          zip -r HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip doc/_build/html
 
       - name: Upload HTML Documentation
-        if: matrix.image-tag == 'v22.2.0'
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
+          path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip           
           retention-days: 7
 
       - name: Deploy stable documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   RESET_EXAMPLES_CACHE: 6
   API_CODE_CACHE: 3
   DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
-
+  DOC_DEPLOYMENT_IMAGE_TAG: v22.2.0
 jobs:
   stylecheck:
     name: Style Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,16 +204,11 @@ jobs:
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
       
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip doc/_build/html
-
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip           
+          path: doc/_build/html           
           retention-days: 7
 
       - name: Deploy stable documentation
@@ -221,7 +216,6 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
             doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-            decompress_artifact: true
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           retention-days: 7
 
       - name: Deploy stable documentation
-        uses: pyansys/actions/doc-deploy-stable@v3
+        uses: ansys/actions/doc-deploy-stable@v4
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
             doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,9 @@ env:
   # You should go up in number, if you go down (or repeat a previous value)
   # you might end up reusing a previous cache if it haven't been deleted already.
   # It applies 7 days retention policy by default.
-  RESET_EXAMPLES_CACHE: 5
-  API_CODE_CACHE: 2
+  RESET_EXAMPLES_CACHE: 6
+  API_CODE_CACHE: 3
+  DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
 
 jobs:
   stylecheck:
@@ -116,15 +117,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # used for documentation deployment
-      - name: Get Bot Application Token
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && matrix.image-tag == 'v22.2.0'
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
-        with:
-          application_id: ${{ secrets.BOT_APPLICATION_ID }}
-          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -206,29 +198,34 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=fluent.docs.pyansys.com
+        run: make build-doc
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+      
+      - name: Zip HTML Documentation before upload
+        run: |
+          sudo apt install zip -y
+          zip -r doc.zip doc/_build/html
 
       - name: Upload HTML Documentation
         if: matrix.image-tag == 'v22.2.0'
         uses: actions/upload-artifact@v3
         with:
-          name: HTML-Documentation-tag-${{ matrix.image-tag }}
-          path: doc/_build/html
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: doc.zip
           retention-days: 7
 
-      - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev') && matrix.image-tag == 'v22.2.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+      - name: Deploy stable documentation
+        uses: pyansys/actions/doc-deploy-stable@v3
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
-          repository-name: pyansys/pyfluent-docs
-          token: ${{ secrets.DOC_DEPLOYMENT_PAT }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+            decompress_artifact: true
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+
 
   build-test:
     name: Build and Unit Testing
@@ -250,7 +247,6 @@ jobs:
           key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_*.txt') }}
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
-
       - name: Add version information
         run: make version-info
 
@@ -338,7 +334,6 @@ jobs:
         run: |
           rm -rf dist
           make install > /dev/null
-
       - name: 22.2 Unit Testing
         run: make unittest-dev-222
         env:
@@ -364,7 +359,6 @@ jobs:
         run: |
           pip install twine
           twine check dist/*
-
       - name: Upload package
         uses: actions/upload-artifact@v3
         with:
@@ -373,7 +367,7 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
           retention-days: 7
-
+          
   release:
     name: Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
+env:
+  DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
+
 jobs:
   nightly_docs_build:
     runs-on: [self-hosted, pyfluent]
@@ -58,18 +61,22 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=dev.fluent.docs.pyansys.com
+        run: make build-doc
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
-      - name: Deploy
-        if: matrix.image-tag == 'v22.2.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+      - name: Upload HTML documentation
+        if: matrix.image-tag == 'v23.1.0'
+        uses: actions/upload-artifact@v3
         with:
-          repository-name: pyansys/pyfluent-dev-docs
-          token: ${{ secrets.DOC_DEPLOYMENT_PAT }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          name: documentation-html
+          path: doc/_build/html
+          retention-days: 7
+
+      - name: "Deploy development documentation"
+        uses: pyansys/actions/doc-deploy-dev@v3
+        with:
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -76,7 +76,7 @@ jobs:
           retention-days: 7
 
       - name: "Deploy development documentation"
-        uses: pyansys/actions/doc-deploy-dev@v3
+        uses: ansys/actions/doc-deploy-dev@v4
         with:
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     args: [ -i, -style=file ]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     args: [

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,6 @@ build-doc:
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples/*
 	@pip install -r requirements/requirements_doc.txt
 	@xvfb-run make -C doc html
-	@touch doc/_build/html/.nojekyll
-	@echo "$(DOCS_CNAME)" >> doc/_build/html/CNAME
+
+compare-flobject:
+	@python .ci/compare_flobject.py

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -81,7 +81,7 @@ _XML_HELPSTRINGS = {}
 def _copy_tui_help_xml_file(version: str):
     if os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1":
         image_tag = os.getenv("FLUENT_IMAGE_TAG", "v22.2.0")
-        image_name = f"ghcr.io/pyansys/pyfluent:{image_tag}"
+        image_name = f"ghcr.io/ansys/pyfluent:{image_tag}"
         container_name = uuid.uuid4().hex
         is_linux = platform.system() == "Linux"
         subprocess.run(

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,7 @@ extensions = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "numpy": ("https://numpy.org/devdocs", None),
     "matplotlib": ("https://matplotlib.org/stable", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -164,7 +164,7 @@ html_theme_options = {
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
     "switcher": {
-        "json_url": f"https://{cname}/release/versions.json",
+        "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,9 +1,10 @@
 """Sphinx documentation configuration file."""
 from datetime import datetime
+import os
 import platform
 import subprocess
 
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black
+from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 from sphinx_gallery.sorting import FileNameSortKey
 
 import ansys.fluent.core as pyfluent
@@ -16,6 +17,7 @@ pyfluent.BUILDING_GALLERY = True
 project = "ansys.fluent.core"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
+cname = os.getenv("DOCUMENTATION_CNAME", "nocname.com")
 
 # The short X.Y version
 release = version = __version__
@@ -161,6 +163,11 @@ html_theme_options = {
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
+    "switcher": {
+        "json_url": f"https://{cname}/release/versions.json",
+        "version_match": get_version_match(__version__),
+    },
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "navigation_depth": -1,
 }
 

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,8 +1,8 @@
-Sphinx==5.1.1
+Sphinx==5.3.0
 jupyter_sphinx==0.4.0
 numpydoc==1.4.0
 matplotlib==3.5.3
-ansys-sphinx-theme==0.5.1
+ansys-sphinx-theme==0.8.0
 pypandoc==1.8.1
 pytest-sphinx==0.4.0
 sphinx-autobuild==2021.3.14

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 11, 0
+version_info = 0, 11, 1
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -57,7 +57,7 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
                 f"REMOTING_PORTS={port}/portspan=2",
                 "-e",
                 "FLUENT_LAUNCHED_FROM_PYFLUENT=1",
-                f"ghcr.io/pyansys/pyfluent:{image_tag}",
+                f"ghcr.io/ansys/pyfluent:{image_tag}",
                 "-gu",
                 f"-sifile={container_sifile}",
             ]

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.skip
 def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing
     # check a few dir elements


### PR DESCRIPTION
The changes from release/0.11.1 which originally added the multi-version support were not merged into release/0.11 - merging those changes first. There is no [pypi package](https://pypi.org/project/ansys-fluent-core/#history) for 0.11.1, I'll push that too.