### PR TITLE
Fix some issues in the existing docstrings

### DIFF
--- a/doc/source/_templates/noindex-base.rst
+++ b/doc/source/_templates/noindex-base.rst
@@ -1,0 +1,6 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}
+   :noindex:

--- a/doc/source/_templates/noindex-class.rst
+++ b/doc/source/_templates/noindex-class.rst
@@ -1,0 +1,32 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :noindex:
+
+   {% block methods %}
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree:
+      :template: noindex-base.rst
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :template: noindex-base.rst
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/source/_templates/noindex-module.rst
+++ b/doc/source/_templates/noindex-module.rst
@@ -1,0 +1,69 @@
+{{ name | escape | underline}}
+
+.. automodule:: {{ fullname }}
+   :noindex:
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: noindex-base.rst
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :template: noindex-base.rst
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: noindex-class.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :template: noindex-base.rst
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: noindex-module.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/source/api/solver/events.rst
+++ b/doc/source/api/solver/events.rst
@@ -32,7 +32,7 @@ The following code triggers a callback at the end of every iteration.
 
 .. autosummary::
     :toctree: _autosummary
-    :template: flobject-class-template.rst
+    :template: noindex-class.rst
     :recursive:
 
     EventsManager

--- a/doc/source/api/solver/fielddata.rst
+++ b/doc/source/api/solver/fielddata.rst
@@ -299,7 +299,7 @@ Some sample use cases are demonstrated below:
 
 .. autosummary::
     :toctree: _autosummary
-    :template: flobject-class-template.rst
+    :template: noindex-class.rst
     :recursive:
 
     field_data.FieldTransaction

--- a/doc/source/api/solver/fieldinfo.rst
+++ b/doc/source/api/solver/fieldinfo.rst
@@ -90,7 +90,7 @@ calling the ``get_surfaces_info`` method.
 
 .. autosummary::
     :toctree: _autosummary
-    :template: flobject-class-template.rst
+    :template: noindex-class.rst
     :recursive:
 
     field_data.FieldInfo

--- a/doc/source/api/solver/monitors.rst
+++ b/doc/source/api/solver/monitors.rst
@@ -11,7 +11,7 @@ property in each solution-mode session object. It provides access to server moni
 
 .. autosummary::
     :toctree: _autosummary
-    :template: flobject-class-template.rst
+    :template: noindex-class.rst
     :recursive:
 
     MonitorsManager

--- a/doc/source/api/solver/schemeeval.rst
+++ b/doc/source/api/solver/schemeeval.rst
@@ -10,7 +10,7 @@ scheme code can be executed.
 
 .. autosummary::
     :toctree: _autosummary
-    :template: flobject-class-template.rst
+    :template: noindex-class.rst
     :recursive:
 
     Symbol

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -59,6 +59,7 @@ class InputParameter:
     @property
     def units(self) -> str:
         """Get the unit label of a Fluent input parameter.
+
         Returns
         -------
         str
@@ -69,6 +70,7 @@ class InputParameter:
     @property
     def numeric_value(self):
         """Get the numeric value of a Fluent input parameter.
+
         Returns
         -------
         float

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -285,17 +285,16 @@ class FluentConnection:
         Immediately terminates the Fluent client,
         losing unsaved progress and data.
 
+        Notes
+        -----
+        If the Fluent session is responsive, prefer using :func:`exit()` instead.
+
         Examples
         --------
 
         >>> import ansys.fluent.core as pyfluent
         >>> session = pyfluent.launch_fluent()
         >>> session.force_exit()
