### PR TITLE
Watchdog to deal with Fluent stray processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
   test:
     name: Unit Testing
     needs: build
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -379,7 +379,7 @@ jobs:
   build_test_232_241:
     name: Build and Test
     needs: test-import
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -349,7 +349,7 @@ def generate():
         len(_XML_HELPSTRINGS),
     )
     for k, _ in _XML_HELPSTRINGS.items():
-        logger.warning(k)
+        logger.info(k)
 
 
 if __name__ == "__main__":

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -253,6 +253,7 @@ class FluentConnection:
                 inside_container = True
             else:
                 logger.debug("Assuming Fluent is not running inside a container.")
+                inside_container = False
 
         self.connection_properties = FluentConnectionProperties(
             ip,
@@ -437,6 +438,7 @@ class FluentConnection:
                     _ = async_result.get(timeout=timeout)
                     logger.debug("session.exit() successful")
                     pool.close()
+                    return
                 except TimeoutError:
                     logger.debug("session.exit() timeout")
                     pool.terminate()

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -95,7 +95,7 @@ class _IsDataValid:
         return self._scheme_eval.scheme_eval("(data-valid?)")
 
 
-def get_container_ids() -> list[str]:
+def get_container_ids() -> List[str]:
     try:
         logger.debug("Attempting to get docker container IDs...")
         proc = subprocess.Popen(

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -2,6 +2,8 @@ from ctypes import c_int, sizeof
 from dataclasses import dataclass
 import itertools
 import logging
+import multiprocessing
+from multiprocessing.context import TimeoutError
 import os
 from pathlib import Path
 import socket
@@ -91,6 +93,21 @@ class _IsDataValid:
 
     def __call__(self):
         return self._scheme_eval.scheme_eval("(data-valid?)")
+
+
+def get_container_ids() -> list[str]:
+    try:
+        logger.debug("Attempting to get docker container IDs...")
+        proc = subprocess.Popen(
+            ["docker", "ps", "-q"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
+        output_bytes = proc.stdout.read()
+        output_str = output_bytes.decode()
+        ids = output_str.strip().split()
+    except:
+        logger.warning("Failed to get docker container IDs.")
+        ids = []
+    return ids
 
 
 @dataclass(frozen=True)
@@ -322,6 +339,14 @@ class FluentConnection:
             cortex_pwd = None
             fluent_host_pid = None
 
+        if inside_container is None and not remote_instance and cortex_host is not None:
+            logger.debug("Checking if Fluent is running inside a container.")
+            if cortex_host in get_container_ids():
+                logger.debug("Fluent is running inside a container.")
+                inside_container = True
+            else:
+                logger.debug("Assuming Fluent is not running inside a container.")
+
         self.connection_properties = FluentConnectionProperties(
             ip,
             port,
@@ -533,39 +558,37 @@ class FluentConnection:
         if timeout is None:
             self._finalizer()
         else:
-
-            def _connection_finalizer(connection):
-                return connection._finalizer()
-
-            tmp_thread = threading.Thread(
-                target=_connection_finalizer, args=(self,), daemon=True
-            )
-            tmp_thread.start()
-
-            tmp_thread.join(timeout)
-
-            if tmp_thread.is_alive():
-                pass
+            if not self.health_check_service.is_serving:
+                logger.debug("gRPC service not working, cancelling soft exit call.")
             else:
-                logger.debug("session.exit() successful")
-                return
+                logger.debug("Attempting session.exit()")
 
-            logger.debug("session.exit() timeout")
+                def _connection_finalizer(connection):
+                    return connection._finalizer()
+
+                pool = multiprocessing.pool.ThreadPool(processes=1)
+                async_result = pool.apply_async(_connection_finalizer, args=(self,))
+                try:
+                    _ = async_result.get(timeout=timeout)
+                    logger.debug("session.exit() successful")
+                    pool.close()
+                except TimeoutError:
+                    logger.debug("session.exit() timeout")
+                    pool.terminate()
+
+            logger.debug("Continuing...")
             if timeout_force:
                 if self._remote_instance:
-                    logger.warning(
-                        "Cannot force exit from Fluent remote instance, and exit command has timed out."
-                    )
+                    logger.warning("Cannot force exit from Fluent remote instance.")
                     return
                 elif self.connection_properties.inside_container:
-                    logger.debug("Fluent running inside container, killing it...")
+                    logger.debug(
+                        "Fluent running inside container, killing container..."
+                    )
                     self.force_exit_container()
                 else:
-                    logger.debug("Fluent running locally, killing it...")
+                    logger.debug("Fluent running locally, killing processes...")
                     self.force_exit()
-                if tmp_thread.is_alive():
-                    logger.debug("Closing existing thread...")
-                    tmp_thread.join()
                 logger.debug("Done.")
             else:
                 logger.debug("Timeout force exit disabled, returning...")

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -21,7 +21,7 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: str = None):
     )
 
     env_watchdog_debug = os.getenv("PYFLUENT_WATCHDOG_DEBUG", "off").upper()
-    if env_watchdog_debug in [1, "1", "ON"]:
+    if env_watchdog_debug in ("1", "ON"):
         print(f"Number of arguments: {len(sys.argv)} arguments.")
         print(f"Argument list: {sys.argv}")
 

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -35,7 +35,7 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: str = None):
     watchdog_env = os.environ.copy()
 
     # No auto PyFluent logging to file on the watchdog
-    if watchdog_env.get("PYFLUENT_LOGGING"):
+    if "PYFLUENT_LOGGING" in watchdog_env:
         watchdog_env.pop("PYFLUENT_LOGGING")
 
     # disable additional services/addons?
@@ -77,7 +77,7 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: str = None):
     if os.name == "posix":
         kwargs.update(start_new_session=True)
 
-    if env_watchdog_debug in [1, "1", "ON"] and os.name != "nt":
+    if env_watchdog_debug in ("1", "ON") and os.name != "nt":
         kwargs.update(
             stdout=open(f"pyfluent_watchdog_out_{watchdog_id}.log", mode="w"),
             stderr=open(f"pyfluent_watchdog_err_{watchdog_id}.log", mode="w"),
@@ -141,7 +141,7 @@ if __name__ == "__main__":
 
     logger = pyfluent.logging.get_logger("pyfluent.watchdog")
 
-    if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "off").upper() in [1, "1", "ON"]:
+    if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "OFF").upper() in ("1", "ON"):
         pyfluent.logging.enable(custom_config=log_config)
         logger.setLevel("DEBUG")
         logger.handlers = pyfluent.logging.get_logger(

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -1,0 +1,274 @@
+import multiprocessing.pool
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+# import threading
+import time
+
+import ansys.fluent.core as pyfluent
+
+IDLE_PERIOD = 2  # seconds
+
+
+def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: str = None):
+    env_watchdog_debug = os.getenv("PYFLUENT_WATCHDOG_DEBUG", "off").upper()
+    if env_watchdog_debug in [1, "1", "ON"]:
+        print(f"Number of arguments: {len(sys.argv)} arguments.")
+        print(f"Argument list: {sys.argv}")
+
+        import random
+        import string
+
+        watchdog_id = "".join(
+            random.choices(
+                string.ascii_uppercase + string.ascii_lowercase + string.digits, k=6
+            )
+        )
+
+        print(
+            f"PYFLUENT_WATCHDOG_DEBUG environment variable found, "
+            f"enabling debugging for watchdog id {watchdog_id}..."
+        )
+    else:
+        watchdog_id = ""
+
+    logger = pyfluent.logging.get_logger("pyfluent.launcher")
+
+    watchdog_env = os.environ.copy()
+
+    # No auto PyFluent logging to file on the watchdog
+    if watchdog_env.get("PYFLUENT_LOGGING"):
+        watchdog_env.pop("PYFLUENT_LOGGING")
+
+    # disable additional services/addons?
+
+    # Path to the Python interpreter executable
+    python_executable = sys.executable
+
+    # Command to be executed by the new process
+    command_list = [
+        Path(python_executable),
+        Path(__file__),
+        str(main_pid),
+        str(sv_ip),
+        str(sv_port),
+        sv_password,
+        watchdog_id,
+    ]
+
+    logger.debug(f"Starting Watchdog logging to directory {os.getcwd()}")
+
+    kwargs = {"env": watchdog_env, "stdin": subprocess.DEVNULL}
+
+    if os.name == "nt":
+        kwargs["shell"] = True
+        # https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+        # https://docs.python.org/3/library/subprocess.html#windows-constants
+        flags = 0
+        flags |= subprocess.CREATE_NO_WINDOW
+        flags |= subprocess.CREATE_NEW_PROCESS_GROUP
+        flags |= subprocess.DETACHED_PROCESS
+        flags |= subprocess.CREATE_BREAKAWAY_FROM_JOB
+        flags |= subprocess.IDLE_PRIORITY_CLASS
+        kwargs["creationflags"] = flags
+
+    if env_watchdog_debug in [1, "1", "ON"] and os.name != "nt":
+        kwargs["stdout"] = open(f"pyfluent_watchdog_out_{watchdog_id}.log", mode="w")
+        kwargs["stderr"] = open(f"pyfluent_watchdog_err_{watchdog_id}.log", mode="w")
+        kwargs["bufsize"] = 1
+    else:
+        kwargs["stdout"] = subprocess.DEVNULL
+        kwargs["stderr"] = subprocess.DEVNULL
+
+    logger.debug(f"kwargs: {kwargs}")
+
+    if os.name == "nt":
+        # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start
+        # os_cmd = ["start", r"/b"]
+        os_cmd = ["start"]
+        # os_cmd = []
+    else:
+        os_cmd = []
+    # os_cmd = []
+
+    cmd_send = os_cmd + command_list
+    logger.debug(f"Command list: {cmd_send}")
+
+    subprocess.Popen(cmd_send, close_fds=True, **kwargs)
+    logger.debug(f"Waiting few secs for Watchdog, then proceeding.")
+    time.sleep(IDLE_PERIOD)
+
+
+if __name__ == "__main__":
+    print(
+        "Starting PyFluent Watchdog process, do not manually close or terminate this process, "
+        "it will automatically exit once finished.".upper()
+    )
+
+    watchdog_id = sys.argv[5]
+
+    import psutil
+
+    launcher_pid = int(sys.argv[1])
+
+    from ansys.fluent.core.fluent_connection import FluentConnection, get_container_ids
+
+    # Configure logger for Watchdog process
+    log_config = pyfluent.logging.get_default_config()
+    log_config["handlers"]["pyfluent_file"][
+        "filename"
+    ] = f"pyfluent_watchdog_{watchdog_id}.log"
+
+    logger = pyfluent.logging.get_logger("pyfluent.watchdog")
+
+    if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "off").upper() in [1, "1", "ON"]:
+        pyfluent.logging.enable(custom_config=log_config)
+        logger.setLevel("DEBUG")
+        logger.handlers = pyfluent.logging.get_logger(
+            "pyfluent.general"
+        ).handlers  # using same handlers as already defined
+
+    import signal
+
+    def got_sig(signum, _):
+        logger.warning(f"Received {signal.Signals(signum).name}, ignoring it")
+
+    for sig in signal.valid_signals():
+        try:
+            logger.debug(f"Handling signal {sig}")
+            signal.signal(sig, got_sig)
+        except OSError:
+            logger.debug(f"Unable to handle signal {sig}")
+
+    logger.debug(f"Number of arguments: {len(sys.argv)} arguments.")
+    logger.debug(f"Argument list: {sys.argv}")
+    logger.debug(f"Watchdog pid: {os.getpid()}")
+    logger.debug(f"Python launcher pid: {launcher_pid}")
+
+    ip, port, password = sys.argv[2:5]
+
+    logger.debug(f"ip:{ip} port:{port} pass:{password}")
+
+    if ip == "None":
+        ip = None
+
+    from multiprocessing.context import TimeoutError
+
+    logger.debug("Attempting to connect to existing Fluent session...")
+
+    kwargs = {
+        "ip": ip,
+        "port": int(port),
+        "password": password,
+        "launcher_args": None,
+        "start_transcript": False,
+        "cleanup_on_exit": False,
+    }
+
+    def _start_connection(**connection_kwargs):
+        return FluentConnection(**connection_kwargs)
+
+    pool = multiprocessing.pool.ThreadPool(processes=1)
+    async_result = pool.apply_async(_start_connection, kwds=kwargs)
+    try:
+        fluent = async_result.get(timeout=IDLE_PERIOD * 5)
+        pool.close()
+    except TimeoutError:
+        logger.debug("Fluent connection timeout")
+        pool.terminate()
+        sys.exit("Unable to connect to Fluent client")
+
+    logger.debug("Fluent connection successful")
+
+    fluent_host_pid = fluent.connection_properties.fluent_host_pid
+    cortex_pid = fluent.connection_properties.cortex_pid
+    cortex_host = fluent.connection_properties.cortex_host
+
+    while True:
+        if not psutil.pid_exists(launcher_pid):
+            logger.debug("Python launcher down")
+            break
+        if (
+            fluent.connection_properties.inside_container is False
+            and not fluent._remote_instance
+        ):
+            if not psutil.pid_exists(cortex_pid):
+                logger.debug("Cortex down")
+                break
+            if not psutil.pid_exists(fluent_host_pid):
+                logger.debug("Fluent down")
+                break
+        logger.debug("Waiting...")
+        time.sleep(IDLE_PERIOD)
+
+    dead = []
+
+    if not psutil.pid_exists(launcher_pid):
+        dead.append("Python")
+
+    if fluent.connection_properties.inside_container:
+        if cortex_host not in get_container_ids():
+            dead.append("Fluent container")
+
+    if (
+        fluent.connection_properties.inside_container is False
+        and not fluent._remote_instance
+    ):
+        if not psutil.pid_exists(fluent_host_pid):
+            dead.append("Fluent")
+        if not psutil.pid_exists(cortex_pid):
+            dead.append("Cortex")
+
+    logger.debug(", ".join(dead) + " not running anymore")
+    # give some time as processes may be currently closing down
+    time.sleep(IDLE_PERIOD * 2)
+
+    def _check_serving(fl):
+        return fl.health_check_service.is_serving
+
+    pool = multiprocessing.pool.ThreadPool(processes=1)
+    async_result = pool.apply_async(_check_serving, args=(fluent,))
+    try:
+        is_serving = async_result.get(timeout=IDLE_PERIOD * 3)
+        pool.close()
+    except TimeoutError:
+        is_serving = False
+        pool.terminate()
+
+    force = False
+    if is_serving:
+        time.sleep(IDLE_PERIOD)
+        logger.debug("Fluent client healthy, trying soft exit with timeout...")
+        fluent.exit(timeout=IDLE_PERIOD * 2, timeout_force=False)
+        logger.debug("Waiting...")
+        time.sleep(IDLE_PERIOD)
+        if (
+            fluent.connection_properties.inside_container
+            and cortex_host in get_container_ids()
+        ):
+            logger.debug("Exit call succeeded, but Fluent container remains...")
+            force = True
+        elif psutil.pid_exists(fluent_host_pid) or psutil.pid_exists(cortex_pid):
+            logger.debug("Exit call succeeded, but Fluent client remains...")
+            force = True
+        else:
+            logger.debug("Exit call succeeded.")
+        logger.debug("Continuing...")
+    else:
+        logger.debug("Fluent client not healthy")
+        force = True
+
+    if force:
+        logger.debug("Forcing cleanup...")
+        if fluent._remote_instance:
+            logger.error("Cannot terminate remote Fluent client.")
+        elif fluent.connection_properties.inside_container:
+            logger.debug("Terminating Fluent container...")
+            fluent.force_exit_container()
+        else:
+            logger.debug("Terminating local Fluent client...")
+            fluent.force_exit()
+
+    logger.debug("Done.")

