### PR TITLE
Logging rework

### DIFF
--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -36,7 +36,7 @@ from ansys.fluent.core.services.datamodel_tui import (
 )
 from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 
-logger = logging.getLogger("ansys.fluent.tui")
+logger = logging.getLogger("pyfluent_tui")
 
 _THIS_DIRNAME = os.path.dirname(__file__)
 

--- a/doc/source/api/general/index.rst
+++ b/doc/source/api/general/index.rst
@@ -73,6 +73,11 @@ Meta
 
 :ref:`ref_meta` consists of some metaclasses used in the PyFluent codebase.
 
+Logging
+#######
+.. autofunction:: ansys.fluent.core.list_loggers
+.. autofunction:: ansys.fluent.core.set_global_log_level
+
 .. currentmodule:: ansys.fluent.core
 
 .. autosummary::

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -202,12 +202,24 @@ event types via the ``events_manager`` attribute of a solution mode session:
 
 For more information, see :ref:`ref_events`.
 
-Global logging
---------------
-You can control the global logging level at any time with:
+Logging controls
+----------------
+Loggers are by default set to show messages of level warning and above.
+See the possible logging level values in
+`<https://docs.python.org/3/library/logging.html#logging-levels>`_.
+The global logging level of PyFluent can be controlled with:
 
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    pyfluent.set_log_level("DEBUG") # by default, only errors are shown
+    pyfluent.set_global_log_level("DEBUG")
+
+the last command being equivalent to ``pyfluent.set_global_log_level(10)``.
+
+Global logging can also be controlled through the environment variable
+``PYFLUENT_LOGGING`` which can be set for example to values "DEBUG" or "10".
+
+See also :func:`list_loggers() <ansys.fluent.core.list_loggers>` and
+:func:`set_global_log_level() <ansys.fluent.core.set_global_log_level>`.
+
 

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -44,16 +44,82 @@ def version_info() -> str:
     return _VERSION_INFO if _VERSION_INFO is not None else __version__
 
 
+def set_global_log_level(level: str | int) -> None:
+    """Method changing the levels of all PyFluent loggers.
+
+    Parameters
+    ----------
+    level : str or int
+        Specified logging level to set PyFluent loggers to. See logging levels in
+        https://docs.python.org/3/library/logging.html#logging-levels
+
+    Examples
+    --------
+    >>> import ansys.fluent.core as pyfluent
+    >>> pyfluent.set_global_log_level(10)
+
+    or
+
+    >>> pyfluent.set_global_log_level("DEBUG")
+
+    Notes
+    -------
+    By default loggers are set to WARNING.
+    """
+    if isinstance(level, str):
+        if level.isdigit():
+            level = int(level)
+    print(f"Setting PyFluent global logging level to {level}.")
+    pyfluent_loggers = list_loggers()
+    for name in pyfluent_loggers:
+        logging.getLogger(name).setLevel(level)
+
+
+def list_loggers():
+    """List with all PyFluent loggers.
+
+    Returns
+    -------
+    list of str
+        Each list element is a PyFluent logger name that can be controlled with logging.getLogger().
+
+    Examples
+    --------
+    >>> import ansys.fluent.core as pyfluent
+    >>> import logging
+    >>> pyfluent.list_loggers()
+    ['pyfluent_general', 'pyfluent_launcher', 'pyfluent_networking', ...]
+    >>> logger = logging.getLogger('pyfluent_networking')
+    >>> logger.setLevel("DEBUG")
+
+    Notes
+    -------
+    By default loggers are set to WARNING.
+    """
+    logger_dict = logging.root.manager.loggerDict
+    pyfluent_loggers = []
+    for name in logger_dict:
+        if name.startswith("pyfluent"):
+            pyfluent_loggers.append(name)
+    return pyfluent_loggers
+
+
+# Configure the logging system
 file_path = os.path.abspath(__file__)
 file_dir = os.path.dirname(file_path)
 yaml_path = os.path.join(file_dir, "logging_config.yaml")
 
