### PR TITLE
Add option to patch existing installation with codegen

### DIFF
--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -20,10 +20,15 @@ def _update_first_level(d, u):
 
 if __name__ == "__main__":
     api_tree = {"<meshing_session>": {}, "<solver_session>": {}}
+    parser = argparse.ArgumentParser(
+        description="Generate python code from Fluent APIs"
+    )
+    parser.add_argument(
+        "--pyfluent-path",
+        dest="pyfluent_path",
+        help="Specify the pyfluent installation folder to patch, with full path.  Such as /my-venv/Lib/site-packages",
+    )
     if not os.getenv("PYFLUENT_LAUNCH_CONTAINER"):
-        parser = argparse.ArgumentParser(
-            description="Generate python code from Fluent APIs"
-        )
         parser.add_argument(
             "--ansys-version",
             dest="ansys_version",
@@ -34,13 +39,9 @@ if __name__ == "__main__":
             dest="fluent_path",
             help="Specify the fluent folder to use, with full path.  Such as /apps/ansys_inc/v232/fluent",
         )
-        parser.add_argument(
-            "--pyfluent-path",
-            dest="pyfluent_path",
-            help="Specify the pyfluent installation folder to patch, with full path.  Such as /my-venv/Lib/site-packages",
-        )
-        args = parser.parse_args()
 
+    args = parser.parse_args()
+    if not os.getenv("PYFLUENT_LAUNCH_CONTAINER"):
         if args.ansys_version:
             awp_root = os.environ[
                 "AWP_ROOT"

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -34,6 +34,11 @@ if __name__ == "__main__":
             dest="fluent_path",
             help="Specify the fluent folder to use, with full path.  Such as /apps/ansys_inc/v232/fluent",
         )
+        parser.add_argument(
+            "--pyfluent-path",
+            dest="pyfluent_path",
+            help="Specify the pyfluent installation folder to patch, with full path.  Such as /my-venv/Lib/site-packages",
+        )
         args = parser.parse_args()
 
         if args.ansys_version:
@@ -45,11 +50,11 @@ if __name__ == "__main__":
         if args.fluent_path:
             os.environ["PYFLUENT_FLUENT_ROOT"] = args.fluent_path
     version = get_version_for_filepath()
-    print_fluent_version.generate(version)
-    _update_first_level(api_tree, tuigen.generate(version))
-    _update_first_level(api_tree, datamodelgen.generate(version))
-    _update_first_level(api_tree, settingsgen.generate(version))
-    api_tree_file = get_api_tree_filepath(version)
+    print_fluent_version.generate(version, args.pyfluent_path)
+    _update_first_level(api_tree, tuigen.generate(version, args.pyfluent_path))
+    _update_first_level(api_tree, datamodelgen.generate(version, args.pyfluent_path))
+    _update_first_level(api_tree, settingsgen.generate(version, args.pyfluent_path))
+    api_tree_file = get_api_tree_filepath(version, args.pyfluent_path)
     Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)
     with open(api_tree_file, "wb") as f:
         pickle.dump(api_tree, f)

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -83,7 +83,12 @@ class DataModelStaticInfo:
     _noindices = []
 
     def __init__(
-        self, rules: str, modes: tuple, version: str, rules_save_name: str = ""
+        self,
+        pyfluent_path: str,
+        rules: str,
+        modes: tuple,
+        version: str,
+        rules_save_name: str = "",
     ):
         self.rules = rules
         self.modes = modes
@@ -91,14 +96,12 @@ class DataModelStaticInfo:
         if rules_save_name == "":
             rules_save_name = rules
         datamodel_dir = (
-            _THIS_DIR
-            / ".."
-            / "src"
+            (Path(pyfluent_path) if pyfluent_path else (Path(_THIS_DIR) / ".." / "src"))
             / "ansys"
             / "fluent"
             / "core"
             / f"datamodel_{version}"
-        )
+        ).resolve()
         datamodel_dir.mkdir(exist_ok=True)
         self.filepath = (datamodel_dir / f"{rules_save_name}.py").resolve()
         if len(modes) > 1:
@@ -107,10 +110,11 @@ class DataModelStaticInfo:
 
 
 class DataModelGenerator:
