### PR TITLE
Expose base class in settings doc

### DIFF
--- a/doc/settings_rstgen.py
+++ b/doc/settings_rstgen.py
@@ -123,8 +123,9 @@ def _populate_rst_from_settings(rst_dir, cls, version):
         r.write(f"{cls_name}\n")
         r.write(f'{"="*(len(cls_name))}\n\n')
         r.write(
-            f".. autoclass:: ansys.fluent.core.solver.settings_{version}.{file_name}.{cls_name}\n\n"
+            f".. autoclass:: ansys.fluent.core.solver.settings_{version}.{file_name}.{cls_name}\n"
         )
+        r.write(f"{istr1}:show-inheritance:\n\n")
 
         if has_children:
             r.write(f".. rubric:: Attributes\n\n")


### PR DESCRIPTION
Exposed base class in settings doc.

![image](https://github.com/ansys/pyfluent/assets/106588300/052a36b6-f151-44fb-af5f-3ec633fee35c)
