### PR TITLE
Additional fixes for docs version v231

### DIFF
--- a/doc/source/api/general/quantity.rst
+++ b/doc/source/api/general/quantity.rst
@@ -54,7 +54,31 @@ Quantity
     >>> velocity_1 != velocity_3
     True
 
-.. automodule:: ansys.fluent.core.quantity
+.. automodule:: ansys.fluent.core.quantity.quantity
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :exclude-members: __weakref__, __dict__
+   :special-members: __init__
+   :autosummary:
+
+.. automodule:: ansys.fluent.core.quantity.dimensions
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :exclude-members: __weakref__, __dict__
+   :special-members: __init__
+   :autosummary:
+
+.. automodule:: ansys.fluent.core.quantity.quantity_map
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :exclude-members: __weakref__, __dict__
+   :special-members: __init__
+   :autosummary:
+
+.. automodule:: ansys.fluent.core.quantity.units_table
    :members:
    :show-inheritance:
    :undoc-members:

--- a/doc/source/api/meshing/index.rst
+++ b/doc/source/api/meshing/index.rst
@@ -3,7 +3,8 @@
 Meshing
 =======
 The ``meshing`` module allows you to use Fluent meshing capabilities from Python.
-Meshing workflows and meshing TUI commands are available.
+:ref:`Meshing workflows <ref_meshing_datamodel_workflow>` and :ref:`meshing TUI commands <ref_meshing_tui>`
+are available.
 
 Workflow example
 ----------------

--- a/doc/source/api/solver/index.rst
+++ b/doc/source/api/solver/index.rst
@@ -3,9 +3,10 @@
 Solver
 ======
 
-The ``solver`` module allows you to use Fluent solver capabilities from Python. You
-can use both :ref:`ref_solver_tui` commands and :ref:`ref_settings` to access Fluent
-events, monitoring, and field data (surface, scalar, and vector). 
+The :obj:`~ansys.fluent.core.session_solver.Solver` object allows you to use Fluent solver capabilities
+from Python. You can use both :ref:`TUI<ref_solver_tui>` commands
+and :ref:`settings objects <ref_settings>` to access Fluent events, monitoring,
+and field data (surface, scalar, and vector).
 
 .. currentmodule:: ansys.fluent.core.solver
 

--- a/doc/source/api/solver/settings.rst
+++ b/doc/source/api/solver/settings.rst
@@ -7,7 +7,8 @@ settings and issue commands to be executed in the Fluent solver.
 
 Accessing solver settings
 -------------------------
-An appropriate call to the ``launch_fluent`` function returns an object (named ``solver`` in
+An appropriate call to the :func:`~ansys.fluent.core.launcher.launcher.launch_fluent`
+function returns an object (named ``solver`` in
 the following code snippets) whose interface directly exposes the
 :ref:`root<settings_root_section>` of the solver settings hierarchy.
 
@@ -17,31 +18,43 @@ the following code snippets) whose interface directly exposes the
   >>> solver = pyfluent.launch_fluent(mode="solver")
 
 
-The ``solver`` object contains attributes such as ``file``, ``setup``, ``solution``, and
-``results``, which are also instances of settings objects. Note that the last three are
+The ``solver`` object contains attributes such as :obj:`~ansys.fluent.core.solver.settings_231.file.file`,
+:obj:`~ansys.fluent.core.solver.settings_231.setup.setup`,
+:obj:`~ansys.fluent.core.solver.settings_231.solution.solution`, and
+:obj:`~ansys.fluent.core.solver.settings_231.results.results`,
+which are also instances of settings objects. Note that the last three are
 top-level nodes in the outline tree view in Fluent's graphical user interface (GUI) --- much
 of this settings hierarchy has been designed in close alignment with this GUI hierarchy.
 
 Types of settings objects
 -------------------------
-A settings object can be one of the primitive types: ``Integer``, ``Real``,``String``, and
-``Boolean``. A settings object can also be one of the three types of container objects:
-``Group``, ``NamedObject``, and ``ListObject``.
+A settings object can be one of the primitive types: :obj:`~ansys.fluent.core.solver.flobject.Integer`,
+:obj:`~ansys.fluent.core.solver.flobject.Real`,
+:obj:`~ansys.fluent.core.solver.flobject.String`, and
+:obj:`~ansys.fluent.core.solver.flobject.Boolean`. A settings object can also be one of the three types
+of container objects: :obj:`~ansys.fluent.core.solver.flobject.Group`,
+:obj:`~ansys.fluent.core.solver.flobject.NamedObject`, and
+:obj:`~ansys.fluent.core.solver.flobject.ListObject`.
 
