### PR TITLE
sort() to sorted()

### DIFF
--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -865,9 +865,7 @@ def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
 
     get_child_nodes(root, nodes, type_list)
 
-    assert type_list.sort() == expected_type_list.sort()
-
-    for type_data in type_list:
+    for type_data in expected_type_list:
         if type_data == "Boolean":
             assert {
                 "is_active",

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -108,7 +108,7 @@ def test_wildcard_fnmatch(new_solver_session):
 
     assert list(solver.results.graphics.mesh["mesh-[2-5]"]().keys()) == ["mesh-2"]
 
-    assert sorted(list(solver.results.graphics.mesh["mesh-[!2-5]"]().keys())) == sorted(
+    assert sorted(solver.results.graphics.mesh["mesh-[!2-5]"]()) == sorted(
         ["mesh-1", "mesh-a"]
     )
 

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -100,18 +100,16 @@ def test_wildcard_fnmatch(new_solver_session):
     solver.results.graphics.mesh.create("mesh-a")
     solver.results.graphics.mesh.create("mesh-bc")
 
-    assert (
-        list(solver.results.graphics.mesh["mesh-*"]().keys()).sort()
-        == ["mesh-1", "mesh-2", "mesh-a", "mesh-bc"].sort()
+    assert sorted(list(solver.results.graphics.mesh["mesh-*"]().keys())) == sorted(
+        ["mesh-1", "mesh-2", "mesh-a", "mesh-bc"]
     )
 
     assert list(solver.results.graphics.mesh["mesh-?c"]().keys()) == ["mesh-bc"]
 
     assert list(solver.results.graphics.mesh["mesh-[2-5]"]().keys()) == ["mesh-2"]
 
-    assert (
-        list(solver.results.graphics.mesh["mesh-[!2-5]"]().keys()).sort()
-        == ["mesh-1", "mesh-a"].sort()
+    assert sorted(list(solver.results.graphics.mesh["mesh-[!2-5]"]().keys())) == sorted(
+        ["mesh-1", "mesh-a"]
     )
 
 

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -100,7 +100,7 @@ def test_wildcard_fnmatch(new_solver_session):
     solver.results.graphics.mesh.create("mesh-a")
     solver.results.graphics.mesh.create("mesh-bc")
 
-    assert sorted(list(solver.results.graphics.mesh["mesh-*"]().keys())) == sorted(
+    assert sorted(solver.results.graphics.mesh["mesh-*"]()) == sorted(
         ["mesh-1", "mesh-2", "mesh-a", "mesh-bc"]
     )
 


### PR DESCRIPTION
lst.sort() sorts the original lst, the function doesn't return anything.
sorted(lst) returns a sorted copy of the original lst.

In a few tests in test_flobject.py and test_settings_api.py, lst.sort() is used to compare lists.