### PR TITLE
Add links for doc and cheat sheet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ PyFluent cheat sheet. This one-page reference provides syntax rules and commands
 for using PyFluent. 
 
 On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
-issues to report bugs and request new features. On the `PyMFluent Discussions
+issues to report bugs and request new features. On the `PyFluent Discussions
 <https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 

--- a/README.rst
+++ b/README.rst
@@ -41,12 +41,24 @@ ability to:
 
 Documentation and issues
 ------------------------
-For comprehensive information on PyFluent, see the latest release
-`documentation <https://fluent.docs.pyansys.com>`_.
+Documentation for the latest stable release of PyFluent is hosted at
+`PyFluent documentation <https://fluent.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf>`_ the
+PyFluent cheat sheet. This one-page reference provides syntax rules and commands
+for using PyFluent. 
 
 On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
-issues to submit questions, report bugs, and request new features. To reach
-the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+issues to report bugs and request new features. On the `PyMFluent Discussions
+<https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -79,31 +79,37 @@ Some of the many features in this primary PyFluent package,
 
 Documentation and issues
 ------------------------
-In addition to installation and usage information, the PyFluent documentation
-provides :ref:`ref_index_api`, :ref:`ref_example_gallery`, and
-:ref:`ref_contributing` sections.
+Documentation for the latest stable release of PyFluent is hosted at
+`PyFluent documentation <https://fluent.docs.pyansys.com/version/stable/>`_.
 
-In the upper right corner of the documentation's title bar, there is an option
-for switching from viewing the documentation for the latest stable release
-to viewing the documentation for the development version or previously
-released versions.
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
 
-On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you
-can create issues to submit questions, report bugs, and request new features. To
-reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+You can also `view <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf>`_ the
+PyFluent cheat sheet. This one-page reference provides syntax rules and commands
+for using PyFluent. 
 
-License
--------
+On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
+issues to report bugs and request new features. On the `PyMFluent Discussions
+<https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+
+License and acknowledgments
+---------------------------
 PyFluent is licensed under the MIT license.
 
-PyFluent makes no commercial claim over Ansys whatsoever. This library extends
-the functionality of Ansys Fluent by adding a Python interface to Fluent without
-changing the core behavior or license of the original software. The use of the
-interactive control of Fluent control of PyFluent requires a legally licensed
-copy of Fluent.
+PyFluent makes no commercial claim over Ansys whatsoever. This library
+extends the functionality of Ansys Fluent by adding a Python interface
+to Fluent without changing the core behavior or license of the original
+software. The use of the interactive Fluent control of PyFluent requires a
+legally licensed local copy of Fluent.
 
-For more information on Fluent, see the `Ansys Fluent page
-<https://www.ansys.com/products/fluids/ansys-fluent>`_ on the Ansys website.
+For more information on Fluent, see the `Ansys Fluent <https://www.ansys.com/products/fluids/ansys-fluent>`_
+page on the Ansys website.
 
 Project index
 -------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -92,7 +92,7 @@ PyFluent cheat sheet. This one-page reference provides syntax rules and commands
 for using PyFluent. 
 
 On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
-issues to report bugs and request new features. On the `PyMFluent Discussions
+issues to report bugs and request new features. On the `PyFluent Discussions
 <https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add links to the PyFluent cheat sheets from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I revised the "Documentation and issues" section in both the README and the overall index.rst file.