### PR TITLE
Improving Linux usage documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,22 @@ the latest release with:
 Dependencies
 ------------
 You must have a licensed copy of Ansys Fluent installed locally. PyFluent
-supports Fluent 2022 R2 and later.
+supports Fluent 2022 R2 and later. The Windows installation of Ansys Fluent automatically
+sets the required environment variables so that PyFluent can find the Ansys Fluent
+installation. Using Fluent 2023 R1 (or 23.1) installed in the default directory as an
+example, the installer automatically sets the ``AWP_ROOT231`` environment variable to point
+to ``C:\Program Files\ANSYS Inc\v231``.
+
+On Linux, the required environment variable is not set automatically, and can be set for the
+current user in the current shell session, using Fluent 2023 R1 in the default installation
+directory as an example, before running PyFluent, with:
+
+.. code:: console
+
+    export AWP_ROOT231=/usr/ansys_inc/v231
+
+For this setting to persist between different shell sessions for the current user, the same
+export command can instead be added to the user's ``~/.profile`` file.
 
 Getting started
 ---------------
@@ -88,19 +103,6 @@ To launch Fluent from Python, use the ``launch_fluent`` method:
   import ansys.fluent.core as pyfluent
   solver_session = pyfluent.launch_fluent(mode="solver")
   solver_session.health_check_service.is_serving
-
-On Windows systems the environment variable ``AWP_ROOT<ver>`` is configured
-when Fluent is installed, where ``<ver>`` is the Fluent release number such as
-``231`` for release 2023 R1. PyFluent automatically uses this environment
-variable to locate the latest Fluent installation. On Linux systems configure
-``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such as
-``/apps/ansys_inc/v231``.
-
-To use a specific Fluent release, set ``AWP_ROOT<ver>`` where ``<ver>`` is the 
-Fluent release that you would like to use. For example, ``AWP_ROOT<231>`` uses release 2023 R1.
-
-For information on other ways of specifying the Fluent location for PyFluent,
-see `Frequently asked questions <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html>`_.
 
 Basic usage
 ~~~~~~~~~~~


### PR DESCRIPTION
Improving the documentation in `README.rst` of the `AWP_ROOT` env variable required to run it on Linux, as the required env variable is not set automatically, with examples. 

Also took this opportunity to streamline and move the Windows env var documentation from the 'Launching fluent' heading to the 'Dependencies' heading, together with the Linux documentation.

edit: also removed the link to the FAQs "for more information about Fluent location", as I didn't find anything there that adds to the readme for this