-
-        Notes
-        -----
-        If the Fluent session is responsive, prefer using :func:`exit()` instead.
-
         """
         if self.connection_properties.inside_container:
             logger.error(
@@ -393,19 +392,19 @@ class FluentConnection:
             exit request reached timeout. Executes :func:`force_exit()` or :func:`force_exit_container()`,
             depending on how Fluent was launched.
 
-        Examples
-        --------
-
-        >>> import ansys.fluent.core as pyfluent
-        >>> session = pyfluent.launch_fluent()
-        >>> session.exit()
-
         Notes
         -----
         Can also set the ``PYFLUENT_TIMEOUT_FORCE_EXIT`` environment variable to specify the number of seconds and
         alter the default ``timeout`` value. Setting this env var to a non-number value, such as ``OFF``,
         will return this function to default behavior. Note that the environment variable will be ignored if
         timeout is specified when calling this function.
+
+        Examples
+        --------
+
+        >>> import ansys.fluent.core as pyfluent
+        >>> session = pyfluent.launch_fluent()
+        >>> session.exit()
         """
 
         if timeout is None:

--- a/src/ansys/fluent/core/logging.py
+++ b/src/ansys/fluent/core/logging.py
@@ -44,14 +44,14 @@ def enable(level: Union[str, int] = "DEBUG", custom_config: dict = None):
     custom_config : dict, optional
         Used to provide a customized logging config file.
 
+    Notes
+    -----
+    See logging levels in https://docs.python.org/3/library/logging.html#logging-levels
+
     Examples
     --------
     >>> import ansys.fluent.core as pyfluent
     >>> pyfluent.logging.enable()
-
-    Notes
-    -----
-    See logging levels in https://docs.python.org/3/library/logging.html#logging-levels
     """
     global _logging_file_enabled
 
@@ -89,6 +89,10 @@ def set_global_level(level: Union[str, int]):
     level : str or int
         Specified logging level to set PyFluent loggers to.
 
+    Notes
+    -----
+    See logging levels in https://docs.python.org/3/library/logging.html#logging-levels
+
     Examples
     --------
     >>> import ansys.fluent.core as pyfluent
@@ -97,10 +101,6 @@ def set_global_level(level: Union[str, int]):
     or
 
     >>> pyfluent.logging.set_global_level('DEBUG')
-
-    Notes
-    -----
-    See logging levels in https://docs.python.org/3/library/logging.html#logging-levels
     """
     if not is_active():
         print("Logging is not active, enable it first.")
@@ -126,6 +126,11 @@ def list_loggers():
         Each list element is a PyFluent logger name that can be individually controlled
         through :func:`ansys.fluent.core.logging.get_logger`.
 
+    Notes
+    -----
+    PyFluent loggers use the standard Python logging library, for more details
+    see https://docs.python.org/3/library/logging.html#logger-objects
+
     Examples
     --------
     >>> import ansys.fluent.core as pyfluent
@@ -138,11 +143,6 @@ def list_loggers():
     >>> logger.setLevel('ERROR')
     >>> logger
     <Logger pyfluent.networking (ERROR)>
-
-    Notes
-    -----
-    PyFluent loggers use the standard Python logging library, for more details
-    see https://docs.python.org/3/library/logging.html#logger-objects
     """
     logger_dict = logging.root.manager.loggerDict
     pyfluent_loggers = []

--- a/src/ansys/fluent/core/services/health_check.py
+++ b/src/ansys/fluent/core/services/health_check.py
@@ -16,7 +16,7 @@ class HealthCheckService:
 
     Methods
     -------
-    check_health
+    check_health()
         Check the health of the Fluent connection.
     """
 

--- a/src/ansys/fluent/core/services/meshing_queries.py
+++ b/src/ansys/fluent/core/services/meshing_queries.py
@@ -817,7 +817,7 @@ class MeshingQueries:
 
     def get_edge_zone_id_list_of_object(self, object) -> Any:
         """
-        Return a list of edge zones by ID in the specified face zone labels of an object
+        Return a list of edge zones by ID in the specified face zone labels of an object.
 
         .. code-block:: python
 
@@ -1005,7 +1005,7 @@ class MeshingQueries:
 
     def get_adjacent_cell_zones(self, list_or_name_or_pattern) -> Any:
         """
-        Return adjacent cell zones for given face zone
+        Return adjacent cell zones for given face zone.
 
         .. code-block:: python
 
