### PR TITLE
Mark some tests to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: GitHub Actions
 
 on:
   pull_request:
+      paths-ignore:
+      - '.github/workflows/run-custom-tests.yml'
   workflow_dispatch:
   push:
     tags:

--- a/.github/workflows/run-custom-tests.yml
+++ b/.github/workflows/run-custom-tests.yml
@@ -2,7 +2,7 @@
 name: Run Custom Tests
 
 on:
-  pull_request:
+  #pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/run-custom-tests.yml
+++ b/.github/workflows/run-custom-tests.yml
@@ -2,7 +2,7 @@
 name: Run Custom Tests
 
 on:
-  #pull_request:
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -90,6 +90,10 @@ jobs:
           make install > /dev/null
 
       - name: Unit Testing
-        run: make unittest-custom
+        run: |
+            echo "Running custom unittest"
+            sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
+            pip install -r requirements/requirements_tests.txt
+            python -m pytest -v --no-cov --capture=no -k test_transcript
         env:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,6 @@ test-import:
 
 unittest: unittest-dev-232
 
-unittest-custom:
-	@echo "Running custom unittest"
-	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
-	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest -v --no-cov --capture=no -k test_transcript  # Update custom testlist
-
 unittest-dev-222:
 	@echo "Running unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples

--- a/Makefile
+++ b/Makefile
@@ -23,73 +23,73 @@ unittest-dev-222:
 	@echo "Running unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=22.2 -m "not nightly"
+	@python -m pytest --fluent-version=22.2
 
 unittest-dev-231:
 	@echo "Running unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.1 -m "not nightly"
+	@python -m pytest --fluent-version=23.1
 
 unittest-dev-232:
 	@echo "Running unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.2 -m "not nightly"
+	@python -m pytest --fluent-version=23.2
 
 unittest-dev-241:
 	@echo "Running unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=24.1 -m "not nightly"
+	@python -m pytest --fluent-version=24.1
 
 unittest-all-222:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=22.2
+	@python -m pytest --nightly --fluent-version=22.2
 
 unittest-all-222-no-codegen:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=22.2 -m "not codegen_required"
+	@python -m pytest --nightly --fluent-version=22.2 -m "not codegen_required"
 
 unittest-all-231:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.1
+	@python -m pytest --nightly --fluent-version=23.1
 
 unittest-all-231-no-codegen:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.1 -m "not codegen_required"
+	@python -m pytest --nightly --fluent-version=23.1 -m "not codegen_required"
 
 unittest-all-232:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.2
+	@python -m pytest --nightly --fluent-version=23.2
 
 unittest-all-232-no-codegen:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=23.2 -m "not codegen_required"
+	@python -m pytest --nightly --fluent-version=23.2 -m "not codegen_required"
 
 unittest-all-241:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=24.1
+	@python -m pytest --nightly --fluent-version=24.1
 
 unittest-all-241-no-codegen:
 	@echo "Running all unittests"
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest --fluent-version=24.1 -m "not codegen_required"
+	@python -m pytest --nightly --fluent-version=24.1 -m "not codegen_required"
 
 api-codegen:
 	@echo "Running API codegen"

--- a/tests/integration/test_optislang/test_optislang_integration.py
+++ b/tests/integration/test_optislang/test_optislang_integration.py
@@ -13,7 +13,7 @@ from ansys.fluent.core import examples
 @pytest.mark.optislang
 @pytest.mark.integration
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_simple_solve(load_mixing_elbow_param_case_dat):
     """Use case 1: This optiSLang integration test performs these steps.
 
@@ -106,7 +106,7 @@ def test_simple_solve(load_mixing_elbow_param_case_dat):
 @pytest.mark.optislang
 @pytest.mark.integration
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_generate_read_mesh(mixing_elbow_geometry):
     """Use case 2: This optiSLang integration test performs these steps.
 

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -10,7 +10,7 @@ from ansys.fluent.core.launcher.fluent_container import DEFAULT_CONTAINER_MOUNT_
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_parametric_workflow():
     # parent path needs to exist for mkdtemp
     Path(pyfluent.EXAMPLES_PATH).mkdir(parents=True, exist_ok=True)

