### PR TITLE
Global search method

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include src/ansys/fluent/core/launcher/fluent_launcher_options.json
 include src/ansys/fluent/core/docs/README.rst
 include src/ansys/fluent/core/logging_config.yaml
 include src/ansys/fluent/core/quantity/cfg.yaml
-recursive-include src *pyi
+recursive-include src/ansys/fluent/core *pyi
+recursive-include src/ansys/fluent/core/data api_tree_*.pickle

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -1,14 +1,11 @@
 import argparse
 import os
 from pathlib import Path
-
-# import pickle
-from pprint import pprint
+import pickle
 
 import datamodelgen
 import print_fluent_version
-
-# import settingsgen
+import settingsgen
 import tuigen
 
 from ansys.fluent.core.launcher.launcher import FluentVersion, get_ansys_version
@@ -51,9 +48,8 @@ if __name__ == "__main__":
     print_fluent_version.generate(version)
     _update_first_level(api_tree, tuigen.generate(version))
     _update_first_level(api_tree, datamodelgen.generate(version))
-    # settingsgen.generate()
+    _update_first_level(api_tree, settingsgen.generate(version))
     api_tree_file = get_api_tree_filepath(version)
     Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)
-    with open(api_tree_file, "w") as f:
-        # pickle.dump(api_tree, f)
-        pprint(api_tree, f)
+    with open(api_tree_file, "wb") as f:
+        pickle.dump(api_tree, f)

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -1,15 +1,33 @@
 import argparse
+import collections
 import os
 from pathlib import Path
 
-import datamodelgen
+# import pickle
+from pprint import pprint
+
+# import datamodelgen
 import print_fluent_version
-import settingsgen
+
+# import settingsgen
 import tuigen
 
 from ansys.fluent.core.launcher.launcher import FluentVersion, get_ansys_version
+from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
+from ansys.fluent.core.utils.search import get_api_tree_filepath
+
+
+def _update(d, u):
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = _update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
 
 if __name__ == "__main__":
+    api_tree = {}
     if not os.getenv("PYFLUENT_LAUNCH_CONTAINER"):
         parser = argparse.ArgumentParser(
             description="Generate python code from Fluent APIs"
@@ -34,8 +52,13 @@ if __name__ == "__main__":
             os.environ["PYFLUENT_FLUENT_ROOT"] = str(Path(awp_root) / "fluent")
         if args.fluent_path:
             os.environ["PYFLUENT_FLUENT_ROOT"] = args.fluent_path
-
-    print_fluent_version.generate()
-    tuigen.generate()
-    datamodelgen.generate()
-    settingsgen.generate()
+    version = get_version_for_filepath()
+    print_fluent_version.generate(version)
+    _update(api_tree, tuigen.generate(version))
+    # datamodelgen.generate()
+    # settingsgen.generate()
+    api_tree_file = get_api_tree_filepath(version)
+    Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)
+    with open(api_tree_file, "w") as f:
+        # pickle.dump(api_tree, f)
+        pprint(api_tree, f)

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -1,12 +1,11 @@
 import argparse
-import collections
 import os
 from pathlib import Path
 
 # import pickle
 from pprint import pprint
 
-# import datamodelgen
+import datamodelgen
 import print_fluent_version
 
 # import settingsgen
@@ -17,17 +16,13 @@ from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 from ansys.fluent.core.utils.search import get_api_tree_filepath
 
 
-def _update(d, u):
-    for k, v in u.items():
-        if isinstance(v, collections.abc.Mapping):
-            d[k] = _update(d.get(k, {}), v)
-        else:
-            d[k] = v
-    return d
+def _update_first_level(d, u):
+    for k in d:
+        d[k].update(u.get(k, {}))
 
 
 if __name__ == "__main__":
-    api_tree = {}
+    api_tree = {"<meshing_session>": {}, "<solver_session>": {}}
     if not os.getenv("PYFLUENT_LAUNCH_CONTAINER"):
         parser = argparse.ArgumentParser(
             description="Generate python code from Fluent APIs"
@@ -54,8 +49,8 @@ if __name__ == "__main__":
             os.environ["PYFLUENT_FLUENT_ROOT"] = args.fluent_path
     version = get_version_for_filepath()
     print_fluent_version.generate(version)
-    _update(api_tree, tuigen.generate(version))
-    # datamodelgen.generate()
+    _update_first_level(api_tree, tuigen.generate(version))
+    _update_first_level(api_tree, datamodelgen.generate(version))
     # settingsgen.generate()
     api_tree_file = get_api_tree_filepath(version)
     Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)