--- a/src/ansys/fluent/core/logging.py
+++ b/src/ansys/fluent/core/logging.py
@@ -25,13 +25,24 @@ def is_active() -> bool:
     return _logging_file_enabled
 
 
-def enable(level: Union[str, int] = "DEBUG"):
+def get_default_config() -> dict:
+    file_path = os.path.abspath(__file__)
+    file_dir = os.path.dirname(file_path)
+    yaml_path = os.path.join(file_dir, "logging_config.yaml")
+    with open(yaml_path, "rt") as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def enable(level: Union[str, int] = "DEBUG", custom_config: dict = None):
     """Enables PyFluent logging to file.
 
     Parameters
     ----------
     level : str or int, optional
         Specified logging level to set PyFluent loggers to. If omitted, level is set to DEBUG.
+    custom_config : dict, optional
+        Used to provide a customized logging config file.
 
     Examples
     --------
@@ -45,21 +56,22 @@ def enable(level: Union[str, int] = "DEBUG"):
     global _logging_file_enabled
 
     if _logging_file_enabled:
-        print("PyFluent logging to file is already active.")
-        return
+        print(
+            "PyFluent logging to file is already active, overwriting previous configuration..."
+        )
 
     _logging_file_enabled = True
 
     # Configure the logging system
-    file_path = os.path.abspath(__file__)
-    file_dir = os.path.dirname(file_path)
-    yaml_path = os.path.join(file_dir, "logging_config.yaml")
-
-    with open(yaml_path, "rt") as f:
-        config = yaml.safe_load(f)
+    if custom_config is not None:
+        config = custom_config
+    else:
+        config = get_default_config()
 
     logging.config.dictConfig(config)
-    print(f"PyFluent logging file {os.path.join(os.getcwd(),'pyfluent.log')}")
+    filename = config["handlers"]["pyfluent_file"]["filename"]
+
+    print(f"PyFluent logging file {os.path.join(os.getcwd(),filename)}")
 
     set_global_level(level)
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -4,7 +4,7 @@ import importlib
 import json
 import logging
 import os
-from typing import Any, Dict
+from typing import Any
 
 from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.session_shared import (  # noqa: F401
@@ -87,11 +87,7 @@ class BaseSession:
 
     @classmethod
     def create_from_server_info_file(
-        cls,
-        server_info_filepath: str,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        launcher_args: Dict[str, Any] = None,
+        cls, server_info_filepath: str, **connection_kwargs
     ):
         """Create a Session instance from server-info file.
 
