### PR TITLE
"Actually" fixing journal creation test, hopefully for the last time

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -245,15 +245,17 @@ def test_journal_creation(new_mesh_session):
     prev_stat = Path(file_path).stat()
     prev_mtime = prev_stat.st_mtime
     prev_size = prev_stat.st_size
+    print(f"prev_stat: {prev_stat}")
+
+    print("Waiting")
+    time.sleep(1)
 
     session = new_mesh_session
     session.journal.start(file_path)
-    time.sleep(1)
     session = session.switch_to_solver()
-    time.sleep(1)
     session.journal.stop()
-    time.sleep(1)
     new_stat = Path(file_path).stat()
+    print(f"new_stat: {new_stat}")
     assert new_stat.st_mtime > prev_mtime
     assert new_stat.st_size > prev_size
 


### PR DESCRIPTION
For `tests/test_session.py::test_journal_creation`

<details> <summary>Example logs where it had failed recently</summary>

https://github.com/ansys/pyfluent/actions/runs/5091062246/attempts/1
https://github.com/ansys/pyfluent/actions/runs/5082325343/jobs/9132695993
https://github.com/ansys/pyfluent/actions/runs/5082965763/jobs/9133417557?pr=1641
https://github.com/ansys/pyfluent/actions/runs/5133184035/jobs/9235563372
https://github.com/ansys/pyfluent/actions/runs/5134366673/jobs/9239139341?pr=1656

</details>

Managed to reproduce the issue locally: my understanding is that the Fluent v232 process inside the docker container image, when editing journal files, sometimes only changes the size of the file without changing the modification time for whatever reason. 

I previously tried adding delays between the Fluent actions, assuming that was going too quickly and maybe getting bundled up into a single filesystem action. However, that did not help. What actually makes a difference in this case is adding a delay between when the file is created, and when it is opened (not edited) by Fluent. When Fluent opens it to work with it inside the container, it actually changes the file modification time, it does not seem to always change it after that when editing. 

Looks like this solves the issue for good, the test went from failing approx 1 out of 4 to 5 times to not failing once in about 20 tests so far (continuing to run these in the background). update: just finished running 100 additional test repeats, no failures

Also left some `print()` to stdout commands inside the test, these will typically be hidden by `pytest` when the test succeeds, and if the test fails, `pytest` will capture and report these, so I believe they should show up in the github actions logs and make this test easier to debug in the future, in case it fails again for any reason. Let me know if anyone prefers that we not have any stdout inside tests.


