### PR TITLE
Fix interrupt from client

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -671,8 +671,6 @@ def launch_fluent(
         sifile_last_mtime = Path(server_info_filepath).stat().st_mtime
         if env is None:
             env = {}
-        if mode != FluentMode.SOLVER_ICING:
-            env["APP_LAUNCHED_FROM_CLIENT"] = "1"  # disables flserver datamodel
         kwargs = _get_subprocess_kwargs_for_fluent(env)
         if cwd:
             kwargs.update(cwd=cwd)

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -5,6 +5,7 @@ import time
 
 from docker.models.containers import Container
 import psutil
+import pytest
 from util.fixture_fluent import load_static_mixer_case  # noqa: F401
 from util.solver_workflow import (  # noqa: F401
     new_solver_session,


### PR DESCRIPTION
Un-setting `APP_LAUNCHED_FROM_CLIENT` sets `fl-appname` in Fluent which fixes the interrupt behaviour.

This reverts #696, we need to investigate the performance issue separately. For now, the `fl-appname` setting in Fluent is the same as other remote infrastructures.