### PR TITLE
Bump version 0.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-  
+
       - name: Running Vale
         uses: errata-ai/vale-action@reviewdog
         env:
@@ -500,16 +500,6 @@ jobs:
 
       - name: Display package file list
         run: ls -R
-
-      - name: Upload to Private PyPi
-        run: |
-          pip install twine
-          python -m twine upload --skip-existing ./**/*.whl
-          python -m twine upload --skip-existing ./**/*.tar.gz
-        env:
-          TWINE_USERNAME: PAT
-          TWINE_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
-          TWINE_REPOSITORY_URL: https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
 
       - name: Upload to Public PyPi
         run: |

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 17, 0
+version_info = 0, 17, 1
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -59,11 +59,10 @@ def test_rp_vars_allowed_values(new_solver_session_no_transcript) -> None:
     with pytest.raises(RuntimeError) as msg:
         rp_vars("number-of-iterat")
 
-    assert (
-        msg.value.args[0] == "number-of-iterat is not an allowed rp-vars name.\n"
-        "The most similar names are: number-of-iterations, "
-        "number-of-time-steps, lb/number-of-timesteps, "
-        "number-of-samples, gpuapp/total-number-of-subiterations."
+    assert msg.value.args[0].startswith(
+        "number-of-iterat is not an allowed rp-vars name.\n"
+        "The most similar names are:"
     )
+    assert "number-of-iterations" in msg.value.args[0]
 
     assert "number-of-iterations" in rp_vars.allowed_values()


### PR DESCRIPTION
Remove the Ansys PyPI upload, which will now happen from [pyfluent-dev](https://github.com/ansys/pyfluent-dev) repo.

The internal package (with the 24.1 API files) will be uploaded to Ansys internal PyPI.
The public package (without the 24.1 API files) will be uploaded to public PyPI.