### PR TITLE
Logging and misc documentation improvements

### DIFF
--- a/doc/source/api/general/index.rst
+++ b/doc/source/api/general/index.rst
@@ -63,10 +63,10 @@ Post objects
 
 :ref:`ref_post_objects` documents visualization objects for interfacing to Matplotlib and pyvista.
 
-Asynchronous execution
-######################
+Execution utilities
+###################
 
-:ref:`ref_execution_utils` documents tools for asynchronous function execution.
+:ref:`ref_execution_utils` documents execution utilities, including an asynchronous option, for command execution.
 
 Search
 ######
@@ -80,8 +80,8 @@ Meta
 
 Logging
 #######
-.. automodule:: ansys.fluent.core.logging
-    :members:
+
+:ref:`ref_logging` documents the PyFluent debug logging module.
 
 .. currentmodule:: ansys.fluent.core
 
@@ -93,17 +93,18 @@ Logging
     :hidden:
 
     launcher/index
-    execution_utils
-    search
     sessions/index
     services/index
     streaming_services/index
-    post_objects/index
     scheduler/index
     case_reader
     data_transfer
     journaling
-    meta
-    quantity
-    rpvars
     workflow
+    rpvars
+    quantity
+    post_objects/index
+    execution_utils
+    search
+    meta
+    logging

--- a/doc/source/api/general/logging.rst
+++ b/doc/source/api/general/logging.rst
@@ -1,0 +1,7 @@
+.. _ref_logging:
+
+Logging
+=======
+
+.. automodule:: ansys.fluent.core.logging
+    :members:

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -227,6 +227,8 @@ event types via the ``events_manager`` attribute of a solution mode session:
 
 For more information, see :ref:`ref_events`.
 
+.. _ref_logging_user_guide:
+
 Logging to file and debugging
 -----------------------------
 PyFluent logging to file is by default disabled. Logging can be enabled with:
@@ -237,8 +239,12 @@ PyFluent logging to file is by default disabled. Logging can be enabled with:
     pyfluent.logging.enable()
 
 the last command being equivalent to ``pyfluent.logging.enable('DEBUG')``,
-using the default PyFluent logging level. See the possible logging level values in
+using the default PyFluent logging level.
+See the possible logging level values in
 `<https://docs.python.org/3/library/logging.html#logging-levels>`_.
+
+PyFluent by default creates and logs to a file named ``pyfluent.log`` in the
+current working directory (see :func:`ansys.fluent.core.logging.enable` for more details).
 
 The global logging level of PyFluent, after logging has been enabled,
 can also be controlled with:
@@ -255,6 +261,9 @@ See also :func:`ansys.fluent.core.logging.enable`,
 
 PyFluent loggers use the standard Python logging library, for more details see
 `<https://docs.python.org/3/library/logging.html>`_.
+
+Additional documentation about the PyFluent logging module is available
+in the :ref:`logging module documentation <ref_logging>`.
 
 .. _ref_logging_env_var:
 

--- a/src/ansys/fluent/core/logging.py
+++ b/src/ansys/fluent/core/logging.py
@@ -1,4 +1,6 @@
-"""Module controlling PyFluent's logging functionality."""
+"""Module controlling PyFluent's logging functionality.
+
+For a basic user guide, see the :ref:`logging user guide <ref_logging_user_guide>`."""
 import logging.config
 import os
 from typing import Union
@@ -26,6 +28,36 @@ def is_active() -> bool:
 
 
 def get_default_config() -> dict:
