### PR TITLE
Set container mount path from env var

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -673,7 +673,6 @@ def launch_fluent(
                 args.append(" -meshing")
 
             host_mount_path = pyfluent.EXAMPLES_PATH
-            # Check if save path exists
             if not os.path.exists(host_mount_path):
                 os.makedirs(host_mount_path)
 
@@ -681,9 +680,6 @@ def launch_fluent(
                 "PYFLUENT_CONTAINER_MOUNT_PATH", host_mount_path
             )
 
-            # Assumes the container OS will be able to create the
-            # EXAMPLES_PATH of host OS. With the Fluent docker
-            # container, the following currently works only in linux.
             port, password = start_fluent_container(
                 host_mount_path, container_mount_path, args
             )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -672,15 +672,21 @@ def launch_fluent(
             if meshing_mode:
                 args.append(" -meshing")
 
-            save_path = pyfluent.EXAMPLES_PATH
+            host_mount_path = pyfluent.EXAMPLES_PATH
             # Check if save path exists
-            if not os.path.exists(save_path):
-                os.makedirs(save_path)
+            if not os.path.exists(host_mount_path):
+                os.makedirs(host_mount_path)
+
+            container_mount_path = os.getenv(
+                "PYFLUENT_CONTAINER_MOUNT_PATH", host_mount_path
+            )
 
             # Assumes the container OS will be able to create the
             # EXAMPLES_PATH of host OS. With the Fluent docker
             # container, the following currently works only in linux.
-            port, password = start_fluent_container(save_path, save_path, args)
+            port, password = start_fluent_container(
+                host_mount_path, container_mount_path, args
+            )
             return new_session(
                 fluent_connection=FluentConnection(
                     start_timeout=start_timeout,


### PR DESCRIPTION
This is useful while launching the Fluent docker container from PyFluent in Windows host for development purpose. We cannot mount a Windows path within the Linux container.