### PR TITLE
Fix warnings due to duplicate indices in TUI and datamodel doc

### DIFF
--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -5,6 +5,10 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
   DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0

--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -73,11 +73,11 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
-      - name: "Deploy development documentation"
-        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
-        uses: ansys/actions/doc-deploy-dev@v4
-        with:
-            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-            decompress-artifact: true
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
+      #- name: "Deploy development documentation"
+      #  if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
+      #  uses: ansys/actions/doc-deploy-dev@v4
+      #  with:
+      #      doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+      #      decompress-artifact: true
+      #      cname: ${{ env.DOCUMENTATION_CNAME }}
+      #      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -5,10 +5,6 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
   DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
@@ -77,11 +73,11 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
-      #- name: "Deploy development documentation"
-      #  if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
-      #  uses: ansys/actions/doc-deploy-dev@v4
-      #  with:
-      #      doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-      #      decompress-artifact: true
-      #      cname: ${{ env.DOCUMENTATION_CNAME }}
-      #      token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Deploy development documentation"
+        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
+        uses: ansys/actions/doc-deploy-dev@v4
+        with:
+            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+            decompress-artifact: true
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-tag: [v22.2.0, v23.1.0, v23.2.0, v24.1.0]
+        image-tag: [v23.1.0, v23.2.0, v24.1.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -63,14 +63,14 @@ jobs:
         run: |
           sudo apt install zip -y
           pushd doc/_build/html
-          zip -r ../../../HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip .
+          zip -r ../../../HTML-Documentation-tag-${{ matrix.image-tag }}.zip .
           popd
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
-          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
+          name: HTML-Documentation-tag-${{ matrix.image-tag }}
+          path: HTML-Documentation-tag-${{ matrix.image-tag }}.zip
           retention-days: 7
 
       #- name: "Deploy development documentation"

--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -67,14 +67,14 @@ jobs:
         run: |
           sudo apt install zip -y
           pushd doc/_build/html
-          zip -r ../../../HTML-Documentation-tag-${{ matrix.image-tag }}.zip .
+          zip -r ../../../HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip .
           popd
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
-          name: HTML-Documentation-tag-${{ matrix.image-tag }}
-          path: HTML-Documentation-tag-${{ matrix.image-tag }}.zip
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
       #- name: "Deploy development documentation"

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -280,7 +280,7 @@ class DataModelGenerator:
             f.write(f"{indent}        pass\n\n")
 
     def _write_doc_for_model_object(
-        self, info, doc_dir: Path, heading, module_name, class_name
+        self, info, doc_dir: Path, heading, module_name, class_name, noindex=True
     ) -> None:
         doc_dir.mkdir(exist_ok=True)
         index_file = doc_dir / "index.rst"
@@ -301,7 +301,7 @@ class DataModelGenerator:
             commands = sorted(info.commands)
 
             f.write(f".. autoclass:: {module_name}.{class_name}\n")
-            if class_name != "Root":
+            if noindex:
                 f.write("   :noindex:\n")
             f.write("   :members:\n")
             f.write("   :show-inheritance:\n")
@@ -391,6 +391,7 @@ class DataModelGenerator:
                             heading=f"{first_heading}.datamodel.{name}",
                             module_name=f"ansys.fluent.core.datamodel_{self.version}.{name}",
                             class_name="Root",
+                            noindex=info.rules == "preferences" and mode != "solver",
                         )
 
     def _delete_generated_files(self):

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -301,6 +301,8 @@ class DataModelGenerator:
             commands = sorted(info.commands)
 
             f.write(f".. autoclass:: {module_name}.{class_name}\n")
+            if class_name != "Root":
+                f.write("   :noindex:\n")
             f.write("   :members:\n")
             f.write("   :show-inheritance:\n")
             f.write("   :undoc-members:\n")

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -391,7 +391,7 @@ class DataModelGenerator:
                             heading=f"{first_heading}.datamodel.{name}",
                             module_name=f"ansys.fluent.core.datamodel_{self.version}.{name}",
                             class_name="Root",
-                            noindex=info.rules == "preferences" and mode != "solver",
+                            noindex=len(info.modes) > 1 and mode != "solver",
                         )
 
     def _delete_generated_files(self):

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -276,6 +276,8 @@ class TUIGenerator:
             ]
 
             f.write(f".. autoclass:: {self._tui_module}.{class_name}\n")
+            if class_name != "main_menu":
+                f.write("   :noindex:\n")
             f.write("   :members:\n")
             f.write("   :show-inheritance:\n")
             f.write("   :undoc-members:\n")

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -253,7 +253,9 @@ class TUIGenerator:
             if not v.is_command:
                 self._write_menu_to_tui_file(v, indent)
 
-    def _write_doc_for_menu(self, menu, doc_dir: Path, heading, class_name) -> None:
+    def _write_doc_for_menu(
+        self, menu, doc_dir: Path, heading, class_name, noindex=True
+    ) -> None:
         doc_dir.mkdir(exist_ok=True)
         index_file = doc_dir / "index.rst"
         with open(index_file, "w", encoding="utf8") as f:
@@ -276,7 +278,7 @@ class TUIGenerator:
             ]
 
             f.write(f".. autoclass:: {self._tui_module}.{class_name}\n")
-            if class_name != "main_menu":
+            if noindex:
                 f.write("   :noindex:\n")
             f.write("   :members:\n")
             f.write("   :show-inheritance:\n")
@@ -335,6 +337,7 @@ class TUIGenerator:
                 Path(self._tui_doc_dir),
                 self._tui_heading,
                 self._main_menu.name,
+                False,
             )
 
 


### PR DESCRIPTION
[Current list of warnings](https://github.com/ansys/pyfluent/actions/runs/5351692657/jobs/9705814458) in the full documentation build with these changes - mostly the missing docstrings in PyFluent source.

There are some already existing issues related to the indices, I'll try to address them in #1710 