### PR TITLE
Re-enabling test_transcript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ unittest-custom:
 	@echo "Running custom unittest"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest -v -k test_parametric_workflow  # Update custom testlist
+	@python -m pytest -v --no-cov --capture=no -k test_transcript  # Update custom testlist
 
 unittest-dev-222:
 	@echo "Running unittests"

--- a/tests/test_streaming_services.py
+++ b/tests/test_streaming_services.py
@@ -1,6 +1,5 @@
 import time
 
-import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 from ansys.fluent.core import connect_to_fluent
@@ -34,7 +33,6 @@ def run_transcript(i, ip, port, password):
     return transcript_checked, transcript_passed
 
 
-@pytest.mark.skip("Skipping for now while investigating Fluent v241, see #1802")
 def test_transcript(new_solver_session):
     solver = new_solver_session
     ip = solver.connection_properties.ip


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/1802, will test a few times to see if it is now stable with recent changes and `tty=False`

Run 1: https://github.com/ansys/pyfluent/actions/runs/5622916297/job/15236570566 - passed
Run 2: https://github.com/ansys/pyfluent/actions/runs/5623577620/ - passed
Run 3 Custom: https://github.com/ansys/pyfluent/actions/runs/5623587862 - passed
Run 4 Custom:  https://github.com/ansys/pyfluent/actions/runs/5623868338 - passed
Run 5 Custom: https://github.com/ansys/pyfluent/actions/runs/5624340868 - passed