### PR TITLE
reverting #1677 and attempting test_transcripts fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
   build_test_232_241:
     name: Build and Test
     needs: test-import
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
   test:
     name: Unit Testing
     needs: build
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_streaming_services.py
+++ b/tests/test_streaming_services.py
@@ -4,7 +4,7 @@ import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 from ansys.fluent.core.fluent_connection import FluentConnection
-from ansys.fluent.core.session_solver import Solver
+from ansys.fluent.core.session import BaseSession
 
 
 def transcript(data):
@@ -12,52 +12,47 @@ def transcript(data):
 
 
 def run_transcript(i, ip, port, password):
-    solver_session = Solver(
+    transcript("")
+    session = BaseSession(
         FluentConnection(ip=ip, port=port, password=password, cleanup_on_exit=False)
     )
-    solver_session.transcript.register_callback(transcript)
+    session.transcript.register_callback(transcript)
 
-    transcript_checked = transcript_passed = 0
+    transcript_checked = False
+    transcript_passed = False
 
     if i % 5 == 0:
-        solver_session.scheme_eval.scheme_eval("(pp 'test)")
-        check_transcript = True
-        time.sleep(1)
-        transcript_checked = 1
-    else:
-        check_transcript = False
-
-    if solver_session:
-        solver_session.exit()
-        if check_transcript:
-            if not transcript.data:
-                assert transcript.data == ""
-            else:
-                assert transcript.data == "test"
-                transcript_passed = 1
-        transcript("")
+        time.sleep(0.5)
+        session.scheme_eval.scheme_eval("(pp 'test)")
+        time.sleep(0.5)
+        if not transcript.data:
+            assert transcript.data == ""
+        else:
+            assert transcript.data == "test"
+            transcript_passed = True
+        transcript_checked = True
 
     return transcript_checked, transcript_passed
 
 
 @pytest.mark.dev
 @pytest.mark.fluent_232
-@pytest.mark.skip
+@pytest.mark.fluent_241
 def test_transcript(new_solver_session):
     solver = new_solver_session
-    ip = solver.fluent_connection._channel_str.split(":")[0]
-    port = int(solver.fluent_connection._channel_str.split(":")[1])
-    password = solver.fluent_connection._metadata[0][-1]
+    ip = solver.connection_properties.ip
+    port = solver.connection_properties.port
+    password = solver.connection_properties.password
 
-    total_checked_transcript = 0
-    passed_transcript = 0
+    total_checked_transcripts = 0
+    total_passed_transcripts = 0
 
     for i in range(100):
         transcript_checked, transcript_passed = run_transcript(i, ip, port, password)
-        total_checked_transcript += transcript_checked
-        passed_transcript += transcript_passed
+        total_checked_transcripts += int(transcript_checked)
+        total_passed_transcripts += int(transcript_passed)
 
     if solver.get_fluent_version() >= "23.2.0":
-        assert total_checked_transcript == passed_transcript
+        assert total_checked_transcripts == total_passed_transcripts
     else:
-        assert total_checked_transcript >= passed_transcript
+        assert total_checked_transcripts >= total_passed_transcripts


### PR DESCRIPTION
Based on `test_transcripts` changes by @mkundu1 from https://github.com/ansys/pyfluent/pull/1701, but instead branched from feat/watchdog to make use of the watchdog functionality, with an additional  `time.sleep()` as a potential fix

Currently testing this fix, running repeated tests locally and on github runners

The objective is to make this test take as little time as possible, while not failing

Update: has passed 100 tests with no failures, while failing approx. 2 out of every 20 tests before (on my local machine, apparently failed a lot more often on GitHub)

Update 2: also, considering we are now identifying and fixing what has been causing tests to fail, we should be able to go back to running as many tests as we can on GitHub runners, rather than self-hosted, to speed up our CI tests due to having more runners available, and only use self-hosted when necessary
