### PR TITLE
Update has-allowed-values

### DIFF
--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -220,7 +220,7 @@ class SettingsService:
         ret = {}
         ret["type"] = info.type
         if info.has_allowed_values:
-            ret["has_allowed_values"] = info.has_allowed_values
+            ret["has-allowed-values"] = info.has_allowed_values
         if info.children:
             ret["children"] = {
                 child.name: self._extract_static_info(child.value)

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1121,7 +1121,7 @@ def get_cls(name, info, parent=None, version=None):
             bases = bases + (_CreatableNamedObjectMixin,)
         elif obj_type == "named-object":
             bases = bases + (_NonCreatableNamedObjectMixin,)
-        elif info.get("has_allowed_values"):
+        elif info.get("has-allowed-values"):
             bases += (_HasAllowedValuesMixin,)
 
         cls = type(pname, bases, dct)


### PR DESCRIPTION
To be consistent in both PyFluent and Fluent, replace `has_allowed_values` with `has-allowed-values`

![image](https://github.com/ansys/pyfluent/assets/106588300/01c83bc7-1550-4afd-9d98-1bfdf7496e99)
