### PR TITLE
feat: pyfluent-examples doc link

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,6 +6,8 @@ Examples
 End-to-end examples show how you can use PyFluent. If the PyFluent ``ansys-fluent-core`` package is installed on your machine,
 you can download these examples as Python files or Jupyter notebooks and run them locally.
 
+The full collection of PyFluent examples can be found at `pyfluent-examples <https://github.com/ansys/pyfluent-examples>`_.
+
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,7 +6,7 @@ Examples
 End-to-end examples show how you can use PyFluent. If the PyFluent ``ansys-fluent-core`` package is installed on your machine,
 you can download these examples as Python files or Jupyter notebooks and run them locally.
 
-The full collection of PyFluent examples can be found at `pyfluent-examples <https://github.com/ansys/pyfluent-examples>`_.
+A collection of PyFluent examples can be found at `pyfluent-examples <https://github.com/ansys/pyfluent-examples>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Changes
---------
Closes #1788 
- Adds link to [pyfluent-examples](https://github.com/ansys/pyfluent-examples) repo within pyfluent docs. 