+    """Returns the default configuration dictionary obtained from parsing from the PyFluent ``logging_config.yaml`` file.
+
+    Examples
+    --------
+    >>> import ansys.fluent.core as pyfluent
+    >>> pyfluent.logging.get_default_config()
+    {'disable_existing_loggers': False,
+     'formatters': {'logfile_fmt': {'format': '%(asctime)s %(name)-21s '
+                                              '%(levelname)-8s %(message)s'}},
+     'handlers': {'pyfluent_file': {'backupCount': 9,
+                                    'class': 'logging.handlers.RotatingFileHandler',
+                                    'filename': 'pyfluent.log',
+                                    'formatter': 'logfile_fmt',
+                                    'level': 'NOTSET',
+                                    'maxBytes': 10485760}},
+     'loggers': {'pyfluent.datamodel': {'handlers': ['pyfluent_file'],
+                                        'level': 'DEBUG'},
+                 'pyfluent.general': {'handlers': ['pyfluent_file'],
+                                      'level': 'DEBUG'},
+                 'pyfluent.launcher': {'handlers': ['pyfluent_file'],
+                                       'level': 'DEBUG'},
+                 'pyfluent.networking': {'handlers': ['pyfluent_file'],
+                                         'level': 'DEBUG'},
+                 'pyfluent.post_objects': {'handlers': ['pyfluent_file'],
+                                           'level': 'DEBUG'},
+                 'pyfluent.settings_api': {'handlers': ['pyfluent_file'],
+                                           'level': 'DEBUG'},
+                 'pyfluent.tui': {'handlers': ['pyfluent_file'], 'level': 'DEBUG'}},
+     'version': 1}
+    """
     file_path = os.path.abspath(__file__)
     file_dir = os.path.dirname(file_path)
     yaml_path = os.path.join(file_dir, "logging_config.yaml")
@@ -42,7 +74,8 @@ def enable(level: Union[str, int] = "DEBUG", custom_config: dict = None):
     level : str or int, optional
         Specified logging level to set PyFluent loggers to. If omitted, level is set to DEBUG.
     custom_config : dict, optional
-        Used to provide a customized logging config file.
+        Used to provide a customized logging configuration file that will be used instead
+        of the ``logging_config.yaml`` file (see also :func:`get_default_config`).
 
     Notes
     -----
@@ -50,8 +83,17 @@ def enable(level: Union[str, int] = "DEBUG", custom_config: dict = None):
 
     Examples
     --------
+    Using the default logging setup:
+
     >>> import ansys.fluent.core as pyfluent
     >>> pyfluent.logging.enable()
+
+    Customizing logging configuration (see also :func:`get_default_config`):
+
+    >>> import ansys.fluent.core as pyfluent
+    >>> config_dict = pyfluent.logging.get_default_config()
+    >>> config_dict['handlers']['pyfluent_file']['filename'] = 'test.log'
+    >>> pyfluent.logging.enable(custom_config=config_dict)
     """
     global _logging_file_enabled
 
@@ -153,16 +195,16 @@ def list_loggers():
 
 
 def configure_env_var() -> None:
-    """Verifies whether PYFLUENT_LOGGING environment variable was defined in the system.
+    """Verifies whether ``PYFLUENT_LOGGING`` environment variable was defined in the system.
     Executed once automatically on PyFluent initialization.
 
     Notes
     -----
     The usual way to enable PyFluent logging to file is through :func:`enable()`.
     ``PYFLUENT_LOGGING`` set to ``0`` or ``OFF`` is the same as if no environment variable was set.
-    If logging debug output to file is desired, without having to use :func:`enable()`,
-    set ``PYFLUENT_LOGGING`` to ``DEBUG`` instead.
-    See also the :ref:`logging user guide <ref_logging_env_var>`.
+    If logging debug output to file by default is desired, without having to use :func:`enable()` every time,
+    set environment variable ``PYFLUENT_LOGGING`` to ``DEBUG``.
+    See also the :ref:`user guide environment variable subsection <ref_logging_env_var>`.
     """
     env_logging_level = os.getenv("PYFLUENT_LOGGING")
     if env_logging_level:


### PR DESCRIPTION
Closes #1935 

Mainly improvements to the documentation of the logging module, and moving logging docs to a separate page, following the same standard already being used for other `api/general` documentation pages.

In addition, reworked `doc/source/api/general/index.rst` so that all 3 sections have the same order and aren't as confusing to navigate (ordering was scrambled before): 
![image](https://github.com/ansys/pyfluent/assets/132297401/0d2348f7-8814-4754-a4ab-fcc50a03aab5)