--- a/tests/test_batch_ops.py
+++ b/tests/test_batch_ops.py
@@ -8,6 +8,7 @@ import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 @pytest.mark.skipif(
     os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1"
@@ -29,6 +30,7 @@ def test_batch_ops_create_mesh(new_solver_session):
     assert "mesh-1" in solver.results.graphics.mesh.get_object_names()
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_batch_ops_create_mesh_and_access_fails(new_solver_session):
     solver = new_solver_session

--- a/tests/test_creatable.py
+++ b/tests/test_creatable.py
@@ -2,6 +2,7 @@ import pytest
 from util.fixture_fluent import load_static_mixer_case  # noqa: F401
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_creatable(load_static_mixer_case) -> None:
     has_not = (

--- a/tests/test_creatable.py
+++ b/tests/test_creatable.py
@@ -2,8 +2,7 @@ import pytest
 from util.fixture_fluent import load_static_mixer_case  # noqa: F401
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("latest")
 def test_creatable(load_static_mixer_case) -> None:
     has_not = (
         load_static_mixer_case.setup.boundary_conditions.velocity_inlet,

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -653,6 +653,7 @@ class root(Group):
     )  # noqa: W293
 
 
+@pytest.mark.nightly
 def test_accessor_methods_on_settings_object(load_static_mixer_case):
     solver = load_static_mixer_case
 
@@ -700,6 +701,7 @@ def test_accessor_methods_on_settings_object(load_static_mixer_case):
     )
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_accessor_methods_on_settings_object_types(load_static_mixer_case):
     solver = load_static_mixer_case
@@ -751,6 +753,7 @@ def test_find_children_from_settings_root_231(load_static_mixer_case):
     }
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_find_children_from_settings_root_232(load_static_mixer_case):
@@ -776,6 +779,7 @@ def test_find_children_from_settings_root_232(load_static_mixer_case):
     }
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_find_children_from_fluent_solver_session(load_static_mixer_case):
     setup_children = find_children(load_static_mixer_case.setup)
@@ -816,6 +820,7 @@ def test_find_children_from_fluent_solver_session(load_static_mixer_case):
     }
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
@@ -846,6 +851,7 @@ def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     assert energy_parent == "\n energy is a child of models \n"
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
@@ -928,6 +934,7 @@ def get_child_nodes(node, nodes, type_list):
                     return
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_strings_with_allowed_values(load_static_mixer_case):
     solver = load_static_mixer_case

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -653,7 +653,7 @@ class root(Group):
     )  # noqa: W293
 
 
-@pytest.mark.nightly
+@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object(load_static_mixer_case):
     solver = load_static_mixer_case
 
@@ -701,8 +701,7 @@ def test_accessor_methods_on_settings_object(load_static_mixer_case):
     )
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object_types(load_static_mixer_case):
     solver = load_static_mixer_case
 
@@ -753,8 +752,7 @@ def test_find_children_from_settings_root_231(load_static_mixer_case):
     }
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("latest")
 @pytest.mark.codegen_required
 def test_find_children_from_settings_root_232(load_static_mixer_case):
     setup_cls = load_static_mixer_case.setup.__class__
@@ -779,8 +777,7 @@ def test_find_children_from_settings_root_232(load_static_mixer_case):
     }
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("latest")
 def test_find_children_from_fluent_solver_session(load_static_mixer_case):
     setup_children = find_children(load_static_mixer_case.setup)
 
@@ -820,8 +817,7 @@ def test_find_children_from_fluent_solver_session(load_static_mixer_case):
     }
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("latest")
 def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
 
@@ -851,8 +847,7 @@ def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     assert energy_parent == "\n energy is a child of models \n"
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     root = solver._root
@@ -934,8 +929,7 @@ def get_child_nodes(node, nodes, type_list):
                     return
 
 
