### PR TITLE
fix rpvars doc

### DIFF
--- a/doc/source/api/general/rpvars.rst
+++ b/doc/source/api/general/rpvars.rst
@@ -3,11 +3,8 @@
 rpvars
 ======
 
-.. currentmodule:: ansys.fluent.core
-
-.. autosummary::
-    :toctree: _autosummary
-    :template: flobject-module-template.rst
-    :recursive:
-
-    rpvars
+.. automodule:: ansys.fluent.core.rpvars
+   :members:
+   :show-inheritance:
+   :special-members: __call__
+   :autosummary:

--- a/doc/source/api/general/rpvars.rst
+++ b/doc/source/api/general/rpvars.rst
@@ -1,6 +1,6 @@
 .. _ref_rpvars:
 
-RPVars
+rpvars
 ======
 
 .. automodule:: ansys.fluent.core.rpvars

--- a/doc/source/api/general/rpvars.rst
+++ b/doc/source/api/general/rpvars.rst
@@ -1,6 +1,6 @@
 .. _ref_rpvars:
 
-rpvars
+RPVars
 ======
 
 .. automodule:: ansys.fluent.core.rpvars

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,6 +45,8 @@ if skip_examples:
 else:
     extensions.append("sphinx_gallery.gen_gallery")
 
+typehints_document_rtype = False
+
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/", None),

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -11,13 +11,7 @@ from ansys.fluent.core.solver.error_message import allowed_name_error_message
 
 
 class RPVars:
-    """Access to rpvars in a specific session.
-
-    Methods
-    -------
-    __call__(var, val)
-        Set or get a specific rpvar or get the full rpvar state.
-    """
+    """Access to rpvars in a specific session."""
 
     _allowed_values = None
 
@@ -40,8 +34,24 @@ class RPVars:
         -------
         Any
             A dict containing the full rpvar state if all arguments are
-            unspecified, or the value of the rpvar if only var is specified,
-            or None if both arguments are specified.
+            unspecified, the value of the rpvar if only var is specified,
+            or a string with the var name if both arguments are specified.
+
+        Examples
+        --------
+        >>> import ansys.fluent.core as pyfluent
+        >>> solver = pyfluent.launch_fluent(mode="solver")
+        >>> iter_count = 100
+        >>> solver.rp_vars("number-of-iterations", iter_count)
+        'number-of-iterations'
+        >>> solver.rp_vars("number-of-iterations")
+        100
+
+        Getting dictionary with all rpvars available:
+
+        >>> solver.rp_vars()
+        {'sg-swirl?': False, 'rp-seg?': True, 'rf-energy?': False, 'rp-inviscid?': False, ...
+        'number-of-iterations': 100, ...}
         """
         return (
             self._set_var(var, val)
@@ -50,6 +60,14 @@ class RPVars:
         )
 
     def allowed_values(self) -> List[str]:
+        """
+        Returns list with the allowed rpvars names.
+
+        Returns
+        -------
+        List[str]
+            List with all allowed rpvars names.
+        """
         if not RPVars._allowed_values:
             RPVars._allowed_values = lispy.parse(
                 self._eval_fn("(cx-send '(map car rp-variables))")


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/1631 and https://github.com/ansys/pyfluent/issues/1714

Currently, in [API reference](https://fluent.docs.pyansys.com/version/stable/api/index.html), clicking on General -> `rpvars` takes us to [this almost empty page ](https://fluent.docs.pyansys.com/version/stable/api/general/rpvars.html), clicking on `rpvars` again takes us to [another almost empty page](https://fluent.docs.pyansys.com/version/stable/api/general/_autosummary/ansys.fluent.core.rpvars.html#module-ansys.fluent.core.rpvars), and clicking once again on `RPVars` finally takes us to the [documentation page](https://fluent.docs.pyansys.com/version/stable/api/general/_autosummary/ansys.fluent.core.rpvars.RPVars.html#ansys.fluent.core.rpvars.RPVars). 

Changed it so that the first click in API reference -> General -> `rpvars` takes the user directly to the documentation page, which now looks like this:
<details><summary> updated RPVars doc</summary>

![image](https://github.com/ansys/pyfluent/assets/132297401/95660968-3e79-4ba4-aac6-ed91cf79736a)
![image](https://github.com/ansys/pyfluent/assets/132297401/62e9bdf8-e6cc-4de8-9db7-b1a19d9465f7)
![image](https://github.com/ansys/pyfluent/assets/132297401/7d4a5938-124b-409e-8e5e-9404be4ee79d)

</details>


Also, for https://github.com/ansys/pyfluent/issues/1714, made it so basic `Return types` are no longer inferred automatically by the documentation, to avoid repeated `Return types` in addition to already specified `Returns`, keeping only the `Returns` field which is what we do actually document and have control over.

