### PR TITLE
Update to Windows data path name, and change to when examples folder is created

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -56,17 +56,8 @@ with open(yaml_path, "rt") as f:
 logging.config.dictConfig(config)
 
 # Setup data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir("ansys_fluent_core")
-    if not os.path.exists(USER_DATA_PATH):
-        os.makedirs(USER_DATA_PATH)
-
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):
-        os.makedirs(EXAMPLES_PATH)
-
-except Exception:
-    pass
+USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_fluent_core", appauthor="Ansys")
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
 
 BUILDING_GALLERY = False
 

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -43,12 +43,10 @@ def _get_file_url(filename: str, directory: Optional[str] = None) -> str:
 
 def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> str:
     if save_path is None:
-        local_path: str = os.path.join(
-            pyfluent.EXAMPLES_PATH, os.path.basename(filename)
-        )
+        save_path = pyfluent.EXAMPLES_PATH
     else:
         save_path = os.path.abspath(save_path)
-        local_path = os.path.join(save_path, os.path.basename(filename))
+    local_path = os.path.join(save_path, os.path.basename(filename))
     local_path_no_zip = re.sub(".zip$", "", local_path)
     # First check if file has already been downloaded
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
@@ -57,6 +55,10 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
         return local_path_no_zip
 
     logging.info("Downloading specified file...")
+
+    # Check if save path exists
+    if not os.path.exists(save_path):
+        os.makedirs(save_path)
 
     # grab the correct url retriever
     urlretrieve = urllib.request.urlretrieve

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -28,8 +28,6 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
     int
         gPRC server port exposed from the container.
     """
-    if not os.path.exists(mounted_from):
-        os.makedirs(mounted_from)
     fd, sifile = tempfile.mkstemp(suffix=".txt", prefix="serverinfo-", dir=mounted_from)
     os.close(fd)
     timeout = 100

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -28,6 +28,8 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
     int
         gPRC server port exposed from the container.
     """
+    if not os.path.exists(mounted_from):
+        os.makedirs(mounted_from)
     fd, sifile = tempfile.mkstemp(suffix=".txt", prefix="serverinfo-", dir=mounted_from)
     os.close(fd)
     timeout = 100

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -665,12 +665,16 @@ def launch_fluent(
             args = _build_fluent_launch_args_string(**argvals).split()
             if meshing_mode:
                 args.append(" -meshing")
+
+            save_path = pyfluent.EXAMPLES_PATH
+            # Check if save path exists
+            if not os.path.exists(save_path):
+                os.makedirs(save_path)
+
             # Assumes the container OS will be able to create the
             # EXAMPLES_PATH of host OS. With the Fluent docker
             # container, the following currently works only in linux.
-            port, password = start_fluent_container(
-                pyfluent.EXAMPLES_PATH, pyfluent.EXAMPLES_PATH, args
-            )
+            port, password = start_fluent_container(save_path, save_path, args)
             return new_session(
                 fluent_connection=FluentConnection(
                     start_timeout=start_timeout,


### PR DESCRIPTION
Resolves issue https://github.com/ansys/pyfluent/issues/1588 for pyfluent

Changes the point of creation of the data and examples paths from when pyfluent is first imported, to when the example files are downloaded.

In addition, before these changes Windows was saving to `%LocalAppData%\ansys_fluent_core\ansys_fluent_core\example`, after these changes it will save to `%LocalAppData%\Ansys\ansys_fluent_core\example`. The root directory `%LocalAppData%\Ansys` is already created when installing Ansys Fluent releases on Windows.

These changes do not influence the default data paths on Linux, only changes them on Windows.

To make things easier for CI/testing or other purposes in the future, we could make `__init__.py` check for an existing env variable for the data paths, like I noticed `ansys/pyprimemesh` does. Let me know if anyone thinks this would be useful.

I am going to suggest the same naming change to other pyansys repositories so we all potentially use the same naming scheme and root Ansys folder, and avoid cluttering the user's local app data folder on Windows (and see if they care about folders being created on import regardless of whether they will actually be used or not). 