### PR TITLE
Use standard grpc-health-checking package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     "ansys-api-fluent>=0.3.15",
     "ansys-platform-instancemanagement~=1.0",
     "grpcio>=1.30.0",
+    "grpcio-health-checking>=1.30.0",
     "numpy>=1.21.5",
     "platformdirs>=3.5.1",
     "pandas>=1.1.5",

--- a/src/ansys/fluent/core/services/health_check.py
+++ b/src/ansys/fluent/core/services/health_check.py
@@ -5,9 +5,9 @@ import sys
 from typing import List, Tuple
 
 import grpc
+from grpc_health.v1 import health_pb2 as HealthCheckModule
+from grpc_health.v1 import health_pb2_grpc as HealthCheckGrpcModule
 
-from ansys.api.fluent.v0 import health_pb2 as HealthCheckModule
-from ansys.api.fluent.v0 import health_pb2_grpc as HealthCheckGrpcModule
 from ansys.fluent.core.services.error_handler import catch_grpc_error
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,

--- a/src/ansys/fluent/core/utils/networking.py
+++ b/src/ansys/fluent/core/utils/networking.py
@@ -4,8 +4,7 @@ import socket
 from typing import Any
 
 import grpc
-
-from ansys.api.fluent.v0 import health_pb2, health_pb2_grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
 
 network_logger = logging.getLogger("pyfluent.networking")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,16 +5,12 @@ import tempfile
 import time
 
 import grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
 import pytest
 from util.meshing_workflow import new_mesh_session  # noqa: F401
 from util.solver_workflow import new_solver_session  # noqa: F401
 
-from ansys.api.fluent.v0 import (
-    health_pb2,
-    health_pb2_grpc,
-    scheme_eval_pb2,
-    scheme_eval_pb2_grpc,
-)
+from ansys.api.fluent.v0 import scheme_eval_pb2, scheme_eval_pb2_grpc
 from ansys.api.fluent.v0.scheme_pointer_pb2 import SchemePointer
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import connect_to_fluent, examples


### PR DESCRIPTION
Using the standard package to get health_pb2 and health_pb2_grpc will avoid clashing with other libraries using the standard package.