### PR TITLE
Attempt to fix tests that are randomly failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
   build_test_232_241:
     name: Build and Test
     needs: test-import
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pyfluent]
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -248,9 +248,11 @@ def test_journal_creation(new_mesh_session):
 
     session = new_mesh_session
     session.journal.start(file_path)
+    time.sleep(1)
     session = session.switch_to_solver()
+    time.sleep(1)
     session.journal.stop()
-
+    time.sleep(1)
     new_stat = Path(file_path).stat()
     assert new_stat.st_mtime > prev_mtime
     assert new_stat.st_size > prev_size


### PR DESCRIPTION
`tests/test_streaming_services.py::test_transcript` has been randomly failing on github test runners, likely due to it being a server-side stress test, and this has been blocking PRs

Examples where it first failed, then passed on re-run without any changes:
https://github.com/ansys/pyfluent/actions/runs/5082325343/jobs/9131963505?pr=1640
https://github.com/ansys/pyfluent/actions/runs/5082183987/jobs/9131631586?pr=1639
https://github.com/ansys/pyfluent/actions/runs/5016027626/jobs/8992408253

As @mkundu1 suggested, one possible way to deal with this is to use a better runner, and that is what this PR is doing by changing it to a self-hosted pyfluent runner

If it continues randomly failing we will have to rework this test

CC: @prmukherj 

update: `tests/test_session.py::test_journal_creation` has been failing for no reason too (e.g. https://github.com/ansys/pyfluent/actions/runs/5082325343/jobs/9132695993 and https://github.com/ansys/pyfluent/actions/runs/5082965763/jobs/9133417557?pr=1641), we can use this PR for that one as well

adding small delays between actions in the `tests/test_session.py::test_journal_creation`, to give the file system some time to work through the changes 