### PR TITLE
Most of the solvermode tests were skipped

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def pytest_runtest_setup(item):
         if spec == "latest":
             spec = (
                 f">={_fluent_release_version}"
-                if is_nightly
+                if is_nightly or is_solvermode_option
                 else f"=={_fluent_release_version}"
             )
         version_specs.append(SpecifierSet(spec))


### PR DESCRIPTION
Most of the solvermode tests were skipped in the weekly solvermode CI (https://github.com/ansys/pyfluent/actions/runs/6294700178/job/17086910227#step:13:393). This should fix the issue. Now the marker `fluent_version("latest")` is correctly resolved to `fluent_version(">=23.2")` for the solvermode CI