### PR TITLE
fix help

### DIFF
--- a/src/ansys/fluent/core/utils/fldoc.py
+++ b/src/ansys/fluent/core/utils/fldoc.py
@@ -10,7 +10,7 @@ def docother(self, object, name=None, mod=None, parent=None, maxlen=None, doc=No
         rep = pprint.pformat(object, width=maxlen, compact=True, indent=indent_len)
         rep = "[" + rep[1:].lstrip()
     else:
-        rep = self.rep(object)
+        rep = self.repr(object)
         if maxlen:
             line = (name and name + " = " or "") + rep
             chop = maxlen - len(line)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -322,4 +322,4 @@ def test_read_case_using_lightweight_mode():
 
 
 def test_help_does_not_throw(new_solver_session):
-    help(new_solver_session.file.read_case)
+    help(new_solver_session.file.read)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -319,3 +319,7 @@ def test_read_case_using_lightweight_mode():
     time.sleep(5)
     assert solver.setup.models.energy.enabled() == False
     solver.exit()
+
+
+def test_help_does_not_throw(new_solver_session):
+    help(new_solver_session.file.read_case)


### PR DESCRIPTION
recent sonar clean-up; multiple replacement of `repr` (due to shadowing) accidentally went too far.

Without the change, we raise and unhandled exception:

```
>>> import ansys.fluent.core as pf
>>> s = pf.launch_fluent(start_transcript=False)
>>> help(s.file.read_case)
Help on read_case in module ansys.fluent.core.solver.flobject object:

class read_case(Command)
 |  read_case(name: str = None, parent=None)
 |
 |  'read_case' command.
 |
 |  Parameters
 |  ----------
 |      file_name : str
 |          'file_name' child.
 |      pdf_file_name : str
 |          'pdf_file_name' child.

```