-# Load the logging configuration from a YAML file
 with open(yaml_path, "rt") as f:
     config = yaml.safe_load(f)
 
-# Configure the logging system
 logging.config.dictConfig(config)
+print(f"PyFluent logging file in {os.path.join(os.getcwd(),'pyfluent.log')}")
+env_logging_level = os.getenv("PYFLUENT_LOGGING")
+if env_logging_level:
+    print(
+        "PYFLUENT_LOGGING environment variable found, setting global logging level..."
+    )
+    set_global_log_level(env_logging_level)
 
 # Setup data directory
 USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_fluent_core", appauthor="Ansys")

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -8,7 +8,6 @@ Examples
 >>> filename
 '/home/user/.local/share/ansys_fluent_core/examples/bracket.iges'
 """
-import logging
 import os
 import re
 import shutil
@@ -49,12 +48,12 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
     local_path = os.path.join(save_path, os.path.basename(filename))
     local_path_no_zip = re.sub(".zip$", "", local_path)
     # First check if file has already been downloaded
+    print("Checking if specified file already exists...")
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
-        logging.info("File already exists.")
-        logging.info(f"File path: {local_path_no_zip}")
+        print(f"File already exists. File path:\n{local_path_no_zip}")
         return local_path_no_zip
 
-    logging.info("Downloading specified file...")
+    print("File does not exist. Downloading specified file...")
 
     # Check if save path exists
     if not os.path.exists(save_path):
@@ -64,13 +63,11 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
     urlretrieve = urllib.request.urlretrieve
 
     # Perform download
-    saved_file, _ = urlretrieve(url)
-    shutil.move(saved_file, local_path)
+    saved_file, _ = urlretrieve(url, filename=local_path)
     if local_path.endswith(".zip"):
         _decompress(local_path)
         local_path = local_path_no_zip
-    logging.info("Download successful.")
-    logging.info(f"File path: {local_path}")
+    print(f"Download successful. File path:\n{local_path}")
     return local_path
 
 

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -38,23 +38,27 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
     image_tag = os.getenv("FLUENT_IMAGE_TAG", "v23.1.0")
     test_name = os.getenv("PYFLUENT_TEST_NAME", "none")
 
+    print("")
+
     try:
         subprocess.run(
             [
                 "docker",
                 "run",
-                "-d",
+                "--detach",
                 "--rm",
-                "-p",
+                "--publish",
                 f"{port}:{port}",
-                "-v",
+                "--volume",
                 f"{mounted_from}:{mounted_to}",
-                "-e",
+                "--env",
                 f"ANSYSLMD_LICENSE_FILE={license_server}",
-                "-e",
+                "--env",
                 f"REMOTING_PORTS={port}/portspan=2",
-                "-l",
+                "--label",
                 f"test_name={test_name}",
+                "--workdir",
+                f"{mounted_to}",
                 f"ghcr.io/ansys/pyfluent:{image_tag}",
                 "-gu",
                 f"-sifile={container_sifile}",

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -13,7 +13,6 @@ import subprocess
 import tempfile
 import time
 from typing import Any, Dict, Union
-import warnings
 
 from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.launcher.fluent_container import start_fluent_container
@@ -28,7 +27,7 @@ import ansys.platform.instancemanagement as pypim
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
-logger = logging.getLogger("ansys.fluent.launcher")
+logger = logging.getLogger("pyfluent_launcher")
 
 
 def _is_windows():
@@ -351,7 +350,7 @@ def _connect_to_running_server(argvals, server_info_filepath: str):
     port = argvals.get("port", None)
     password = argvals.get("password", None)
     if ip and port:
-        warnings.warn(
+        logger.debug(
             "The server-info file was not parsed because ip and port were provided explicitly."
         )
     elif server_info_filepath:

--- a/src/ansys/fluent/core/logging_config.yaml
+++ b/src/ansys/fluent/core/logging_config.yaml
@@ -1,84 +1,50 @@
+# More examples and references:
+# https://docs.python.org/3/howto/logging-cookbook.html
+# https://docs.python.org/3/library/logging.html#logging-levels
+# https://gist.github.com/kingspp/9451566a5555fb022215ca2b7b802f19
+
 version: 1
-disable_existing_loggers: False
+disable_existing_loggers: no
+
 formatters:
-  simple:
-    format: "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
+  console_fmt:
+    format: "%(name)s %(levelname)s: %(message)s"
+  logfile_fmt:
+    format: "%(asctime)s %(name)-21s %(levelname)-8s %(message)s"
+
 handlers:
-  console:
+  console_stdout:
     class: logging.StreamHandler
-    level: INFO
-    formatter: simple
+    level: ERROR
+    formatter: console_fmt
     stream: ext://sys.stdout
-  fluent.file:
+  pyfluent_file:
     class: logging.handlers.RotatingFileHandler
-    level: DEBUG
-    formatter: simple
+    level: NOTSET #  no log level filtering on this handler, message log levels are managed by the loggers instead
+    formatter: logfile_fmt
     filename: pyfluent.log
-    maxBytes: 10485760
-    backupCount: 5
-  tui.file:
-    class: logging.handlers.RotatingFileHandler
-    level: DEBUG
-    formatter: simple
-    filename: tui.log
-    maxBytes: 10485760
-    backupCount: 5
-  datamodel.file:
-    class: logging.handlers.RotatingFileHandler
-    level: DEBUG
-    formatter: simple
-    filename: datamodel.log
-    maxBytes: 10485760
-    backupCount: 5
-  settings.file:
-    class: logging.handlers.RotatingFileHandler
-    level: DEBUG
-    formatter: simple
-    filename: settings_api.log
-    maxBytes: 10485760
-    backupCount: 5
-  launcher.file:
-    class: logging.handlers.RotatingFileHandler
-    level: INFO
-    formatter: simple
-    filename: launcher.log
-    maxBytes: 10485760
-    backupCount: 5
-  networking.file:
-    class: logging.handlers.RotatingFileHandler
-    level: DEBUG
-    formatter: simple
-    filename: networking.log
-    maxBytes: 10485760
-    backupCount: 5
+    maxBytes: 10485760 # 10 Megabytes
+    backupCount: 9 # if .log file size > maxBytes, roll over to another file .log.1, then .log.2, and so on
 
-root:
-  level: INFO
-  handlers: [console]
 loggers:
-  ansys.fluent:
-    level: DEBUG
-    handlers: [fluent.file]
-    propagate: no
-  ansys.fluent.services.datamodel:
-    level: DEBUG
-    handlers: [datamodel.file]
-    propagate: no
-  ansys.fluent.services.tui:
-    level: DEBUG
-    handlers: [tui.file]
-    propagate: no
-  ansys.fluent.services.settings_api:
-    level: DEBUG
-    handlers: [settings.file]
-    propagate: no
-  ansys.fluent.launcher:
-    level: DEBUG
-    handlers: [launcher.file]
-    propagate: no
-  ansys.fluent.networking:
-    level: DEBUG
-    handlers: [networking.file]
-    propagate: no
-  
-
+  pyfluent_general:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_datamodel:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_tui:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_settings_api:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_launcher:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_networking:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]
+  pyfluent_post_objects:
+    level: WARNING
+    handlers: [pyfluent_file, console_stdout]

--- a/src/ansys/fluent/core/post_objects/post_object_definitions.py
+++ b/src/ansys/fluent/core/post_objects/post_object_definitions.py
@@ -1,7 +1,7 @@
 """Module providing visualization objects definition."""
 from abc import abstractmethod
+import logging
 from typing import List, NamedTuple, Optional
-import warnings
 
 from ansys.fluent.core.meta import (
     Attribute,
@@ -9,6 +9,8 @@ from ansys.fluent.core.meta import (
     PyLocalObjectMeta,
     PyLocalPropertyMeta,
 )
+
+logger = logging.getLogger("pyfluent_post_objects")
 
 
 class BasePostObjectDefn:
@@ -392,8 +394,8 @@ class ContourDefn(GraphicsDefn):
             filled = self._get_parent_by_type(ContourDefn).filled()
             auto_range_off = self._get_parent_by_type(ContourDefn).range.auto_range_off
             if not filled or (auto_range_off and auto_range_off.clip_to_range()):
-                warnings.warn(
-                    "For unfilled and clipped contours node values are diaplyed."
+                logger.warning(
+                    "For unfilled and clipped contours node values are displayed."
                 )
                 self._value = True
             return self._value

--- a/src/ansys/fluent/core/services/batch_ops.py
+++ b/src/ansys/fluent/core/services/batch_ops.py
@@ -11,7 +11,7 @@ import ansys.api.fluent.v0 as api
 from ansys.api.fluent.v0 import batch_ops_pb2, batch_ops_pb2_grpc
 from ansys.fluent.core.services.error_handler import catch_grpc_error
 
-network_logger = logging.getLogger("ansys.fluent.networking")
+network_logger = logging.getLogger("pyfluent_networking")
 
 
 class BatchOpsService:

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -4,7 +4,6 @@ import functools
 import itertools
 import logging
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Type
-import warnings
 
 import grpc
 
@@ -19,7 +18,7 @@ from ansys.fluent.core.services.streaming import StreamingService
 
 Path = List[Tuple[str, str]]
 
-logger = logging.getLogger("ansys.fluent.services.datamodel")
+logger = logging.getLogger("pyfluent_datamodel")
 
 
 class Attribute(Enum):
@@ -1052,7 +1051,7 @@ class PyCommand:
                 static_info,
             )
         except RuntimeError:
-            warnings.warn(
+            logger.warning(
                 "Create command arguments object is available from 23.1 onwards"
             )
             pass

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -16,7 +16,7 @@ from ansys.fluent.core.services.interceptors import BatchInterceptor, TracingInt
 
 Path = List[str]
 
-logger = logging.getLogger("ansys.fluent.services.tui")
+logger = logging.getLogger("pyfluent_tui")
 
 
 class DatamodelService:

--- a/src/ansys/fluent/core/services/interceptors.py
+++ b/src/ansys/fluent/core/services/interceptors.py
@@ -8,7 +8,7 @@ import grpc
 
 from ansys.fluent.core.services.batch_ops import BatchOps
 
-network_logger = logging.getLogger("ansys.fluent.networking")
+network_logger = logging.getLogger("pyfluent_networking")
 
 
 class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -19,7 +19,7 @@ try:
 except Exception:
     root = Any
 
-data_model_logger = logging.getLogger("ansys.fluent.services.datamodel")
+datamodel_logger = logging.getLogger("pyfluent_datamodel")
 
 
 def _parse_server_info_file(filename: str):
@@ -39,7 +39,7 @@ def _get_datamodel_attributes(session, attribute: str):
         )
         return preferences_module.Root(session._se_service, attribute, [])
     except (ImportError, ModuleNotFoundError):
-        data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+        datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
 
 
 def _get_preferences(session):

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -9,9 +9,9 @@ from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MS
 from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 from ansys.fluent.core.workflow import WorkflowWrapper
 
-fluent_logger = logging.getLogger("ansys.fluent")
-data_model_logger = logging.getLogger("ansys.fluent.services.datamodel")
-tui_logger = logging.getLogger("ansys.fluent.services.tui")
+pyfluent_logger = logging.getLogger("pyfluent_general")
+datamodel_logger = logging.getLogger("pyfluent_datamodel")
+tui_logger = logging.getLogger("pyfluent_tui")
 
 
 class BaseMeshing:
@@ -37,7 +37,9 @@ class BaseMeshing:
 
     def get_fluent_version(self):
         """Gets and returns the fluent version."""
-        fluent_logger.info(self._fluent_connection.get_fluent_version())
+        pyfluent_logger.debug(
+            "Fluent version = " + str(self._fluent_connection.get_fluent_version())
+        )
         return self._fluent_connection.get_fluent_version()
 
     @property
@@ -70,7 +72,7 @@ class BaseMeshing:
             )
             meshing_root = meshing_module.Root(self._se_service, "meshing", [])
         except (ImportError, ModuleNotFoundError):
-            data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+            datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
             meshing_root = PyMenuGeneric(self._se_service, "meshing")
         return meshing_root
 
@@ -94,7 +96,7 @@ class BaseMeshing:
             )
             workflow_se = workflow_module.Root(self._se_service, "workflow", [])
         except (ImportError, ModuleNotFoundError):
-            data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+            datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
             workflow_se = PyMenuGeneric(self._se_service, "workflow")
         return workflow_se
 
@@ -116,7 +118,7 @@ class BaseMeshing:
                     self._se_service, "PartManagement", []
                 )
             except (ImportError, ModuleNotFoundError):
-                data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+                datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
                 self._part_management = PyMenuGeneric(
                     self._se_service, "PartManagement"
                 )
@@ -134,7 +136,7 @@ class BaseMeshing:
                     self._se_service, "PMFileManagement", []
                 )
             except (ImportError, ModuleNotFoundError):
-                data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+                datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
                 self._pm_file_management = PyMenuGeneric(
                     self._se_service, "PMFileManagement"
                 )

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -20,8 +20,8 @@ from ansys.fluent.core.utils.async_execution import asynchronous
 from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 from ansys.fluent.core.workflow import WorkflowWrapper
 
-tui_logger = logging.getLogger("ansys.fluent.services.tui")
-data_model_logger = logging.getLogger("ansys.fluent.services.datamodel")
+tui_logger = logging.getLogger("pyfluent_tui")
+datamodel_logger = logging.getLogger("pyfluent_datamodel")
 
 
 class Solver(BaseSession):
@@ -86,7 +86,7 @@ class Solver(BaseSession):
             )
             workflow_se = workflow_module.Root(self._se_service, "workflow", [])
         except (ImportError, ModuleNotFoundError):
-            data_model_logger.warning(_CODEGEN_MSG_DATAMODEL)
+            datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
             workflow_se = PyMenuGeneric(self._se_service, "workflow")
         return workflow_se
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -29,7 +29,7 @@ import weakref
 
 from .error_message import allowed_name_error_message, allowed_values_error
 
-settings_logger = logging.getLogger("ansys.fluent.services.settings_api")
+settings_logger = logging.getLogger("pyfluent_settings_api")
 
 # Type hints
 RealType = NewType("real", Union[float, str])  # constant or expression
@@ -1078,7 +1078,7 @@ def get_cls(name, info, parent=None, version=None):
         obj_type = info["type"]
         base = _baseTypes.get(obj_type)
         if base is None:
-            settings_logger.error(
+            settings_logger.warning(
                 f"Unable to find base class for '{name}' "
                 f"(type = '{obj_type}'). "
                 f"Falling back to String."

--- a/src/ansys/fluent/core/utils/data_transfer.py
+++ b/src/ansys/fluent/core/utils/data_transfer.py
@@ -6,7 +6,7 @@ import tempfile
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.utils.async_execution import asynchronous
 
-network_logger = logging.getLogger("ansys.fluent.networking")
+network_logger = logging.getLogger("pyfluent_networking")
 
 
 @asynchronous
@@ -84,7 +84,7 @@ def transfer_case(
                 try:
                     os.remove(full_file_name)
                 except BaseException as ex:
-                    network_logger.warn(
+                    network_logger.warning(
                         f"Encountered exception while cleaning up during case transfer {ex}"
                     )
             return

--- a/src/ansys/fluent/core/utils/networking.py
+++ b/src/ansys/fluent/core/utils/networking.py
@@ -7,7 +7,7 @@ import grpc
 
 from ansys.api.fluent.v0 import health_pb2, health_pb2_grpc
 
-network_logger = logging.getLogger("ansys.fluent.networking")
+network_logger = logging.getLogger("pyfluent_networking")
 
 
 def get_free_port() -> int:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -3,7 +3,7 @@ from typing import Iterator, Tuple
 
 from ansys.fluent.core.services.datamodel_se import PyCallableStateObject
 
-datamodel_logger = logging.getLogger("ansys.fluent.services.datamodel")
+datamodel_logger = logging.getLogger("pyfluent_datamodel")
 
 
 def _new_command_for_task(task, session):


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/1259, https://github.com/ansys/pyfluent/issues/1625, https://github.com/ansys/pyfluent/issues/1532 and I believe also https://github.com/ansys/pyfluent/issues/9 (see discussion below)

Changes:

- Default error output level is now `WARNING` rather than `DEBUG`
- PyFluent loggers now have the `pyfluent_` prefix to avoid conflict with other loggers (also note that using `.` in the logger names is usually for logging propagation, which is not something we are using here)
- All logging output now goes to a single file, example: <details><summary> Logging file example </summary> ![image](https://github.com/ansys/pyfluent/assets/132297401/f7a8410d-1813-4106-8125-1987bab7f84c) </details>
- Logging messages of level `ERROR` and above go to the python console (stdout) as well, example: <details><summary> Warning and error, Python console and file </summary>![image](https://github.com/ansys/pyfluent/assets/132297401/03953242-9cb9-4b7f-97c6-b8923096e1ab) </details>
- Added support for `PYFLUENT_LOGGING` environment variable, which we can use so that we don't have to change logging levels manually and so that logging is automatically set to `DEBUG` (or any other level you want) for development rather than the much more silent default `WARNING`
- Added convenience functions `list_loggers()` and `set_global_log_level()` (see documentation in the item below)
- Add documentation:  <details><summary> Screenshots</summary> User guide index: ![image](https://github.com/ansys/pyfluent/assets/132297401/3f79e6d4-11e0-47b7-b6c6-15dae57fa4e1) API reference index (this isn't directly related to Fluent's API, but couldn't think of a better place in the current docs, please let me know of any suggestions): ![image](https://github.com/ansys/pyfluent/assets/132297401/7c008334-b9af-4f40-9934-447f5ab510d9)  </details>

Recommendations:
- I think using root `logging` calls such as `logging.info()` or `logging.warning()` is something we should avoid and could conflict/cause issues with other packages or something that users have set up themselves,  using the custom defined loggers is better in every way that I can think of, so `logger=getLogger('pyfluent_...'); logger.info()`
- Use `print()` when the objective is to output non-error information to the Python console directly for the user to see or when it is an important non-error message and just logging to files is insufficient (we can set up additional logging for different combinations as well if necessary)

In regards to https://github.com/ansys/pyfluent/issues/9, the only scenario where no useful information or silent failing was being returned to the user that I could think of, and based on my experience as this was an issue for me too, was when running Fluent on containers, where it was failing completely silently with no logs or console output at all to help. My suggested fix (relevant lines below) is to set the docker image to run on the specified work directory that is also mounted on the container host system, so that the user, which has access to the host, at least has access to the Fluent automatic transcript output which is typically all that is needed to debug launch issues. I have also changed all the shorthand args for their actual names for the docker run command (check the other lines around the ones linked below), as I believe this makes them much clearer and easier to work with. Please let me know if I missed any scenarios where this isn't sufficient. https://github.com/ansys/pyfluent/blob/3ff4f0078bd66bcc6ccdddcd4b41c12bd9b6fc65/src/ansys/fluent/core/launcher/fluent_container.py#L60-L61

While this is fresh on my mind, please let me know if you have any questions, can think of any suggestions or ways in which logging would be more useful to you for development or any other purposes.
