### PR TITLE
Bump version 0.16.dev2

### DIFF
--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 16, "dev1"
+version_info = 0, 16, "dev2"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Creating a dev release to include 23.2 API files in the package, will be followed by a public release.