### PR TITLE
Reworking gRPC and TUI debug logging

### DIFF
--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -260,9 +260,6 @@ def configure_container_dict(
         auto_remove=True,
     )
 
-    if fluent_image.split(":")[1] == "v24.1.0":
-        container_dict_default.update(tty=True)
-
     for k, v in container_dict_default.items():
         if k not in container_dict:
             container_dict[k] = v

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -267,8 +267,6 @@ def configure_container_dict(
         if k not in container_dict:
             container_dict[k] = v
 
-    logger.debug(f"container_dict after processing: {container_dict}")
-
     host_server_info_file = Path(host_mount_path) / container_server_info_file.name
 
     return (

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -192,7 +192,8 @@ class PyMenu:
         if self._path.startswith("/query/"):
             return self._execute_query(request)
         else:
-            logger.debug(f"TUI Command: {request}")
+            request_str = " ".join(str(request).split())
+            logger.debug(f"TUI Command: {request_str}")
             return self._execute_command(request)
 
     def get_doc_string(self, include_unavailable: bool = False) -> str:

--- a/src/ansys/fluent/core/services/interceptors.py
+++ b/src/ansys/fluent/core/services/interceptors.py
@@ -10,7 +10,7 @@ import grpc
 from ansys.fluent.core.services.batch_ops import BatchOps
 
 network_logger = logging.getLogger("pyfluent.networking")
-log_bytes_limit = int(int(os.getenv("PYFLUENT_GRPC_LOG_BYTES_LIMIT", 1000)))
+log_bytes_limit = int(os.getenv("PYFLUENT_GRPC_LOG_BYTES_LIMIT", 1000))
 
 
 class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):

--- a/src/ansys/fluent/core/services/interceptors.py
+++ b/src/ansys/fluent/core/services/interceptors.py
@@ -10,7 +10,7 @@ import grpc
 from ansys.fluent.core.services.batch_ops import BatchOps
 
 network_logger = logging.getLogger("pyfluent.networking")
-log_bytes_limit = int(os.getenv("PYFLUENT_GRPC_LOG_BYTES_LIMIT", 1000))
+log_bytes_limit = int(int(os.getenv("PYFLUENT_GRPC_LOG_BYTES_LIMIT", 1000)))
 
 
 class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):
@@ -32,7 +32,7 @@ class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):
         response = continuation(client_call_details, request)
         if not response.exception():
             response_bytes = response.result().ByteSize()
-            if log_bytes_limit and response_bytes < log_bytes_limit:
+            if not log_bytes_limit or response_bytes < log_bytes_limit:
                 network_logger.debug(
                     f"GRPC_TRACE: response = {MessageToDict(response.result())}"
                 )

--- a/src/ansys/fluent/core/services/interceptors.py
+++ b/src/ansys/fluent/core/services/interceptors.py
@@ -1,7 +1,7 @@
 """Interceptor classes to use with gRPC services."""
 
 import logging
-import sys
+import os
 from typing import Any
 
 from google.protobuf.json_format import MessageToDict
@@ -10,7 +10,7 @@ import grpc
 from ansys.fluent.core.services.batch_ops import BatchOps
 
 network_logger = logging.getLogger("pyfluent.networking")
-log_bytes_limit = 1000
+log_bytes_limit = int(os.getenv("PYFLUENT_GRPC_LOG_BYTES_LIMIT", 1000))
 
 
 class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):
@@ -31,14 +31,15 @@ class TracingInterceptor(grpc.UnaryUnaryClientInterceptor):
         )
         response = continuation(client_call_details, request)
         if not response.exception():
-            response_str = str(MessageToDict(response.result()))
-            response_bytes = sys.getsizeof(response_str)
-            if response_bytes < log_bytes_limit:
-                network_logger.debug(f"GRPC_TRACE: response = {response_str}")
+            response_bytes = response.result().ByteSize()
+            if log_bytes_limit and response_bytes < log_bytes_limit:
+                network_logger.debug(
+                    f"GRPC_TRACE: response = {MessageToDict(response.result())}"
+                )
             else:
                 network_logger.debug(
                     f"GRPC_TRACE: response hidden, {response_bytes} bytes > "
-                    f"{log_bytes_limit} bytes limit."
+                    f"{log_bytes_limit} bytes limit. To see the response, set PYFLUENT_GRPC_LOG_BYTES_LIMIT to 0."
                 )
         return response
 


### PR DESCRIPTION
Minor suggestion to have debug logs that are much easier to work with, and not overwhelmed by gRPC calls that pass millions of characters or with multiple line breaks each time. Partially addresses https://github.com/ansys/pyfluent/issues/1800 from the logging point of view (but I don't know if passing such gigantic gRPC calls so often is intentional or desired). 


<details><summary> Before </summary>

![image](https://github.com/ansys/pyfluent/assets/132297401/7acf2bc9-360c-4068-b0b0-2730c42f5a40)

Fluent root settings API call
```
2023-07-19 16:39:20,210 pyfluent.networking   DEBUG    GRPC_TRACE: rpc = /ansys.api.fluent.v0.settings.Settings/GetStaticInfo, request = {'root': 'fluent'}
2023-07-19 16:39:22,301 pyfluent.networking   DEBUG    GRPC_TRACE: response = {'info': ... <2.2 MILLION CHARACTERS> ... }
```

TUI call
```
2023-07-19 16:39:10,286 pyfluent.tui          DEBUG    TUI Command: path: "/file/read_case"
args {
  fields {
    key: "tui_args"
    value {
      list_value {
        values {
          string_value: "ablation.msh.h5"
        }
      }
    }
  }
}

2023-07-19 16:39:10,287 pyfluent.networking   DEBUG    GRPC_TRACE: rpc = /ansys.api.fluent.v0.DataModel/ExecuteCommand, request = {'path': '/file/read_case', 'args': {'tui_args': ['ablation.msh.h5']}}
2023-07-19 16:39:20,164 pyfluent.networking   DEBUG    GRPC_TRACE: response = {}

```

</details>

<details><summary> After </summary>

![image](https://github.com/ansys/pyfluent/assets/132297401/26d07e1c-125d-4f1c-ba6c-3057d2afdc03)

Fluent root settings API call
```
2023-07-20 12:34:31,332 pyfluent.networking   DEBUG    GRPC_TRACE: rpc = /ansys.api.fluent.v0.settings.Settings/GetStaticInfo, request = {'root': 'fluent'}
2023-07-20 12:34:32,882 pyfluent.networking   DEBUG    GRPC_TRACE: response hidden, 2221700 bytes > 1000 bytes limit.

```

TUI call
```
2023-07-20 12:34:21,939 pyfluent.tui          DEBUG    TUI Command: path: "/file/read_case" args { fields { key: "tui_args" value { list_value { values { string_value: "ablation.msh.h5" } } } } }
2023-07-20 12:34:21,941 pyfluent.networking   DEBUG    GRPC_TRACE: rpc = /ansys.api.fluent.v0.DataModel/ExecuteCommand, request = {'path': '/file/read_case', 'args': {'tui_args': ['ablation.msh.h5']}}
2023-07-20 12:34:31,304 pyfluent.networking   DEBUG    GRPC_TRACE: response = {}
```

</details>