-- The ``Group`` type is a static container with predefined child objects that
-  can be accessed as attributes. For example, in ``setup.models.energy``
-  ``energy`` is a child of ``models``, which itself is a child of ``setup``, and each of those 
-  three objects is a ``Group``. The names of the child objects of a group can be accessed 
+- The :obj:`~ansys.fluent.core.solver.flobject.Group` type is a static container with predefined child objects that
+  can be accessed as attributes. For example, using the expression ``solver.setup.models.energy``,
+  which resolves to :obj:`~ansys.fluent.core.solver.settings_231.energy.energy`,
+  which is a child of :obj:`~ansys.fluent.core.solver.settings_231.models_1.models`,
+  which itself is a child of :obj:`~ansys.fluent.core.solver.settings_231.setup.setup`, and each of those
+  three objects is a ``Group``.
+  The names of the child objects of a group can be accessed
   via ``<Group>.child_names``.
 
-- The ``NamedObject`` type is a container holding dynamically created named objects. For
+- The :obj:`~ansys.fluent.core.solver.flobject.NamedObject` type is a container holding dynamically
+  created named objects. For
   a given ``NamedObject`` container, each contained object is of the same
   specific type. A given named object can be accessed using the index operator. For example,
   ``solver.setup.boundary_conditions.velocity_inlet['inlet2']`` yields a ``velocity_inlet``
   object with the name ``inlet2``, assuming it exists. The current list of named object
   children can be accessed via ``<NamedObject>.get_object_names()``.
 
-- The ``ListObject`` type is a container holding dynamically created unnamed objects of
+- The :obj:`~ansys.fluent.core.solver.flobject.ListObject` type is a container holding dynamically
+  created unnamed objects of
   its specified child type (accessible via a ``child_object_type`` attribute) in a
   list. Children of a ``ListObject`` object can be accessed using the index operator.
   For example, ``solver.setup.cell_zone_conditions.fluid['fluid-1'].source_terms['mass'][2]``
@@ -318,6 +331,5 @@ The following list summarizes common wildcards:
 
 Root object
 -----------
-The ``root`` object (named solver in the preceding examples) is the top-level
+The :obj:`~ansys.fluent.core.solver.settings_231.root.root` object (named solver in the preceding examples) is the top-level
 solver settings object. It contains all other settings objects in a hierarchical structure.
-For more information, see :ref:`root`.

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -100,11 +100,11 @@ class FluentConnectionProperties:
     inside_container: bool = None
 
     def list_names(self) -> list:
-        """List all property names."""
+        """Returns list with all property names."""
         return [k for k, _ in vars(self).items()]
 
     def list_values(self) -> dict:
-        """Dictionary with all property names and values."""
+        """Returns dictionary with all property names and values."""
         return vars(self)
 
 

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -260,7 +260,10 @@ def launch_remote_fluent(
 
     Returns
     -------
-    Union[Meshing, PureMeshing, Solver, SolverIcing]
+    :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
+    :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
+    :class:`~ansys.fluent.core.session_solver.Solver`, \
+    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`]
         Session object.
     """
     pim = pypim.connect()
@@ -575,7 +578,10 @@ def launch_fluent(
 
     Returns
     -------
-    Union[Meshing, PureMeshing, Solver, SolverIcing]
+    :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
+    :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
+    :class:`~ansys.fluent.core.session_solver.Solver`, \
+    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`]
         Session object.
 
     Notes

--- a/src/ansys/fluent/core/quantity/dimensions.py
+++ b/src/ansys/fluent/core/quantity/dimensions.py
@@ -49,7 +49,7 @@ class Dimensions(object):
 
         Returns
         -------
-        units : str
+        str
             Unit string representation of dimensions.
         """
         # Ensure dimensions list contains 9 terms
@@ -79,7 +79,7 @@ class Dimensions(object):
 
         Returns
         -------
-        dimensions : list
+        list
             Dimensions representation of unit string.
         """
 
@@ -113,10 +113,10 @@ class Dimensions(object):
 
     @property
     def units(self):
-        """Unit string representation of dimensions"""
+        """Unit string representation of dimensions."""
         return self._unit
 
     @property
     def dimensions(self):
