### PR TITLE
Use self-hosted runners for all unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
   test:
     name: Unit Testing
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pyfluent]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This will potentially fix failures of some resource-intensive tests in github.