--- a/codegen/print_fluent_version.py
+++ b/codegen/print_fluent_version.py
@@ -1,12 +1,12 @@
 import os
 
 import ansys.fluent.core as pyfluent
-from ansys.fluent.core.utils.fluent_version import get_version, get_version_for_filepath
+from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 
 _THIS_DIR = os.path.dirname(__file__)
 
 
-def print_fluent_version():
+def print_fluent_version(version):
     session = pyfluent.launch_fluent(mode="solver")
     eval = session.scheme_eval.scheme_eval
     version_file = os.path.join(
@@ -16,10 +16,10 @@ def print_fluent_version():
         "ansys",
         "fluent",
         "core",
-        f"fluent_version_{get_version_for_filepath()}.py",
+        f"fluent_version_{version}.py",
     )
     with open(version_file, "w", encoding="utf8") as f:
-        f.write(f'FLUENT_VERSION = "{get_version()}"\n')
+        f.write(f'FLUENT_VERSION = "{session.get_fluent_version()}"\n')
         f.write(f'FLUENT_BUILD_TIME = "{eval("(inquire-build-time)")}"\n')
         f.write(f'FLUENT_BUILD_ID = "{eval("(inquire-build-id)")}"\n')
         f.write(f'FLUENT_REVISION = "{eval("(inquire-src-vcs-id)")}"\n')
@@ -27,9 +27,10 @@ def print_fluent_version():
     session.exit()
 
 
-def generate():
-    print_fluent_version()
+def generate(version):
+    print_fluent_version(version)
 
 
 if __name__ == "__main__":
-    generate()
+    version = get_version_for_filepath()
+    generate(version)

--- a/codegen/print_fluent_version.py
+++ b/codegen/print_fluent_version.py
@@ -7,7 +7,7 @@ _THIS_DIR = os.path.dirname(__file__)
 
 
 def print_fluent_version(version):
