### PR TITLE
doc: fix global logging

### DIFF
--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -208,6 +208,18 @@ You can control the global logging level at any time with:
 
 .. code:: python
 
-    import ansys.fluent.core as pyfluent
-    pyfluent.set_log_level("DEBUG") # by default, only errors are shown
+    from ansys.fluent.core import logging
 
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+
+    logger.debug("DEBUG STATEMENT")
+
+Logging levels:
+- CRITICAL
+- FATAL
+- ERROR
+- WARNING
+- INFO
+- DEBUG
+- NOTSET


### PR DESCRIPTION
Fixes global logging setup in user guide. 

old:
```
import ansys.fluent.core as pyfluent
pyfluent.set_log_level("DEBUG") # by default, only errors are shown
```
new:
``` 
from ansys.fluent.core import logging

logger = logging.getLogger()
logger.setLevel(logging.DEBUG)
```