### PR TITLE
Added environmental variable PYFLUENT_ADDITIONAL_ARGUMENTS

### DIFF
--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -111,7 +111,7 @@ scheduler environments are Univa Grid Engine (UGE), Load Sharing Facility (LSF),
 Portable Batch System (PBS), and Slurm.
 
 This example shows a bash shell script that can be submitted to a Slurm
-scheduler using the ```sbatch``` command:  
+scheduler using the ```sbatch``` command:
 
 .. code:: bash
 
@@ -194,3 +194,29 @@ For distributed parallel processing, you usually pass both parameters:
       mode="solver",
       additional_arguments="-t16 -cnf=m1:8,m2:8",
    )
+
+Using the PYFLUENT_ADDITIONAL_ARGUMENTS environment variable
+------------------------------------------------------------
+You can set additional arguments also using this environment variable.
+This can be useful for running on multiple platforms and allows you to keep
+a the same python script to use on the platforms.
+
+.. code:: bash
+
+   #!/bin/bash
+   #
+   # Activate your favorite Python environment
+   #
+   export AWP_ROOT232=/apps/ansys_inc/v232
+   . ./venv/bin/activate
+   #
+   # Set additional arguments
+   #
+   export PYFLUENT_ADDITIONAL_ARGUMENTS="-cnf=m1:8,m2:8 -t16 -peth.efa"
+   #
+   # Run a PyFluent script
+   #
+   python run.py
+
+Note: You should omit the additional_arguments option in the launch_fluent function as
+that variable is taken over the environmental variable.

--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -197,7 +197,7 @@ For distributed parallel processing, you usually pass both parameters:
 
 Using the PYFLUENT_ADDITIONAL_ARGUMENTS environment variable
 ------------------------------------------------------------
-You can set additional arguments also using this environment variable.
+You can also set additional arguments using this environment variable.
 This can be useful when running on multiple platforms, avoiding the need to change the
 Python scripts being run.
 
@@ -217,6 +217,3 @@ Python scripts being run.
    # Run a PyFluent script
    #
    python run.py
-
-Note: You should omit the additional_arguments option in the launch_fluent function as
-that variable is ignored when using the environmental variable.

--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -198,8 +198,8 @@ For distributed parallel processing, you usually pass both parameters:
 Using the PYFLUENT_ADDITIONAL_ARGUMENTS environment variable
 ------------------------------------------------------------
 You can set additional arguments also using this environment variable.
-This can be useful for running on multiple platforms and allows you to keep
-a the same python script to use on the platforms.
+This can be useful when running on multiple platforms, avoiding the need to change the
+Python scripts being run.
 
 .. code:: bash
 

--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -219,4 +219,4 @@ a the same python script to use on the platforms.
    python run.py
 
 Note: You should omit the additional_arguments option in the launch_fluent function as
-that variable is taken over the environmental variable.
+that variable is ignored when using the environmental variable.

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -600,6 +600,17 @@ def launch_fluent(
 
     del start_container
 
+    # Check if user set PYFLUENT_ADDITIONAL_ARGUMENTS var
+    if os.environ.get("PYFLUENT_ADDITIONAL_ARGUMENTS",None) is not None:
+        # Now check if user used the additional_arguments option
+        if additional_arguments is None:
+            additional_arguments = os.environ.get("PYFLUENT_ADDITIONAL_ARGUMENTS")
+        else:
+            logger.warning(
+                "Both the 'PYFLUENT_ADDITIONAL_ARGUMENTS' variable and 'additional_arguments' "
+                "options cannot be used together. Using the 'additional_arguments' option."
+            )
+
     if additional_arguments is None:
         additional_arguments = ""
     elif fluent_launch_mode == LaunchMode.PIM:

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -499,7 +499,7 @@ def launch_fluent(
         format they are normally passed to Fluent on the command line.
         As an alternative, a user may set the PYFLUENT_ADDITIONAL_ARGUMENTS environment
         variable instead of setting this option. If both the environment variable is set,
-        and the user uses this option, the environment variable is ignored.
+        and the user uses this option, the environment variable is used.
     env : dict[str, str], optional
         Mapping to modify environment variables in Fluent. The default
         is ``None``.

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -497,6 +497,9 @@ def launch_fluent(
     additional_arguments : str, optional
         Additional arguments to send to Fluent as a string in the same
         format they are normally passed to Fluent on the command line.
+        As an alternative, a user may set the PYFLUENT_ADDITIONAL_ARGUMENTS environment
+        variable instead of setting this option. If both the environment variable is set,
+        and the user uses this option, the environment variable is ignored.
     env : dict[str, str], optional
         Mapping to modify environment variables in Fluent. The default
         is ``None``.
@@ -601,7 +604,7 @@ def launch_fluent(
     del start_container
 
     # Check if user set PYFLUENT_ADDITIONAL_ARGUMENTS var
-    if os.environ.get("PYFLUENT_ADDITIONAL_ARGUMENTS",None) is not None:
+    if os.getenv("PYFLUENT_ADDITIONAL_ARGUMENTS") is not None:
         # Now check if user used the additional_arguments option
         if additional_arguments is None:
             additional_arguments = os.environ.get("PYFLUENT_ADDITIONAL_ARGUMENTS")


### PR DESCRIPTION
Added an environmental variable to allow a user to pass additional arguments to the launcher without having to change their python file.

Launcher checks if the environment variable is set and that the user did not launch with the additional_arguments option. If this is the case, the user additional_arguments are used instead.