-    session = pyfluent.launch_fluent(mode="solver")
+    session = pyfluent.launch_fluent()
     eval = session.scheme_eval.scheme_eval
     version_file = os.path.join(
         _THIS_DIR,

--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -51,7 +51,7 @@ def _get_indent_str(indent):
     return f"{' '*indent*4}"
 
 
-def _populate_hash_dict(name, info, cls):
+def _populate_hash_dict(name, info, cls, api_tree):
     children = info.get("children")
     if children:
         children_hash = []
@@ -59,7 +59,17 @@ def _populate_hash_dict(name, info, cls):
             for child in getattr(cls, "child_names", None):
                 child_cls = getattr(cls, child)
                 if cname == child_cls.fluent_name:
-                    children_hash.append(_populate_hash_dict(cname, cinfo, child_cls))
+                    api_tree[child] = {}
+                    children_hash.append(
+                        _populate_hash_dict(cname, cinfo, child_cls, api_tree[child])
+                    )
+                    okey = f"{child}:<name>"
+                    if okey in api_tree[child]:
+                        api_tree[child].update(api_tree[child][okey])
+                        del api_tree[child][okey]
+                        api_tree[okey] = api_tree.pop(child)
+                    else:
+                        api_tree[child] = api_tree[child] or "Parameter"
                     break
     else:
         children_hash = None
@@ -71,7 +81,10 @@ def _populate_hash_dict(name, info, cls):
             for command in getattr(cls, "command_names", None):
                 command_cls = getattr(cls, command)
                 if cname == command_cls.fluent_name:
-                    commands_hash.append(_populate_hash_dict(cname, cinfo, command_cls))
+                    api_tree[command] = "Command"
+                    commands_hash.append(
+                        _populate_hash_dict(cname, cinfo, command_cls, {})
+                    )
                     break
     else:
         commands_hash = None
@@ -83,7 +96,10 @@ def _populate_hash_dict(name, info, cls):
             for query in getattr(cls, "query_names", None):
                 query_cls = getattr(cls, query)
                 if qname == query_cls.fluent_name:
-                    queries_hash.append(_populate_hash_dict(qname, qinfo, query_cls))
+                    api_tree[query] = "Query"
+                    queries_hash.append(
+                        _populate_hash_dict(qname, qinfo, query_cls, {})
+                    )
                     break
     else:
         queries_hash = None
@@ -96,7 +112,7 @@ def _populate_hash_dict(name, info, cls):
                 argument_cls = getattr(cls, argument)
                 if aname == argument_cls.fluent_name:
                     arguments_hash.append(
-                        _populate_hash_dict(aname, ainfo, argument_cls)
+                        _populate_hash_dict(aname, ainfo, argument_cls, {})
                     )
                     break
     else:
@@ -104,10 +120,13 @@ def _populate_hash_dict(name, info, cls):
 
     object_type = info.get("object-type")
     if object_type:
+        key = f"{cls.__name__}:<name>"
+        api_tree[key] = {}
         object_hash = _populate_hash_dict(
             "child-object-type",
             object_type,
             getattr(cls, "child_object_type", None),
+            api_tree[key],
         )
     else:
         object_hash = None
@@ -439,11 +458,7 @@ def _populate_init(parent_dir, sinfo):
         f.write(f"from .{root_class_path} import root")
 
 
-def generate():
-    from ansys.fluent.core.launcher.launcher import launch_fluent
-
-    session = launch_fluent()
-    version = get_version_for_filepath(session=session)
+def generate(version):
     dirname = os.path.dirname(__file__)
     parent_dir = os.path.normpath(
         os.path.join(
@@ -463,14 +478,20 @@ def generate():
         shutil.rmtree(parent_dir)
     os.makedirs(parent_dir)
 
+    from ansys.fluent.core.launcher.launcher import launch_fluent
+
+    session = launch_fluent()
     sinfo = session._settings_service.get_static_info()
     session.exit()
     cls = flobject.get_cls("", sinfo, version=version)
 
-    _populate_hash_dict("", sinfo, cls)
+    api_tree = {}
+    _populate_hash_dict("", sinfo, cls, api_tree)
     _populate_classes(parent_dir)
     _populate_init(parent_dir, sinfo)
+    return {"<solver_session>": api_tree}
 
 
 if __name__ == "__main__":
-    generate()
+    version = get_version_for_filepath()
+    generate(version)

--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -442,7 +442,7 @@ def _populate_init(parent_dir, sinfo):
 def generate():
     from ansys.fluent.core.launcher.launcher import launch_fluent
 
-    session = launch_fluent(mode="solver")
+    session = launch_fluent()
     version = get_version_for_filepath(session=session)
     dirname = os.path.dirname(__file__)
     parent_dir = os.path.normpath(

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -21,6 +21,7 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils import fldoc
+from ansys.fluent.core.utils.search import search  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
 
 _VERSION_INFO = None

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -159,6 +159,11 @@ class Solver(BaseSession):
         return self._root.current_parametric_study
 
     @property
+    def parameters(self):
+        """Settings for parameters."""
+        return self._root.parameters
+
+    @property
     def parallel(self):
         """Settings for parallel."""
         return self._root.parallel

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -139,7 +139,7 @@ def search(
         Whether to match case, by default False
     version : str, optional
         Fluent version to search in, by default None in which case
-        it will search in the latest released version.
+        it will search in the latest version for which codegen was run.
     root : Any, optional
         The root object within which the search will be performed,
         can be a session object or any API object within a session,

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -1,0 +1,35 @@
+import os
+from typing import Any
+
+# from ansys.fluent.core.session import BaseSession
+
+
+def get_api_tree_filepath(version: str):
+    this_dirname = os.path.dirname(__file__)
+    return os.path.normpath(
+        os.path.join(
+            this_dirname,
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "data",
+            f"api_tree_{version}.pickle",
+        )
+    )
+
+
+def search(pattern: str, root: Any = None):
+    """_summary_
+
+    Parameters
+    ----------
+    pattern : str
+        The pattern to search for.
+    root : Any, optional
+        The root object within which the search will be performed,
+        can be a session object or any API object within a session,
+        by default None in which case it will search everything.
+    """
+    pass

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -1,31 +1,74 @@
-import os
+from collections.abc import Mapping
+from pathlib import Path
+import pickle
 from typing import Any
 
 # from ansys.fluent.core.session import BaseSession
+from ansys.fluent.core.launcher.launcher import FluentVersion
+from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 
 
-def get_api_tree_filepath(version: str):
-    this_dirname = os.path.dirname(__file__)
-    return os.path.normpath(
-        os.path.join(
-            this_dirname,
-            "..",
-            "data",
-            f"api_tree_{version}.pickle",
-        )
-    )
+def get_api_tree_filepath(version: str) -> Path:
+    return Path(__file__) / ".." / ".." / "data" / f"api_tree_{version}.pickle"
 
 
-def search(pattern: str, root: Any = None):
-    """_summary_
+def _match(source: str, word: str, match_whole_word: bool, match_case: bool):
+    if not match_case:
+        source = source.lower()
+        word = word.lower()
+    if match_whole_word:
+        return source == word
+    else:
+        return word in source
+
+
+def search(
+    word: str,
+    match_whole_word: bool = False,
+    match_case: bool = False,
+    version: str = None,
+    root: Any = None,
+):
+    """
+    Search for a word through the API object hierarchy.
 
     Parameters
     ----------
-    pattern : str
-        The pattern to search for.
+    word : str
+        The word to search for.
+    match_whole_word : bool, optional
+        _description_, by default False
+    match_case : bool, optional
+        _description_, by default False
+    version : str, optional
+        Fluent version to search in, by default None in which case
+        it will search in the latest released version.
     root : Any, optional
         The root object within which the search will be performed,
         can be a session object or any API object within a session,
         by default None in which case it will search everything.
     """
-    pass
+    if not version:
+        version = str(list(FluentVersion)[1])
+    version = get_version_for_filepath(version)
+    api_tree_file = get_api_tree_filepath(version)
+    with open(api_tree_file, "rb") as f:
+        api_tree = pickle.load(f)
+
+    def inner(tree, path=""):
+        for k, v in tree.items():
+            if k in ("<meshing_session>", "<solver_session>"):
+                next_path = k
+            else:
+                if k.endswith(":<name>"):
+                    k = k.removesuffix(":<name>")
+                    next_path = f"{path}.{k}[<name>]"
+                else:
+                    next_path = f"{path}.{k}"
+                if _match(k, word, match_whole_word, match_case):
+                    type_ = "Object" if isinstance(v, Mapping) else v
+                    print(f"{next_path} ({type_})")
+            if isinstance(v, Mapping):
+                inner(v, next_path)
+
+    inner(api_tree)

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -123,9 +123,9 @@ def search(
     word : str
         The word to search for.
     match_whole_word : bool, optional
-        _description_, by default False
+        Whether to match whole word, by default False
     match_case : bool, optional
-        _description_, by default False
+        Whether to match case, by default False
     version : str, optional
         Fluent version to search in, by default None in which case
         it will search in the latest released version.

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -3,9 +3,14 @@ from pathlib import Path
 import pickle
 from typing import Any
 
-# from ansys.fluent.core.session import BaseSession
 from ansys.fluent.core.launcher.launcher import FluentVersion
+from ansys.fluent.core.services.datamodel_se import PyMenu, PyNamedObjectContainer
+from ansys.fluent.core.services.datamodel_tui import TUIMenu
+from ansys.fluent.core.session_pure_meshing import PureMeshing
+from ansys.fluent.core.session_solver import Solver
+from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
+from ansys.fluent.core.workflow import BaseTask, TaskContainer, WorkflowWrapper
 
 
 def get_api_tree_filepath(version: str) -> Path:
@@ -20,6 +25,87 @@ def _match(source: str, word: str, match_whole_word: bool, match_case: bool):
         return source == word
     else:
         return word in source
+
+
+_meshing_rules = ["workflow", "meshing", "PartManagement", "PMFileManagement"]
+
+
+def _get_version_path_prefix_from_obj(obj: Any):
+    path = None
+    version = None
+    prefix = None
+    if isinstance(obj, PureMeshing):
+        path = ["<meshing_session>"]
+        version = get_version_for_filepath(obj.get_fluent_version())
+        prefix = "<root>"
+    elif isinstance(obj, Solver):
+        path = ["<solver_session>"]
+        version = get_version_for_filepath(obj.get_fluent_version())
+        prefix = "<root>"
+    elif isinstance(obj, TUIMenu):
+        module = obj.__class__.__module__
+        path = [
+            "<meshing_session>"
+            if module.startswith("ansys.fluent.core.meshing")
+            else "<solver_session>",
+            "tui",
+        ]
+        path.extend(obj.path)
+        version = module.rsplit("_", 1)[-1]
+        prefix = "<root>"
+    elif isinstance(obj, WorkflowWrapper):
+        path = ["<meshing_session>", obj.rules]
+        module = obj._workflow.__class__.__module__
+        module = module.removesuffix(".workflow")
+        version = module.rsplit("_", 1)[-1]
+        prefix = "<root>"
+    elif isinstance(obj, BaseTask):
+        path = ["<meshing_session>", obj.rules]
+        path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        module = obj._workflow.__class__.__module__
+        module = module.removesuffix(".workflow")
+        version = module.rsplit("_", 1)[-1]
+        prefix = "<root>"
+    elif isinstance(obj, TaskContainer):
+        path = ["<meshing_session>", obj.rules]
+        path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        path[-1] = f"{path[-1]}:<name>"
+        module = obj._container._workflow.__class__.__module__
+        module = module.removesuffix(".workflow")
+        version = module.rsplit("_", 1)[-1]
+        prefix = '<root>["<name>"]'
+    elif isinstance(obj, PyMenu):
+        rules = obj.rules
+        path = ["<meshing_session>" if rules in _meshing_rules else "<solver_session>"]
+        path.append(rules)
+        path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        module = obj.__class__.__module__
+        module = module.removesuffix(f".{rules}")
+        version = module.rsplit("_", 1)[-1]
+        prefix = "<root>"
+    elif isinstance(obj, PyNamedObjectContainer):
+        rules = obj.rules
+        path = ["<meshing_session>" if rules in _meshing_rules else "<solver_session>"]
+        path.append(rules)
+        path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        path[-1] = f"{path[-1]}:<name>"
+        module = obj.__class__.__module__
+        module = module.removesuffix(f".{rules}")
+        version = module.rsplit("_", 1)[-1]
+        prefix = '<root>["<name>"]'
+    elif isinstance(obj, flobject.Group):
+        module = obj.__class__.__module__
+        version = module.split(".")[-2].rsplit("_", 1)[-1]
+        prefix = "<root>"
+        path = ["<solver_session>"]
+        # Cannot deduce the whole path without api_tree
+    elif isinstance(obj, flobject.NamedObject):
+        module = obj.__class__.__module__
+        version = module.split(".")[-2].rsplit("_", 1)[-1]
+        prefix = '<root>["<name>"]'
+        path = ["<solver_session>"]
+        # Cannot deduce the whole path without api_tree
+    return version, path, prefix
 
 
 def search(
@@ -48,27 +134,61 @@ def search(
         can be a session object or any API object within a session,
         by default None in which case it will search everything.
     """
+    if version:
+        version = get_version_for_filepath(version)
+    root_version, root_path, prefix = _get_version_path_prefix_from_obj(root)
+    if root and not prefix:
+        return
+    if not version:
+        version = root_version
     if not version:
         version = str(list(FluentVersion)[1])
-    version = get_version_for_filepath(version)
+        version = get_version_for_filepath(version)
     api_tree_file = get_api_tree_filepath(version)
     with open(api_tree_file, "rb") as f:
         api_tree = pickle.load(f)
 
-    def inner(tree, path=""):
+    if isinstance(root, (flobject.Group, flobject.NamedObject)):
+        path = root_path + [flobject.to_python_name(x) for x in root.path.split("/")]
+        root_path = []
+        tree = api_tree
+        while path:
+            p = path.pop(0)
+            if p in tree:
+                tree = tree[p]
+                root_path.append(p)
+            elif f"{p}:<name>" in tree:
+                tree = tree[f"{p}:<name>"]
+                root_path.append(f"{p}:<name>")
+                if path:
+                    path.pop(0)
+            else:
+                return
+    print(root_path)
+
+    def inner(tree, path, root_path):
+        if root_path:
+            path = prefix
+        while root_path:
+            p = root_path.pop(0)
+            if p in tree:
+                tree = tree[p]
+            else:
+                return
+
         for k, v in tree.items():
             if k in ("<meshing_session>", "<solver_session>"):
                 next_path = k
             else:
                 if k.endswith(":<name>"):
                     k = k.removesuffix(":<name>")
-                    next_path = f"{path}.{k}[<name>]"
+                    next_path = f'{path}.{k}["<name>"]'
                 else:
                     next_path = f"{path}.{k}"
                 if _match(k, word, match_whole_word, match_case):
                     type_ = "Object" if isinstance(v, Mapping) else v
                     print(f"{next_path} ({type_})")
             if isinstance(v, Mapping):
-                inner(v, next_path)
+                inner(v, next_path, root_path)
 
-    inner(api_tree)
+    inner(api_tree, "", root_path)

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -29,6 +29,15 @@ def _match(source: str, word: str, match_whole_word: bool, match_case: bool):
         return word in source
 
 
+def _remove_suffix(input: str, suffix):
+    if hasattr(input, "removesuffix"):
+        return input.removesuffix(suffix)
+    else:
+        if suffix and input.endswith(suffix):
+            return input[: -len(suffix)]
+        return input
+
+
 _meshing_rules = ["workflow", "meshing", "PartManagement", "PMFileManagement"]
 
 
@@ -58,14 +67,14 @@ def _get_version_path_prefix_from_obj(obj: Any):
     elif isinstance(obj, WorkflowWrapper):
         path = ["<meshing_session>", obj.rules]
         module = obj._workflow.__class__.__module__
-        module = module.removesuffix(".workflow")
+        module = _remove_suffix(module, ".workflow")
         version = module.rsplit("_", 1)[-1]
         prefix = "<root>"
     elif isinstance(obj, BaseTask):
         path = ["<meshing_session>", obj.rules]
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         module = obj._workflow.__class__.__module__
-        module = module.removesuffix(".workflow")
+        module = _remove_suffix(module, ".workflow")
         version = module.rsplit("_", 1)[-1]
         prefix = "<root>"
     elif isinstance(obj, TaskContainer):
@@ -73,7 +82,7 @@ def _get_version_path_prefix_from_obj(obj: Any):
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         path[-1] = f"{path[-1]}:<name>"
         module = obj._container._workflow.__class__.__module__
-        module = module.removesuffix(".workflow")
+        module = _remove_suffix(module, ".workflow")
         version = module.rsplit("_", 1)[-1]
         prefix = '<root>["<name>"]'
     elif isinstance(obj, PyMenu):
@@ -82,7 +91,7 @@ def _get_version_path_prefix_from_obj(obj: Any):
         path.append(rules)
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         module = obj.__class__.__module__
-        module = module.removesuffix(f".{rules}")
+        module = _remove_suffix(module, f".{rules}")
         version = module.rsplit("_", 1)[-1]
         prefix = "<root>"
     elif isinstance(obj, PyNamedObjectContainer):
@@ -92,7 +101,7 @@ def _get_version_path_prefix_from_obj(obj: Any):
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         path[-1] = f"{path[-1]}:<name>"
         module = obj.__class__.__module__
-        module = module.removesuffix(f".{rules}")
+        module = _remove_suffix(module, f".{rules}")
         version = module.rsplit("_", 1)[-1]
         prefix = '<root>["<name>"]'
     elif isinstance(obj, flobject.Group):
@@ -182,7 +191,7 @@ def search(
                 next_path = k
             else:
                 if k.endswith(":<name>"):
-                    k = k.removesuffix(":<name>")
+                    k = _remove_suffix(k, ":<name>")
                     next_path = f'{path}.{k}["<name>"]'
                 else:
                     next_path = f"{path}.{k}"

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -153,8 +153,10 @@ def search(
     if not version:
         version = root_version
     if not version:
-        version = str(list(FluentVersion)[1])
-        version = get_version_for_filepath(version)
+        for fluent_version in FluentVersion:
+            version = get_version_for_filepath(str(fluent_version))
+            if get_api_tree_filepath(version).exists():
+                break
     api_tree_file = get_api_tree_filepath(version)
     with open(api_tree_file, "rb") as f:
         api_tree = pickle.load(f)

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -164,7 +164,6 @@ def search(
                     path.pop(0)
             else:
                 return
-    print(root_path)
 
     def inner(tree, path, root_path):
         if root_path:

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -10,10 +10,6 @@ def get_api_tree_filepath(version: str):
         os.path.join(
             this_dirname,
             "..",
-            "..",
-            "..",
-            "..",
-            "..",
             "data",
             f"api_tree_{version}.pickle",
         )

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -14,7 +14,9 @@ from ansys.fluent.core.workflow import BaseTask, TaskContainer, WorkflowWrapper
 
 
 def get_api_tree_filepath(version: str) -> Path:
-    return Path(__file__) / ".." / ".." / "data" / f"api_tree_{version}.pickle"
+    return (
+        Path(__file__) / ".." / ".." / "data" / f"api_tree_{version}.pickle"
+    ).resolve()
 
 
 def _match(source: str, word: str, match_whole_word: bool, match_case: bool):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -174,13 +174,11 @@ def test_search_settings_from_root(capsys, load_static_mixer_case):
     assert (
         '<root>["<name>"].phase["<name>"].shell_conduction["<name>"] (Object)' in lines
     )
-    pyfluent.search(
-        "conduction", root=solver.setup.boundary_conditions.wall["wall-inlet"]
-    )
+    pyfluent.search("conduction", root=solver.setup.boundary_conditions.wall["wall"])
     lines = capsys.readouterr().out.splitlines()
     assert '<root>.phase["<name>"].shell_conduction["<name>"] (Object)' in lines
     pyfluent.search(
-        "conduction", root=solver.setup.boundary_conditions.wall["wall-inlet"].phase
+        "conduction", root=solver.setup.boundary_conditions.wall["wall"].phase
     )
     lines = capsys.readouterr().out.splitlines()
     assert '<root>["<name>"].shell_conduction["<name>"] (Object)' in lines

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,10 @@
+import pytest
+from util.fixture_fluent import load_static_mixer_case  # noqa: F401
+from util.meshing_workflow import new_watertight_workflow_session  # noqa: F401
+from util.solver_workflow import new_solver_session  # noqa: F401
+
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core.utils.search import _get_version_path_prefix_from_obj
 
 
 def test_search(capsys):
@@ -10,17 +16,17 @@ def test_search(capsys):
         "<meshing_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeout (Parameter)"
         in lines
     )
-    assert "<solver_session>.results.graphics.mesh[<name>].display (Command)" in lines
+    assert '<solver_session>.results.graphics.mesh["<name>"].display (Command)' in lines
     assert (
-        "<solver_session>.results.graphics.mesh[<name>].display_state_name (Parameter)"
+        '<solver_session>.results.graphics.mesh["<name>"].display_state_name (Parameter)'
         in lines
     )
 
     pyfluent.search("display", match_whole_word=True)
     lines = capsys.readouterr().out.splitlines()
-    assert "<solver_session>.results.graphics.mesh[<name>].display (Command)" in lines
+    assert '<solver_session>.results.graphics.mesh["<name>"].display (Command)' in lines
     assert (
-        "<solver_session>.results.graphics.mesh[<name>].display_state_name (Parameter)"
+        '<solver_session>.results.graphics.mesh["<name>"].display_state_name (Parameter)'
         not in lines
     )
 
@@ -44,3 +50,137 @@ def test_search(capsys):
         "<solver_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeoutValue (Parameter)"
         not in lines
     )
+
+
+@pytest.mark.fluent_version("latest")
+def test_get_version_path_prefix_from_obj(
+    new_watertight_workflow_session, new_solver_session
+):
+    meshing = new_watertight_workflow_session
+    solver = new_solver_session
+    version = solver.version
+    assert _get_version_path_prefix_from_obj(meshing) == (
+        version,
+        ["<meshing_session>"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(solver) == (
+        version,
+        ["<solver_session>"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(meshing.tui.file.import_) == (
+        version,
+        ["<meshing_session>", "tui", "file", "import_"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(meshing.tui.file.read_case) == (
+        None,
+        None,
+        None,
+    )
+    assert _get_version_path_prefix_from_obj(meshing.meshing) == (
+        version,
+        ["<meshing_session>", "meshing"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(meshing.workflow) == (
+        version,
+        ["<meshing_session>", "workflow"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(solver.workflow) == (
+        version,
+        ["<meshing_session>", "workflow"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(meshing.workflow.TaskObject) == (
+        version,
+        ["<meshing_session>", "workflow", "TaskObject:<name>"],
+        '<root>["<name>"]',
+    )
+    assert _get_version_path_prefix_from_obj(
+        meshing.workflow.TaskObject["Import Geometry"]
+    ) == (version, ["<meshing_session>", "workflow", "TaskObject:<name>"], "<root>")
+    assert _get_version_path_prefix_from_obj(meshing.preferences.Appearance.Charts) == (
+        version,
+        ["<solver_session>", "preferences", "Appearance", "Charts"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(solver.setup.models) == (
+        version,
+        ["<solver_session>"],
+        "<root>",
+    )
+    assert _get_version_path_prefix_from_obj(solver.file.cff_files) == (
+        None,
+        None,
+        None,
+    )
+
+
+@pytest.mark.fluent_version("latest")
+def test_search_from_root(capsys, new_watertight_workflow_session):
+    meshing = new_watertight_workflow_session
+    pyfluent.search("display", root=meshing)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.tui.display (Object)" in lines
+    pyfluent.search("display", root=meshing.tui)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.display (Object)" in lines
+    pyfluent.search("display", root=meshing.tui.display)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.update_scene.display (Command)" in lines
+    assert "<root>.display_states (Object)" in lines
+    pyfluent.search("cad", root=meshing.meshing)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.GlobalSettings.EnableCleanCAD (Parameter)" in lines
+    assert "<root>.LoadCADGeometry (Command)" in lines
+    pyfluent.search("next", root=meshing.workflow)
+    lines = capsys.readouterr().out.splitlines()
+    assert '<root>.TaskObject["<name>"].InsertNextTask (Command)' in lines
+    pyfluent.search("next", root=meshing.workflow.TaskObject)
+    lines = capsys.readouterr().out.splitlines()
+    assert '<root>["<name>"].InsertNextTask (Command)' in lines
+    pyfluent.search("next", root=meshing.workflow.TaskObject["Import Geometry"])
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.InsertNextTask (Command)" in lines
+    pyfluent.search("timeout", root=meshing.preferences)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.General.IdleTimeout (Parameter)" in lines
+    pyfluent.search("timeout", root=meshing.preferences.General)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.IdleTimeout (Parameter)" in lines
+
+
+@pytest.mark.fluent_version("latest")
+def test_search_settings_from_root(capsys, load_static_mixer_case):
+    solver = load_static_mixer_case
+    pyfluent.search("conduction", root=solver)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<root>.tui.define.models.shell_conduction (Object)" in lines
+    assert (
+        '<root>.setup.boundary_conditions.wall["<name>"].phase["<name>"].shell_conduction["<name>"] (Object)'
+        in lines
+    )
+    pyfluent.search("conduction", root=solver.setup.boundary_conditions)
+    lines = capsys.readouterr().out.splitlines()
+    assert (
+        '<root>.wall["<name>"].phase["<name>"].shell_conduction["<name>"] (Object)'
+        in lines
+    )
+    pyfluent.search("conduction", root=solver.setup.boundary_conditions.wall)
+    lines = capsys.readouterr().out.splitlines()
+    assert (
+        '<root>["<name>"].phase["<name>"].shell_conduction["<name>"] (Object)' in lines
+    )
+    pyfluent.search(
+        "conduction", root=solver.setup.boundary_conditions.wall["wall-inlet"]
+    )
+    lines = capsys.readouterr().out.splitlines()
+    assert '<root>.phase["<name>"].shell_conduction["<name>"] (Object)' in lines
+    pyfluent.search(
+        "conduction", root=solver.setup.boundary_conditions.wall["wall-inlet"].phase
+    )
+    lines = capsys.readouterr().out.splitlines()
+    assert '<root>["<name>"].shell_conduction["<name>"] (Object)' in lines

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,46 @@
+import ansys.fluent.core as pyfluent
+
+
+def test_search(capsys):
+    pyfluent.search("display")
+    lines = capsys.readouterr().out.splitlines()
+    assert "<meshing_session>.tui.display (Object)" in lines
+    assert "<meshing_session>.tui.display.update_scene.display (Command)" in lines
+    assert (
+        "<meshing_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeout (Parameter)"
+        in lines
+    )
+    assert "<solver_session>.results.graphics.mesh[<name>].display (Command)" in lines
+    assert (
+        "<solver_session>.results.graphics.mesh[<name>].display_state_name (Parameter)"
+        in lines
+    )
+
+    pyfluent.search("display", match_whole_word=True)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<solver_session>.results.graphics.mesh[<name>].display (Command)" in lines
+    assert (
+        "<solver_session>.results.graphics.mesh[<name>].display_state_name (Parameter)"
+        not in lines
+    )
+
+    pyfluent.search("Display", match_case=True)
+    lines = capsys.readouterr().out.splitlines()
+    assert "<meshing_session>.tui.display (Object)" not in lines
+    assert (
+        "<meshing_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeout (Parameter)"
+        in lines
+    )
+
+    pyfluent.search(
+        "GraphicsWindowDisplayTimeout", match_whole_word=True, match_case=True
+    )
+    lines = capsys.readouterr().out.splitlines()
+    assert (
+        "<meshing_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeout (Parameter)"
+        in lines
+    )
+    assert (
+        "<solver_session>.preferences.Graphics.MeshingMode.GraphicsWindowDisplayTimeoutValue (Parameter)"
+        not in lines
+    )


### PR DESCRIPTION
Added a global search method to search statically through all API paths. This will be useful to discover object paths while writing scripts without running a Fluent session. E.g., all queries in #1890 can be addressed using this method (outputs are truncated):
```
>>> pyfluent.search("periodic")
...
<solver_session>.setup.boundary_conditions.periodic["<name>"] (Object)
<solver_session>.setup.mesh_interfaces.interface["<name>"].periodic (Parameter)
...
>>> pyfluent.search("compute") 
...
<solver_session>.setup.reference_values.compute (Command)
...
>>> pyfluent.search("console")      
...
<solver_session>.tui.define.parameters.output_parameters.print_to_console (Command)
...
>>> pyfluent.search("report_file") 
<solver_session>.tui.solution.monitor.report_files (Object)
<solver_session>.tui.solve.report_files (Object)
<solver_session>.solution.monitor.report_files["<name>"] (Object)
```
The documentation search (https://fluent.docs.pyansys.com/version/stable/search.html?q=compute) also outputs these objects/commands, but that does not show the runtime hierarchy.

Please see the unittests for more usage.

For the implementation, a nested dictionary of all API paths is stored during codegen which is parsed during the search. 