### PR TITLE
Added section to Example Page

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -11,4 +11,4 @@ you can download these examples as Python files or Jupyter notebooks and run the
    :hidden:
 
    00-fluent/README.txt
-   Miscellaneous Examples <https://examples.fluent.docs.pyansys.com/version/dev/examples/index.html>    
+   Miscellaneous Examples <https://examples.fluent.docs.pyansys.com/version/dev/index.html>    

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,10 +6,9 @@ Examples
 End-to-end examples show how you can use PyFluent. If the PyFluent ``ansys-fluent-core`` package is installed on your machine,
 you can download these examples as Python files or Jupyter notebooks and run them locally.
 
-A collection of PyFluent examples can be found at `pyfluent-examples <https://github.com/ansys/pyfluent-examples>`_.
-
 .. toctree::
    :maxdepth: 1
    :hidden:
 
-.. 00-fluent/README.txt
+   00-fluent/README.txt
+   Miscellaneous Examples <https://examples.fluent.docs.pyansys.com/version/dev/examples/index.html>    


### PR DESCRIPTION
— Added a section in example section as “Miscellaneous Examples”, which links to the Miscellaneous examples repositories example documentation landing page.
— Removed existing repository link