### PR TITLE
rm solverworkflow

### DIFF
--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -67,10 +67,6 @@ def _get_preferences(session):
     return _get_datamodel_attributes(session, "preferences")
 
 
-def _get_solverworkflow(session):
-    return _get_datamodel_attributes(session, "solverworkflow")
-
-
 class _IsDataValid:
     def __init__(self, scheme_eval):
         self._scheme_eval = scheme_eval
@@ -118,7 +114,6 @@ class BaseSession:
         self.rp_vars = RPVars(self.scheme_eval.string_eval)
         self._uploader = None
         self._preferences = None
-        self._solverworkflow = None
         self.journal = Journal(self.scheme_eval)
 
         self.transcript = self.fluent_connection.create_service(Transcript)

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -10,12 +10,7 @@ from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
 from ansys.fluent.core.services.reduction import Reduction, ReductionService
 from ansys.fluent.core.services.svar import SVARData, SVARInfo, SVARService
-from ansys.fluent.core.session import (
-    _CODEGEN_MSG_TUI,
-    BaseSession,
-    _get_preferences,
-    _get_solverworkflow,
-)
+from ansys.fluent.core.session import _CODEGEN_MSG_TUI, BaseSession, _get_preferences
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL
 from ansys.fluent.core.solver.flobject import get_root as settings_get_root
 from ansys.fluent.core.systemcoupling import SystemCoupling
@@ -52,7 +47,6 @@ class Solver(BaseSession):
         self._system_coupling = None
         self._settings_root = None
         self._version = None
-        self._solverworkflow = None
         self._lck = threading.Lock()
         self.svar_service = self.fluent_connection.create_service(SVARService)
         self.svar_info = SVARInfo(self.svar_service)
@@ -187,13 +181,6 @@ class Solver(BaseSession):
         if self._preferences is None:
             self._preferences = _get_preferences(self)
         return self._preferences
-
-    @property
-    def solverworkflow(self):
-        """Datamodel root of solverworkflow."""
-        if self._solverworkflow is None:
-            self._solverworkflow = _get_solverworkflow(self)
-        return self._solverworkflow
 
     def _sync_from_future(self, fut: Future):
         with self._lck:

--- a/src/ansys/fluent/core/utils/setup_for_fluent.py
+++ b/src/ansys/fluent/core/utils/setup_for_fluent.py
@@ -13,7 +13,6 @@ def setup_for_fluent(*args, **kwargs):
         globals["solver"] = Solver(fluent_connection=session.fluent_connection)
     else:
         globals["solver"] = session
-        globals["solverworkflow"] = session.solverworkflow
 
     globals["preferences"] = session.preferences
     globals["workflow"] = session.workflow

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -292,11 +292,15 @@ def test_start_transcript_file_write(new_mesh_session):
 
 
 @pytest.mark.fluent_version(">=23.1")
-def test_solverworkflow_in_solver_session(new_solver_session):
-    solver = new_solver_session
-    solver_dir = dir(solver)
-    for attr in ("preferences", "solverworkflow", "tui", "workflow"):
-        assert attr in solver_dir
+def test_expected_interfaces_in_solver_session(new_solver_session):
+    assert all(
+        intf in dir(new_solver_session) for intf in ("preferences", "tui", "workflow")
+    )
+
+
+@pytest.mark.fluent_version(">=24.1")
+def test_solverworkflow_not_in_solver_session(new_solver_session):
+    assert "solverworkflow" not in dir(new_solver_session)
 
 
 @pytest.mark.fluent_version(">=23.2")


### PR DESCRIPTION
Removing the solverworkflow object from the Python console as discussed with wf team. This object does not generally contribute well to the overall user experience, Command executions cause unpredictable side effects in the task tree.