@@ -1071,7 +1071,7 @@ class MeshingQueries:
 
     def get_adjacent_zones_by_edge_connectivity(self, list_or_name_or_pattern) -> Any:
         """
-        Return adjacent zones based on edge connectivity
+        Return adjacent zones based on edge connectivity.
 
         .. code-block:: python
 
@@ -1091,7 +1091,7 @@ class MeshingQueries:
 
     def get_adjacent_zones_by_node_connectivity(self, list_or_name_or_pattern) -> Any:
         """
-        Return adjacent zones based on node connectivity
+        Return adjacent zones based on node connectivity.
 
         .. code-block:: python
 

--- a/src/ansys/fluent/core/services/streaming.py
+++ b/src/ansys/fluent/core/services/streaming.py
@@ -8,10 +8,9 @@ class _StreamingServiceHelper:
 
     Methods
     -------
-    begin_streaming
+    begin_streaming(request, started_evt)
         Begin streaming from Fluent.
-
-    end_streaming
+    end_streaming()
         End streaming
     """
 
@@ -45,10 +44,9 @@ class StreamingService:
 
     Methods
     -------
-    begin_streaming
+    begin_streaming(request, started_evt, id, stream_begin_method)
         Begin streaming from Fluent.
-
-    end_streaming
+    end_streaming(id, stream_begin_method)
         End streaming
     """
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -102,7 +102,7 @@ class BaseSession:
     """
 
     def __init__(self, fluent_connection: FluentConnection):
-        """BaseSession
+        """BaseSession.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -71,7 +71,7 @@ class BaseMeshing:
 
     @property
     def _meshing_root(self):
-        """meshing datamodel root."""
+        """Datamodel root of meshing."""
         try:
             meshing_module = importlib.import_module(
                 f"ansys.fluent.core.datamodel_{self.version}.meshing"
@@ -95,7 +95,7 @@ class BaseMeshing:
 
     @property
     def _workflow_se(self):
-        """workflow datamodel root."""
+        """Datamodel root of workflow."""
         try:
             workflow_module = importlib.import_module(
                 f"ansys.fluent.core.datamodel_{self.version}.workflow"
@@ -114,7 +114,7 @@ class BaseMeshing:
 
     @property
     def PartManagement(self):
-        """PartManagement datamodel root."""
+        """Datamdoel root of PartManagement."""
         if self._part_management is None:
             try:
                 pm_module = importlib.import_module(
@@ -132,7 +132,7 @@ class BaseMeshing:
 
     @property
     def PMFileManagement(self):
-        """PMFileManagement datamodel root."""
+        """Datamodel root of PMFileManagement."""
         if self._pm_file_management is None:
             try:
                 pmfm_module = importlib.import_module(
@@ -150,7 +150,7 @@ class BaseMeshing:
 
     @property
     def preferences(self):
-        """preferences datamodel root."""
+        """Datamodel root of preferences."""
         if self._preferences is None:
             from ansys.fluent.core.session import _get_preferences
 

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -41,25 +41,25 @@ class Meshing(PureMeshing):
 
     @property
     def meshing(self):
-        """meshing datamodel root."""
+        """Datamodel root of meshing."""
         return super(Meshing, self).meshing if not self.switched else None
 
     @property
     def workflow(self):
-        """workflow datamodel root."""
+        """Datamodel root of workflow."""
         return super(Meshing, self).workflow if not self.switched else None
 
     @property
     def PartManagement(self):
-        """PartManagement datamodel root."""
+        """Datamodel root of PartManagement."""
         return super(Meshing, self).PartManagement if not self.switched else None
 
     @property
     def PMFileManagement(self):
-        """PMFileManagement datamodel root."""
+        """Datamodel root of PMFileManagement."""
         return super(Meshing, self).PMFileManagement if not self.switched else None
 
     @property
     def preferences(self):
-        """preferences datamodel root."""
+        """Datamodel root of preferences."""
         return super(Meshing, self).preferences if not self.switched else None

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -71,27 +71,27 @@ class PureMeshing(BaseSession):
 
     @property
     def meshing(self):
-        """meshing datamodel root."""
+        """Datamodel root of meshing."""
         return self._base_meshing.meshing
 
     @property
     def workflow(self):
-        """workflow datamodel root."""
+        """Datamodel root of workflow."""
         return self._base_meshing.workflow
 
     @property
     def PartManagement(self):
-        """PartManagement datamodel root."""
+        """Datamodel root of PartManagement."""
         return self._base_meshing.PartManagement
 
     @property
     def PMFileManagement(self):
-        """PMFileManagement datamodel root."""
+        """Datamodel root of PMFileManagement."""
         return self._base_meshing.PMFileManagement
 
     @property
     def preferences(self):
-        """preferences datamodel root."""
+        """Datamodel root of preferences."""
         return self._base_meshing.preferences
 
     def transfer_mesh_to_solvers(

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -95,7 +95,7 @@ class Solver(BaseSession):
 
     @property
     def _workflow_se(self):
-        """workflow datamodel root."""
+        """Datamodel root for workflow."""
         try:
             workflow_module = importlib.import_module(
                 f"ansys.fluent.core.datamodel_{self.version}.workflow"
@@ -114,7 +114,7 @@ class Solver(BaseSession):
 
     @property
     def _root(self):
-        """root settings object."""
+        """Root settings object."""
         if self._settings_root is None:
             self._settings_root = settings_get_root(
                 flproxy=self._settings_service, version=self.version
@@ -123,59 +123,59 @@ class Solver(BaseSession):
 
     @property
     def file(self):
-        """file settings."""
+        """Settings for file."""
         return self._root.file
 
     @property
     def mesh(self):
-        """mesh settings."""
+        """Settings for mesh."""
         return self._root.mesh
 
     @property
     def setup(self):
-        """setup settings."""
+        """Settings for setup."""
         return self._root.setup
 
     @property
     def solution(self):
-        """solution settings."""
+        """Settings for solution."""
         return self._root.solution
 
     @property
     def results(self):
-        """results settings."""
+        """Settings for results."""
         return self._root.results
 
     @property
     def parametric_studies(self):
-        """parametric_studies settings."""
+        """Settings for parametric_studies."""
         return self._root.parametric_studies
 
     @property
     def current_parametric_study(self):
-        """current_parametric_study settings."""
+        """Settings for current_parametric_study."""
         return self._root.current_parametric_study
 
     @property
     def parallel(self):
-        """parallel settings."""
+        """Settings for parallel."""
         return self._root.parallel
 
     @property
     def report(self):
-        """report settings."""
+        """Settings for report."""
         return self._root.report
 
     @property
     def preferences(self):
-        """preferences datamodel root."""
+        """Datamodel root of preferences."""
         if self._preferences is None:
             self._preferences = _get_preferences(self)
         return self._preferences
 
     @property
     def solverworkflow(self):
-        """solverworkflow datamodel root."""
+        """Datamodel root of solverworkflow."""
         if self._solverworkflow is None:
             self._solverworkflow = _get_solverworkflow(self)
         return self._solverworkflow

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -42,7 +42,7 @@ class SolverIcing(Solver):
 
     @property
     def _flserver(self):
-        """root datamodel object."""
+        """Root datamodel object."""
         if self._flserver_root is None:
             se = self.datamodel_service_se
             dm_module = tui_module = importlib.import_module(
@@ -53,5 +53,5 @@ class SolverIcing(Solver):
 
     @property
     def icing(self):
-        """instance of icing (Case.App) -> root datamodel object."""
+        """Instance of icing (Case.App) -> root datamodel object."""
         return self._flserver.Case.App

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -454,8 +454,14 @@ class Group(SettingsBase[DictStateType]):
                 ret.append(query)
         return ret
 
-    def get_completer_info(self, prefix=""):
-        """Return list of [name, type, doc]"""
+    def get_completer_info(self, prefix="") -> List[List[str]]:
+        """Get completer info of all children.
+
+        Returns
+        -------
+        List[List[str]]
+            Name, type and docstring of all children.
+        """
         ret = []
         for child_name in self.child_names:
             if child_name.startswith(prefix):
@@ -888,8 +894,14 @@ class Action(Base):
             raise RuntimeError(f"{self.__class__.__name__} is not active")
         return attrs["arguments"] if attrs else None
 
-    def get_completer_info(self, prefix="", excluded=None):
-        """Return list of [name, type, doc]"""
+    def get_completer_info(self, prefix="", excluded=None) -> List[List[str]]:
+        """Get completer info of all arguments.
+
+        Returns
+        -------
+        List[List[str]]
+            Name, type and docstring of all arguments.
+        """
         excluded = excluded or []
         ret = []
         for argument_name in self.argument_names:

--- a/src/ansys/fluent/core/solver/function/reduction.py
+++ b/src/ansys/fluent/core/solver/function/reduction.py
@@ -26,6 +26,7 @@ ctxt : Any, optional
     object but any solver API object will suffice) to set
     the context of the call's execution. If the location
     objects are strings, then such a context is required
+
 Returns
 -------
 float or List[float]

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -77,8 +77,9 @@ class Task(PyCallableStateObject):
     def ordered_children(self) -> list:
         """Get the ordered task list held by this task. Sorting is in terms
         of the workflow order and only includes this task's top-level tasks, while other tasks