-@pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version("latest")
 def test_strings_with_allowed_values(load_static_mixer_case):
     solver = load_static_mixer_case
 

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -4,6 +4,7 @@ from util.solver_workflow import new_solver_session  # noqa: F401
 from ansys.fluent.core import examples
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=24.1")
 def test_1364(new_solver_session):
     solver = new_solver_session

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -18,7 +18,7 @@ from ansys.fluent.core.utils.execution import timeout_loop
 
 def _read_case(session):
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
-    session.file.read(file_type="case", file_name=case_path)
+    session.tui.file.read_case(case_path)
 
 
 def test_session_starts_transcript_by_default(new_solver_session) -> None:

--- a/tests/test_fluent_version_marker.py
+++ b/tests/test_fluent_version_marker.py
@@ -5,6 +5,11 @@ def test_dev_fluent_any():
     pass
 
 
+@pytest.mark.fluent_version("latest")
+def test_dev_fluent_latest():
+    pass
+
+
 @pytest.mark.fluent_version(">=24.1")
 def test_dev_fluent_ge_241():
     pass
@@ -27,6 +32,12 @@ def test_dev_fluent_ge_222():
 
 @pytest.mark.nightly
 def test_nightly_fluent_any():
+    pass
+
+
+@pytest.mark.nightly
+@pytest.mark.fluent_version("latest")
+def test_nightly_fluent_latest():
     pass
 
 

--- a/tests/test_meshingmode/test_meshing_launch.py
+++ b/tests/test_meshingmode/test_meshing_launch.py
@@ -6,7 +6,7 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.nightly
 @pytest.mark.mesh
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 @pytest.mark.codegen_required
 def test_launch_pure_meshing(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -296,6 +296,7 @@ def _test_moment(solver):
     solver.setup.named_expressions.pop(key="test_expr_1")
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_reductions(load_static_mixer_case, load_static_mixer_case_2) -> None:
     solver1 = load_static_mixer_case

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -8,7 +8,7 @@ from ansys.fluent.core.filereader.casereader import CaseReader
 def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
     solver = new_solver_session_no_transcript
-    solver.file.read(file_type="case", file_name=case_path)
+    solver.tui.file.read_case(case_path)
     rp_vars = solver.rp_vars
 
     # simple integer
@@ -29,15 +29,15 @@ def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
 def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
     solver = new_solver_session_no_transcript
-    solver.file.read(file_type="case", file_name=case_path)
+    solver.tui.file.read_case(case_path)
     rp_vars = solver.rp_vars
     # all vars
     all_vars = rp_vars()
     assert len(all_vars) == pytest.approx(9000, 10)
 
     # refresh
-    solver.file.write(file_type="case", file_name=case_path)
-    solver.file.read(file_type="case", file_name=case_path)
+    solver.tui.file.write_case(file_type="case", file_name=case_path)
+    solver.tui.file.read_case(file_type="case", file_name=case_path)
 
     # all vars again
     all_vars = rp_vars()

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -36,7 +36,7 @@ def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     assert len(all_vars) == pytest.approx(9000, 10)
 
     # refresh
-    solver.tui.file.write_case(case_path)
+    solver.file.write(file_type="case", file_name=case_path)
     solver.tui.file.read_case(case_path)
 
     # all vars again

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -36,8 +36,8 @@ def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     assert len(all_vars) == pytest.approx(9000, 10)
 
     # refresh
-    solver.tui.file.write_case(file_type="case", file_name=case_path)
-    solver.tui.file.read_case(file_type="case", file_name=case_path)
+    solver.tui.file.write_case(case_path)
+    solver.tui.file.read_case(case_path)
 
     # all vars again
     all_vars = rp_vars()

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -4,6 +4,7 @@ from util.solver_workflow import new_solver_session  # noqa: F401
 from ansys.fluent.core.examples import download_file
 
 
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_setup_models_viscous_model_settings(new_solver_session) -> None:
     solver_session = new_solver_session

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -38,7 +38,7 @@ def test_results_graphics_mesh_settings(new_solver_session) -> None:
 
 
 @pytest.mark.skip("Fluent bug")
-@pytest.mark.nigthly
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_wildcard(new_solver_session):
     solver = new_solver_session
@@ -88,7 +88,7 @@ def test_wildcard(new_solver_session):
 
 
 @pytest.mark.skip("Fluent bug")
-@pytest.mark.nigthly
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_wildcard_fnmatch(new_solver_session):
     solver = new_solver_session
@@ -116,7 +116,7 @@ def test_wildcard_fnmatch(new_solver_session):
     )
 
 
