### PR TITLE
Remote launcher: don't provide any product version by default

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -653,7 +653,7 @@ def launch_fluent(
             if product_version:
                 fluent_product_version = "".join(product_version.split("."))[:-1]
             else:
-                fluent_product_version = "latest"
+                fluent_product_version = None
 
             return launch_remote_fluent(
                 session_cls=new_session,

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -53,9 +53,7 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     assert mock_is_configured.called
     assert mock_connect.called
 
-    mock_client.create_instance.assert_called_with(
-        "fluent-3ddp", product_version="latest"
-    )
+    mock_client.create_instance.assert_called_with("fluent-3ddp", product_version=None)
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with()
 


### PR DESCRIPTION
Follow-up to #1604 for the fix for #1591 This is just a small adjustment, I was out so I missed the review, but thank you for the quick fix @prmukherj

When the user does not explicitly request for a version, then `None` should be used. `latest` is not a standard name for a version so it will likely not be available. Leaving `None` will let the backend choose. I will add a note on this in the `pypim` documentation, at the moment it's only explain in the `.proto` I believe.
