### PR TITLE
Remove redundant 'get_fluent_version()'

### DIFF
--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -30,10 +30,6 @@ class SolverIcing(Solver):
         self._version = None
         self._fluent_connection = fluent_connection
 
-    def get_fluent_version(self):
-        """Gets and returns the fluent version."""
-        return self.get_fluent_version()
-
     @property
     def version(self):
         """Fluent's product version."""


### PR DESCRIPTION
get_fluent_version() can be accessed from 'Solver'

Thank You @seanpearsonuk, for mentioning the specific commit that was causing this issue :).