### PR TITLE
PyFluent Example File Path

### DIFF
--- a/src/ansys/fluent/core/examples/__init__.py
+++ b/src/ansys/fluent/core/examples/__init__.py
@@ -1,1 +1,2 @@
 from .downloads import download_file  # noqa: F401
+from .downloads import path  # noqa: F401

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -1,5 +1,6 @@
 """Functions to download sample datasets from the Ansys example data repository."""
 import os
+from pathlib import Path
 import re
 import shutil
 from typing import Optional
@@ -131,3 +132,11 @@ def download_file(
 
     url = _get_file_url(filename, directory)
     return _retrieve_file(url, filename, save_path, return_only_filename)
+
+
+def path(filename: str):
+    file_path = str(Path(pyfluent.EXAMPLES_PATH) / filename)
+    if os.path.isfile(file_path):
+        return file_path
+    else:
+        raise FileNotFoundError(f"{filename} does not exist.")

--- a/tests/integration/test_optislang/test_optislang_integration.py
+++ b/tests/integration/test_optislang/test_optislang_integration.py
@@ -6,6 +6,7 @@ import pytest
 from util.meshing_workflow import mixing_elbow_geometry  # noqa: F401
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core import examples
 
 
 @pytest.mark.nightly
@@ -34,7 +35,7 @@ def test_simple_solve(load_mixing_elbow_param_case_dat):
     # Step 2: Launch fluent session and read case file with and without data file
     solver_session = load_mixing_elbow_param_case_dat
     assert solver_session.health_check_service.is_serving
-    case_path = str(Path(pyfluent.EXAMPLES_PATH) / "elbow_param.cas.h5")
+    case_path = examples.path("elbow_param.cas.h5")
     solver_session.tui.file.read_case_data(case_path)
 
     # Step 3: Get input and output parameters and create a dictionary

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -1,10 +1,7 @@
-from pathlib import Path
-
 import pytest
 from util.solver_workflow import new_solver_session_no_transcript  # noqa: F401
 
-import ansys.fluent.core as pyfluent
-from ansys.fluent.core.examples import download_file
+from ansys.fluent.core.examples import download_file, path
 from ansys.fluent.core.filereader.casereader import CaseReader
 
 
@@ -47,7 +44,7 @@ def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     assert len(all_vars) == pytest.approx(9000, 20)
 
     # CaseFile comparison, note that the PyFluent work dir is not necessarily the same as the Fluent work dir
-    case = CaseReader(case_filepath=str(Path(pyfluent.EXAMPLES_PATH) / case_path))
+    case = CaseReader(case_filepath=path(case_path))
     case_vars = case.rp_vars()
     assert len(case_vars) == pytest.approx(9000, 450)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2,13 +2,14 @@ import pytest
 from util.meshing_workflow import new_mesh_session  # noqa: F401
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core import examples
 
 
 def test_base_session_upload(new_mesh_session):
     base_session = new_mesh_session
     with pytest.raises(AttributeError) as e_info:
         base_session._upload(
-            pyfluent.EXAMPLES_PATH + "/mixing_elbow.py", "test_upload_download.py"
+            examples.path("mixing_elbow.py"), "test_upload_download.py"
         )
     base_session.exit()
 
@@ -23,9 +24,7 @@ def test_base_session_download(new_mesh_session):
 def test_session_upload(new_mesh_session):
     session = new_mesh_session
     with pytest.raises(AttributeError) as e_info:
-        session._upload(
-            pyfluent.EXAMPLES_PATH + "/mixing_elbow.py", "test_upload_download.py"
-        )
+        session._upload(examples.path("mixing_elbow.py"), "test_upload_download.py")
     session.exit()
 
 


### PR DESCRIPTION
Added `path` function to check existence of valid file name.

```
>>> import ansys.fluent.core as pyfluent                                                  
>>> from ansys.fluent.core import examples
>>> filepath = examples.path("elbow_param.cas.h5")
Traceback (most recent call last):                                                       
  File "<stdin>", line 1, in <module>                                                    
  File "D:\Repos\pyfluent\src\ansys\fluent\core\examples\downloads.py", line 141, in path
    raise FileNotFoundError(f"{filename} does not exist.")                               
FileNotFoundError: elbow_param.cas.h5 does not exist.                                    
>>> case_filename = examples.download_file("elbow_param.cas.h5", "pyfluent/mixing_elbow")
Checking if specified file already exists...      
File does not exist. Downloading specified file...
Download successful. File path:                                                    
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\elbow_param.cas.h5
>>> filepath = examples.path("elbow_param.cas.h5")
>>> filepath
'C:\\Users\\<user_name>\\AppData\\Local\\Ansys\\ansys_fluent_core\\examples\\elbow_param.cas.h5'
>>>
```