### PR TITLE
Move the Fluent API tests to run with 24.1 Fluent version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ addopts = """
 --cov-report=html
 --durations=0
 --show-capture=all
---ignore-glob=tests/test_pro/*
---ignore-glob=tests/test_datamodel_server/*
 """
 markers = [
     "integration: Short-running tests which read a simple input file and check the exposure and values of various setting objects",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 import pytest
 
+from ansys.fluent.core.launcher.launcher import FluentVersion
+
+_fluent_dev_version = next(iter(FluentVersion))
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -16,9 +20,12 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-    version_specs = [
-        SpecifierSet(mark.args[0]) for mark in item.iter_markers(name="fluent_version")
-    ]
+    version_specs = []
+    for mark in item.iter_markers(name="fluent_version"):
+        spec = mark.args[0]
+        if spec == "dev":
+            spec = f"=={_fluent_dev_version}"
+        version_specs.append(SpecifierSet(spec))
     if version_specs:
         combined_spec = functools.reduce(operator.and_, version_specs)
         version = item.config.getoption("--fluent-version")

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -10,7 +10,7 @@ from ansys.fluent.core.launcher.fluent_container import DEFAULT_CONTAINER_MOUNT_
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 def test_parametric_workflow():
     # parent path needs to exist for mkdtemp
     Path(pyfluent.EXAMPLES_PATH).mkdir(parents=True, exist_ok=True)

--- a/tests/test_meshingmode/test_meshing_launch.py
+++ b/tests/test_meshingmode/test_meshing_launch.py
@@ -6,7 +6,7 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.nightly
 @pytest.mark.mesh
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 @pytest.mark.codegen_required
 def test_launch_pure_meshing(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -9,7 +9,7 @@ from util.solver import assign_settings_value_from_value_dict as assign_dict_val
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=22.2")
+@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.codegen_required

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -9,7 +9,7 @@ from util.solver import assign_settings_value_from_value_dict as assign_dict_val
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.codegen_required
@@ -90,7 +90,7 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.integration
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 @pytest.mark.skip
 def test_boundaries_periodic(load_periodic_rot_cas):
     solver_session = load_periodic_rot_cas

--- a/tests/test_solvermode/test_calculationactivities.py
+++ b/tests/test_solvermode/test_calculationactivities.py
@@ -4,6 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.integration
 @pytest.mark.quick
+@pytest.mark.fluent_version("dev")
 def test_solver_calculation(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert (

--- a/tests/test_solvermode/test_controls.py
+++ b/tests/test_solvermode/test_controls.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 def test_controls(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_controls.py
+++ b/tests/test_solvermode/test_controls.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version(">=23.2")
 def test_controls(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -10,7 +10,7 @@ import ansys.fluent.core as pyfluent
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert solver_session._root.is_active()
@@ -83,7 +83,7 @@ def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_disk_2d_setup(load_disk_mesh):
     session = load_disk_mesh
     assert session._root.get_attr("active?")

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -5,7 +5,7 @@ from util.fixture_fluent import download_input_file
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 def test_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")
@@ -61,7 +61,7 @@ def test_initialize(launch_fluent_solver_3ddp_t2):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_fmg_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file(

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -5,7 +5,7 @@ from util.fixture_fluent import download_input_file
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version(">=23.2")
 def test_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")

--- a/tests/test_solvermode/test_materials.py
+++ b/tests/test_solvermode/test_materials.py
@@ -5,7 +5,7 @@ from util.solver import copy_database_material
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_solver_material(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     copy_database_material(

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 def test_methods(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version(">=23.2")
 def test_methods(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -5,7 +5,7 @@ import pytest
 @pytest.mark.integration
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("dev")
 def test_solver_models(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert not solver_session.setup.models.energy.enabled()
@@ -27,7 +27,7 @@ def test_solver_models(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_disk_2d_models(load_disk_mesh):
     solver_session = load_disk_mesh
     solver_session.setup.general.solver.two_dim_space = "axisymmetric"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -5,7 +5,7 @@ import pytest
 @pytest.mark.integration
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version(">=23.2")
 def test_solver_models(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert not solver_session.setup.models.energy.enabled()

--- a/tests/test_solvermode/test_named_expressions.py
+++ b/tests/test_solvermode/test_named_expressions.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("dev")
 def test_expression(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     solver_session.setup.models.energy.enabled = True

--- a/tests/test_solvermode/test_post_vector.py
+++ b/tests/test_solvermode/test_post_vector.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.nightly
 @pytest.mark.setup
+@pytest.mark.fluent_version("dev")
 def test_post_elbow(load_mixing_elbow_case_dat):
     pyflu = load_mixing_elbow_case_dat
     pyflu.results.graphics.vector["velocity_vector_symmetry"] = {}


### PR DESCRIPTION
This will fix 23.1 nightly failure - https://github.com/ansys/pyfluent/actions/runs/5676374753/job/15383014718#step:24:1229