### PR TITLE
fix: doc-artifact name when uploading doc index

### DIFF
--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -93,6 +93,7 @@ jobs:
       - name: "Deploy the latest documentation index"
         uses: ansys/actions/doc-deploy-index@v4
         with:
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
           index-name: pyfluent-vdev
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}

--- a/.github/workflows/release-doc-build.yml
+++ b/.github/workflows/release-doc-build.yml
@@ -112,6 +112,7 @@ jobs:
       - name: "Deploy the latest documentation index"
         uses: ansys/actions/doc-deploy-index@v4
         with:
+          doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pyfluent-v${{ env.VERSION_MEILI }}
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}


### PR DESCRIPTION
Continuation of #2024. This pull-request fixes the name of the documentation artifacts as per the failures in https://github.com/ansys/pyfluent/actions/runs/6321215095/job/17166203692