### PR TITLE
test_does_not_exit_fluent_by_default_when_connected_to_running_fluent

### DIFF
--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -124,12 +124,13 @@ def test_server_does_not_exit_when_session_goes_out_of_scope() -> None:
 def test_does_not_exit_fluent_by_default_when_connected_to_running_fluent(
     monkeypatch,
 ) -> None:
-    session1 = pyfluent.launch_fluent(cleanup_on_exit=False)
+    session1 = pyfluent.launch_fluent()
     session2 = pyfluent.connect_to_fluent(
         ip=session1.connection_properties.ip,
         port=session1.connection_properties.port,
         password=session1.connection_properties.password,
     )
+    assert session2.health_check_service.is_serving
     session2.exit()
 
     timeout_loop(


### PR DESCRIPTION
Fixing logic in `test_does_not_exit_fluent_by_default_when_connected_to_running_fluent`. 

When running without `PYFLUENT_TIMEOUT_FORCE_EXIT`, this test was leaving Fluent zombies every single run, due to a small logic error: `cleanup_on_exit=False` is the opposite of what we want on `session1` (and also disables the Watchdog for that run, guaranteeing zombies). 

With this change, the test is also closer to its stated intent: testing the *default* behavior of both `launch_fluent` (which is `cleanup_on_exit=True`) as well as `connect_to_fluent` (which is `cleanup_on_exit=False`)