@@ -99,15 +95,11 @@ class BaseSession:
         ----------
         server_info_filepath : str
             Path to server-info file written out by Fluent server
-        cleanup_on_exit : bool, optional
-            When True, the connected Fluent session will be shut down
-            when PyFluent is exited or exit() is called on the session
-            instance, by default True.
-        start_transcript : bool, optional
-            The Fluent transcript is started in the client only when
-            start_transcript is True. It can be started and stopped
-            subsequently via method calls on the Session object.
-            Defaults to true.
+        **connection_kwargs : dict, optional
+            Additional keyword arguments may be specified, and they will be passed to the `FluentConnection`
+            being initialized. For example, ``cleanup_on_exit = True``, or ``start_transcript = True``.
+            See :func:`FluentConnection initialization <ansys.fluent.core.fluent_connection.FluentConnection.__init__>`
+            for more details and possible arguments.
 
         Returns
         -------
@@ -117,12 +109,7 @@ class BaseSession:
         ip, port, password = _parse_server_info_file(server_info_filepath)
         session = cls(
             fluent_connection=FluentConnection(
-                ip=ip,
-                port=port,
-                password=password,
-                cleanup_on_exit=cleanup_on_exit,
-                start_transcript=start_transcript,
-                launcher_args=launcher_args,
+                ip=ip, port=port, password=password, **connection_kwargs
             )
         )
         return session