-        can be obtained by calling ordered_children() on a parent task. Given the
-        workflow::
+        can be obtained by calling ordered_children() on a parent task.
+
+        Given the workflow::
 
             Workflow
             ├── A
@@ -286,8 +287,9 @@ class WorkflowWrapper:
     def ordered_children(self) -> list:
         """Get the ordered task list held by the workflow. Sorting is in terms
         of the workflow order and only includes the top-level tasks, while other tasks
-        can be obtained by calling ordered_children() on a parent task. Given the
-        workflow::
+        can be obtained by calling ordered_children() on a parent task.
+
+        Given the workflow::
 
             Workflow
             ├── A

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -54,7 +54,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        upstreams : list
+        list
             Upstream task list.
         """
         return self._tasks_with_matching_attributes(
@@ -67,7 +67,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        downstreams : list
+        list
             Downstream task list.
         """
         return self._tasks_with_matching_attributes(
@@ -92,7 +92,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        children : list
+        list
             Ordered children.
         """
         return [
@@ -105,7 +105,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        children : list
+        list
             Inactive ordered children.
         """
         return [
@@ -119,7 +119,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        identifier : str
+        str
             The string identifier.
         """
         workflow_state = self._command_source._workflow_state()
@@ -136,7 +136,7 @@ class Task(PyCallableStateObject):
 
         Returns
         -------
-        index : int
+        int
             The integer index.
         """
         return int(self.get_id()[len("TaskObject") :])
@@ -269,7 +269,7 @@ class WorkflowWrapper:
 
         Returns
         -------
-        task : Task
+        Task
             wrapped task object.
         """
         return Task(self, name)


### PR DESCRIPTION
1. Fixing most of the
`SS02: Summary does not start with a capital letter`
`SS03: Summary does not end with a period`
`RT02: The first line of the Returns section should contain only the type, unless multiple values are being returned`
`GL07: Sections are in the wrong order`.
Among the remaining ones, most are due to missing docstrings:
175 `GL08: The object does not have a docstring` warnings and 24 `SS01: No summary found` warnings

2. Fix warnings due to duplicate indices like `pyfluent\src\ansys\fluent\core\services\field_data.py:docstring of ansys.fluent.core.services.field_data.FieldData:1: WARNING: duplicate object description of ansys.fluent.core.services.field_data.FieldData, other instance in api/general/services/field_data, use :noindex: for one of them`