-    def __init__(self, version):
+    def __init__(self, version, pyfluent_path):
         self.version = version
         self._static_info: Dict[str, DataModelStaticInfo] = {
             "workflow": DataModelStaticInfo(
+                pyfluent_path,
                 "workflow",
                 (
                     "meshing",
@@ -118,21 +122,26 @@ class DataModelGenerator:
                 ),
                 self.version,
             ),
-            "meshing": DataModelStaticInfo("meshing", ("meshing",), self.version),
+            "meshing": DataModelStaticInfo(
+                pyfluent_path, "meshing", ("meshing",), self.version
+            ),
             "PartManagement": DataModelStaticInfo(
-                "PartManagement", ("meshing",), self.version
+                pyfluent_path, "PartManagement", ("meshing",), self.version
             ),
             "PMFileManagement": DataModelStaticInfo(
-                "PMFileManagement", ("meshing",), self.version
+                pyfluent_path, "PMFileManagement", ("meshing",), self.version
             ),
             "flicing": DataModelStaticInfo(
-                "flserver", ("flicing",), self.version, "flicing"
+                pyfluent_path, "flserver", ("flicing",), self.version, "flicing"
             ),
             "preferences": DataModelStaticInfo(
-                "preferences", ("meshing", "solver", "flicing,"), self.version
+                pyfluent_path,
+                "preferences",
+                ("meshing", "solver", "flicing,"),
+                self.version,
             ),
             "solverworkflow": DataModelStaticInfo(
-                "solverworkflow", ("solver",), self.version
+                pyfluent_path, "solverworkflow", ("solver",), self.version
             )
             if int(self.version) >= 231
             else None,
@@ -420,10 +429,10 @@ class DataModelGenerator:
             shutil.rmtree(Path(_SOLVER_DM_DOC_DIR))
 
 
-def generate(version):
-    return DataModelGenerator(version).write_static_info()
+def generate(version, pyfluent_path):
+    return DataModelGenerator(version, pyfluent_path).write_static_info()
 
 
 if __name__ == "__main__":
     version = get_version_for_filepath()
-    generate(version)
+    generate(version, None)

--- a/codegen/print_fluent_version.py
+++ b/codegen/print_fluent_version.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
@@ -6,18 +7,16 @@ from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 _THIS_DIR = os.path.dirname(__file__)
 
 
-def print_fluent_version(version):
+def print_fluent_version(version, pyfluent_path):
     session = pyfluent.launch_fluent()
     eval = session.scheme_eval.scheme_eval
-    version_file = os.path.join(
-        _THIS_DIR,
-        "..",
-        "src",
-        "ansys",
-        "fluent",
-        "core",
-        f"fluent_version_{version}.py",
-    )
+    version_file = (
+        (Path(pyfluent_path) if pyfluent_path else (Path(_THIS_DIR) / ".." / "src"))
+        / "ansys"
+        / "fluent"
+        / "core"
+        / f"fluent_version_{version}.py"
+    ).resolve()
     with open(version_file, "w", encoding="utf8") as f:
         f.write(f'FLUENT_VERSION = "{session.get_fluent_version()}"\n')
         f.write(f'FLUENT_BUILD_TIME = "{eval("(inquire-build-time)")}"\n')
@@ -27,10 +26,10 @@ def print_fluent_version(version):
     session.exit()
 
 
-def generate(version):
-    print_fluent_version(version)
+def generate(version, pyfluent_path):
+    print_fluent_version(version, pyfluent_path)
 
 
 if __name__ == "__main__":
     version = get_version_for_filepath()
-    generate(version)
+    generate(version, None)

--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -28,6 +28,7 @@ import contextlib
 import hashlib
 import io
 import os
+from pathlib import Path
 import pickle
 import pprint
 import shutil
@@ -458,20 +459,16 @@ def _populate_init(parent_dir, sinfo):
         f.write(f"from .{root_class_path} import root")
 
 
-def generate(version):
+def generate(version, pyfluent_path):
     dirname = os.path.dirname(__file__)
-    parent_dir = os.path.normpath(
-        os.path.join(
-            dirname,
-            "..",
-            "src",
-            "ansys",
-            "fluent",
-            "core",
-            "solver",
-            f"settings_{version}",
-        )
-    )
+    parent_dir = (
+        (Path(pyfluent_path) if pyfluent_path else (Path(dirname) / ".." / "src"))
+        / "ansys"
+        / "fluent"
+        / "core"
+        / "solver"
+        / f"settings_{version}"
+    ).resolve()
 
     # Clear previously generated data
     if os.path.exists(parent_dir):
@@ -494,4 +491,4 @@ def generate(version):
 
 if __name__ == "__main__":
     version = get_version_for_filepath()
-    generate(version)
+    generate(version, None)

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -13,9 +13,15 @@ from ansys.fluent.core.utils.fluent_version import get_version_for_filepath
 from ansys.fluent.core.workflow import BaseTask, TaskContainer, WorkflowWrapper
 
 
-def get_api_tree_filepath(version: str) -> Path:
+def get_api_tree_filepath(version: str, pyfluent_path: str) -> Path:
     return (
-        Path(__file__) / ".." / ".." / "data" / f"api_tree_{version}.pickle"
+        (
+            (Path(pyfluent_path) / "ansys" / "fluent" / "core")
+            if pyfluent_path
+            else (Path(__file__) / ".." / "..")
+        )
+        / "data"
+        / f"api_tree_{version}.pickle"
     ).resolve()
 
 

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -180,9 +180,9 @@ def search(
     if not version:
         for fluent_version in FluentVersion:
             version = get_version_for_filepath(str(fluent_version))
-            if get_api_tree_filepath(version).exists():
+            if get_api_tree_filepath(version, None).exists():
                 break
-    api_tree_file = get_api_tree_filepath(version)
+    api_tree_file = get_api_tree_filepath(version, None)
     with open(api_tree_file, "rb") as f:
         api_tree = pickle.load(f)
 


### PR DESCRIPTION
If we install pyfluent with `pip install ansys-fluent-core` now, we don't get the generated API files for unreleased Fluent version 24.1. This PR adds an option in codegen to patch an existing pyfluent installation. E.g., if pyfluent is installed in a virtual environment `D:\ANSYSDev\env`, we can run codegen from another pyfluent git area (make sure `AWP_ROOT241` env var is set)
```
python codegen\allapigen.py --pyfluent-path=D:\ANSYSDev\env\Lib\site-packages
```
to add the 24.1 API files in the pyfluent installation in the virtual environment.