-        """Dimensions list"""
+        """Dimensions list."""
         return self._dimensions

--- a/src/ansys/fluent/core/quantity/quantity.py
+++ b/src/ansys/fluent/core/quantity/quantity.py
@@ -102,7 +102,7 @@ class Quantity(float):
             Name of caller function.
         Returns
         -------
-        : str
+        str
             SI unit string of new quantity.
         """
         # Cannot perform operations between quantities with opposing dimensions
@@ -127,7 +127,7 @@ class Quantity(float):
 
     @property
     def value(self):
-        """Real value"""
+        """Real value."""
         return self._value
 
     @value.setter
@@ -136,22 +136,22 @@ class Quantity(float):
 
     @property
     def units(self):
-        """Unit string"""
+        """Unit string."""
         return self._unit
 
     @property
     def si_value(self):
-        """SI conversion value"""
+        """SI conversion value."""
         return self._si_value
 
     @property
     def si_units(self):
-        """SI conversion unit string"""
+        """SI conversion unit string."""
         return self._si_units
 
     @property
     def dimensions(self):
-        """Dimensions"""
+        """Dimensions."""
         return self._dimensions.dimensions
 
     @property
@@ -161,7 +161,7 @@ class Quantity(float):
 
     @property
     def type(self):
-        """Type"""
+        """Type."""
         return self._type
 
     def to(self, to_units: str) -> "Quantity":
@@ -174,7 +174,7 @@ class Quantity(float):
 
         Returns
         -------
-        : Quantity
+        Quantity
             Quantity object containing desired quantity conversion.
         """
 
@@ -202,7 +202,7 @@ class Quantity(float):
 
         Returns
         -------
-        : Quantity
+        Quantity
             Quantity object containing desired unit system conversion.
         """
 

--- a/src/ansys/fluent/core/quantity/quantity_map.py
+++ b/src/ansys/fluent/core/quantity/quantity_map.py
@@ -28,7 +28,7 @@ class QuantityMap(object):
 
         Returns
         -------
-        : str
+        str
             Unit string representation of quantity map.
         """
         unit_dict = {
@@ -54,5 +54,5 @@ class QuantityMap(object):
 
     @property
     def units(self):
-        """Unit string representation of quantity map"""
+        """Unit string representation of quantity map."""
         return self._unit

--- a/src/ansys/fluent/core/quantity/units_table.py
+++ b/src/ansys/fluent/core/quantity/units_table.py
@@ -48,7 +48,7 @@ class UnitsTable(object):
 
         Returns
         -------
-        : bool
+        bool
             Boolean of multiplier within unit_term.
         """
         # Check if the unit term is not an existing fundamental or derived unit.
@@ -112,7 +112,7 @@ class UnitsTable(object):
 
         Returns
         -------
-        : tuple
+        tuple
             Tuple containing multiplier, base, and power of the unit term.
         """
         multiplier = ""
@@ -161,7 +161,7 @@ class UnitsTable(object):
 
         Returns
         -------
-        : tuple
+        tuple
             Tuple containing si_unitsing, si_multiplier and si_offset.
         """
 
@@ -226,7 +226,7 @@ class UnitsTable(object):
 
         Returns
         -------
-        unitsing : str
+        str
             Simplified unit string.
         """
         terms_and_powers = {}
@@ -261,7 +261,7 @@ class UnitsTable(object):
 
         Returns
         -------
-        : str
+        str
             Type of quantity.
         """
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -10,10 +10,10 @@ Calling an object will return its current value.
 
 Example
 -------
-r = flobject.get_root(proxy)
-is_energy_on = r.setup.models.energy.enabled()
-r.setup.models.energy.enabled = True
-r.boundary_conditions.velocity_inlet['inlet'].vmag.constant = 20
+>>> r = flobject.get_root(proxy)
+>>> is_energy_on = r.setup.models.energy.enabled()
+>>> r.setup.models.energy.enabled = True
+>>> r.boundary_conditions.velocity_inlet['inlet'].vmag.constant = 20
 """
 import collections
 import fnmatch


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/1634, also related to https://github.com/ansys/pyfluent/issues/1690

`doc\source\api\solver\settings.rst` has new links specific for `settings_231` files, which will need to be manually (unless we automate this) updated for `settings_232` once we update the doc deployment version in the GitHub workflows.