### PR TITLE
Make sure Fluent is shutdown on exit

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -348,6 +348,13 @@ class FluentConnection:
         self.launcher_args = launcher_args
 
         self._exit_evt = threading.Event()
+
+        # session.exit() is handled in the daemon thread (MonitorThread) which ensures
+        # shutdown of non-daemon threads. A daemon thread is terminated abruptly
+        # during interpreter exit (after all non-daemon threads are exited).
+        # self._waiting_thread is a long-running thread which is exited
+        # at the end of session.exit() to ensure everything within session.exit()
+        # gets executed during exit.
         self._waiting_thread = threading.Thread(target=self._exit_evt.wait)
         self._waiting_thread.start()
 


### PR DESCRIPTION
`session.exit()` is handled in a daemon thread (MonitorThread) which ensures shutdown of all streaming (non-daemon) threads. A daemon thread is terminated abruptly during Python process exit, after all non-daemon threads are exited). In the current code, the streaming threads are shut down after the server is exited within `session.exit()`. The MonitorThread shuts down immediately after shutting down the streaming threads without exiting the last server.

In this PR, a long-running thread is added which is exited at the end of `session.exit()` to ensure everything within `session.exit()` gets executed during exit.

Need to see how to unittest this (need a Python process exit).