### PR TITLE
Deploy documentation from github runner

### DIFF
--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -16,7 +16,7 @@ env:
   PYFLUENT_HIDE_LOG_SECRETS: 1
 
 jobs:
-  nightly_docs_build:
+  build_dev_docs:
     runs-on: [self-hosted, pyfluent]
     strategy:
       fail-fast: false
@@ -75,8 +75,11 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
+  deploy_dev_docs:
+    runs-on: ubuntu-latest
+    needs: [build_dev_docs]
+    steps:
       - name: "Deploy development documentation"
-        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
         uses: ansys/actions/doc-deploy-dev@v4
         with:
             doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'

--- a/.github/workflows/release-doc-build.yml
+++ b/.github/workflows/release-doc-build.yml
@@ -18,7 +18,7 @@ env:
   PYFLUENT_HIDE_LOG_SECRETS: 1
 
 jobs:
-  nightly_docs_build:
+  build_release_docs:
     runs-on: [self-hosted, pyfluent]
 
     steps:
@@ -73,6 +73,10 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
+  deploy_release_docs:
+    runs-on: ubuntu-latest
+    needs: [build_release_docs]
+    steps:
       - name: "Deploy release documentation"
         uses: ansys/actions/doc-deploy-stable@v4
         with:


### PR DESCRIPTION
As discussed with Roberto and Jorge, this will avoid generating the actions_github_pages_* folders on self-hosted runners which is causing disk space to run out.

I'll make this change in other repos after testing.