-@pytest.mark.nigthly
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.2")
 def test_wildcard_path_is_iterable(new_solver_session):
     solver = new_solver_session

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -9,7 +9,7 @@ from util.solver import assign_settings_value_from_value_dict as assign_dict_val
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.codegen_required
@@ -90,7 +90,7 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.integration
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 @pytest.mark.skip
 def test_boundaries_periodic(load_periodic_rot_cas):
     solver_session = load_periodic_rot_cas

--- a/tests/test_solvermode/test_calculationactivities.py
+++ b/tests/test_solvermode/test_calculationactivities.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.integration
 @pytest.mark.quick
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_solver_calculation(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert (

--- a/tests/test_solvermode/test_controls.py
+++ b/tests/test_solvermode/test_controls.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_controls(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -10,7 +10,7 @@ import ansys.fluent.core as pyfluent
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert solver_session._root.is_active()
@@ -83,7 +83,7 @@ def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_disk_2d_setup(load_disk_mesh):
     session = load_disk_mesh
     assert session._root.get_attr("active?")

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -5,7 +5,7 @@ from util.fixture_fluent import download_input_file
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")
@@ -61,7 +61,7 @@ def test_initialize(launch_fluent_solver_3ddp_t2):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_fmg_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file(

--- a/tests/test_solvermode/test_materials.py
+++ b/tests/test_solvermode/test_materials.py
@@ -5,7 +5,7 @@ from util.solver import copy_database_material
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_solver_material(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     copy_database_material(

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_methods(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -5,7 +5,7 @@ import pytest
 @pytest.mark.integration
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_solver_models(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     assert not solver_session.setup.models.energy.enabled()
@@ -27,7 +27,7 @@ def test_solver_models(load_mixing_elbow_mesh):
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_disk_2d_models(load_disk_mesh):
     solver_session = load_disk_mesh
     solver_session.setup.general.solver.two_dim_space = "axisymmetric"

--- a/tests/test_solvermode/test_named_expressions.py
+++ b/tests/test_solvermode/test_named_expressions.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.nightly
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_expression(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     solver_session.setup.models.energy.enabled = True

--- a/tests/test_solvermode/test_post_vector.py
+++ b/tests/test_solvermode/test_post_vector.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.nightly
 @pytest.mark.setup
-@pytest.mark.fluent_version("dev")
+@pytest.mark.fluent_version("latest")
 def test_post_elbow(load_mixing_elbow_case_dat):
     pyflu = load_mixing_elbow_case_dat
     pyflu.results.graphics.vector["velocity_vector_symmetry"] = {}


### PR DESCRIPTION
I have identified some tests to move to nightly based on the fact that the client-side code covered by these tests is very minimal and stable (exercising settings API, flobject.py or stable APIs like the batch operation, reduction services). These are basically testing the server-side APIs.

Additional thoughts:
1. The tests for fielddata and svars services are also calling settings API. But as these services have been developed recently and contain some wrapper code on the client side, I haven't moved them to the nightly, but let me know whether we should move them too.
2. Another idea is to run the settings API tests with Fluent <=23.2 during PRs but run them with Fluent 24.1 nightly. But I think settings API tests with Fluent 23.2 won't be impacted by PyFluent changes except for changes in flobject.py. But we should consider flobject.py belonging to the Fluent package, so any changes in flobject.py should first be tested with Fluent's PyConsole which should cover the PyFluent behaviour in most scenarios. Edit: This is implemented now using the "latest" marker.
3. I think we need to run some tests with Fluent 24.1 which are testing 24.1 server-side changes for any PyFluent feature.

We are also considering running some of these "API tests" in PyFluent during the certification process of the Fluent docker image, so a new revision of the docker image won't break these tests. 