--- a/tests/test_streaming_services.py
+++ b/tests/test_streaming_services.py
@@ -4,7 +4,7 @@ import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 from ansys.fluent.core.fluent_connection import FluentConnection
-from ansys.fluent.core.session_solver import Solver
+from ansys.fluent.core.session import BaseSession
 
 
 def transcript(data):
@@ -12,52 +12,47 @@ def transcript(data):
 
 
 def run_transcript(i, ip, port, password):
-    solver_session = Solver(
+    transcript("")
+    session = BaseSession(
         FluentConnection(ip=ip, port=port, password=password, cleanup_on_exit=False)
     )
-    solver_session.transcript.register_callback(transcript)
+    session.transcript.register_callback(transcript)
 
-    transcript_checked = transcript_passed = 0
+    transcript_checked = False
+    transcript_passed = False
 
     if i % 5 == 0:
-        solver_session.scheme_eval.scheme_eval("(pp 'test)")
-        check_transcript = True
-        time.sleep(1)
-        transcript_checked = 1
-    else:
-        check_transcript = False
-
-    if solver_session:
-        solver_session.exit()
-        if check_transcript:
-            if not transcript.data:
-                assert transcript.data == ""
-            else:
-                assert transcript.data == "test"
-                transcript_passed = 1
-        transcript("")
+        time.sleep(0.5)
+        session.scheme_eval.scheme_eval("(pp 'test)")
+        time.sleep(0.5)
+        if not transcript.data:
+            assert transcript.data == ""
+        else:
+            assert transcript.data == "test"
+            transcript_passed = True
+        transcript_checked = True
 
     return transcript_checked, transcript_passed
 
 
 @pytest.mark.dev
 @pytest.mark.fluent_232
-@pytest.mark.skip
+@pytest.mark.fluent_241
 def test_transcript(new_solver_session):
     solver = new_solver_session
-    ip = solver.fluent_connection._channel_str.split(":")[0]
-    port = int(solver.fluent_connection._channel_str.split(":")[1])
-    password = solver.fluent_connection._metadata[0][-1]
+    ip = solver.connection_properties.ip
+    port = solver.connection_properties.port
+    password = solver.connection_properties.password
 
-    total_checked_transcript = 0
-    passed_transcript = 0
+    total_checked_transcripts = 0
+    total_passed_transcripts = 0
 
     for i in range(100):
         transcript_checked, transcript_passed = run_transcript(i, ip, port, password)
-        total_checked_transcript += transcript_checked
-        passed_transcript += transcript_passed
+        total_checked_transcripts += int(transcript_checked)
+        total_passed_transcripts += int(transcript_passed)
 
     if solver.get_fluent_version() >= "23.2.0":
-        assert total_checked_transcript == passed_transcript
+        assert total_checked_transcripts == total_passed_transcripts
     else:
-        assert total_checked_transcript >= passed_transcript
+        assert total_checked_transcripts >= total_passed_transcripts


### PR DESCRIPTION
Update: zero stray containers left on the GitHub CI runners after going through all tests multiple times (before would leave around 2 to 15 stray Fluent containers each run)

By default, Watchdog will only be started when Fluent is launched with `show_gui=False`, or with `start_watchdog=True`

For debugging, set `PYFLUENT_LOGGING=DEBUG` (for PyFluent) and `PYFLUENT_WATCHDOG_DEBUG=ON` (for the Watchdog)

Common situations that leave lots of stray Fluent processes behind include: 

- When running PyFluent tests that open and close many Fluent connections in quick succession (e.g. our CI runs on GitHub)
- Cancelling GitHub CI runs (automatically when for example a new commit is made while previous tests were running, or manually when cancelling workflows)
- When closing the window or terminal that is running Python while a launched Fluent process is active in the background
- When using the "restart" button on VSCode Jupyter or similar functions in other IDEs
- When sending multiple keyboard interrupts (Ctrl+C) to active Python sessions while a launched Fluent process is active in the background
- When either PyFluent or Fluent freeze/hang

Watchdog Pros:

- Can deal with Fluent stray processes in the most common situations listed above

Watchdog Cons:

- Slows down execution when launching Fluent, as the interpreter needs to wait a bit for Watchdog to properly hook to the Fluent client
- Shouldn't be necessary

To-do list (could be done in future PRs if we want to get this up asap to deal with the runner issues):

1. Done: ~Add some communication between watchdog and launcher, so that launcher does not need to wait more than necessary for watchdog, and to avoid situations where processes can still be left behind when Fluent is initialized and starts exiting (then gets stuck) before Watchdog can connect to Fluent and prepare to deal with the stray processes~ 
2. Lots of room to optimize and streamline the code (e.g., using wrappers for executing calls with timeout), review and improve logic
3. Done: ~Change how Fluent without GUI is launched, so that it is in a separate process group and can avoid bad VSCode Jupyter notebook termination attempts (and other similar situations) that leave `mpiexec` and `hydra_pmi_proxy` processes behind. Not an issue on v241 with @lagacep-ans Fluent error management fix~ 
4. Done: ~Figure out if there is a way to hide the Watchdog process window on Windows (this is an issue exclusive to Windows, on Linux no separate window is required)~ 
5. Tests
6. Future PR: update and restructure how Fluent is being launched by PyFluent, use Python Docker SDK for containers (?), use argument list rather than a single string for local non-container Fluent client, also use docker-composer as in #1616 raised by Mainak
7. Future PR: review Fluent launcher documentation and add watchdog documentation

