### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ env:
   PACKAGE_NAME: 'ansys-fluent-core'
   PACKAGE_NAMESPACE: 'ansys.fluent.core'
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+  MAIN_PYTHON_VERSION: '3.9'
   PYFLUENT_TIMEOUT_FORCE_EXIT: 30
   PYFLUENT_LAUNCH_CONTAINER: 1
   PYFLUENT_LOGGING: 'DEBUG'
@@ -62,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -193,7 +194,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Cache pip
         uses: actions/cache@v3
@@ -365,7 +366,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Download package
         uses: actions/download-artifact@v3
@@ -432,7 +433,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Cache pip
         uses: actions/cache@v3
@@ -494,7 +495,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - uses: actions/download-artifact@v3
 

--- a/.github/workflows/run-custom-tests.yml
+++ b/.github/workflows/run-custom-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@a
 
 Installation
 ------------
-The ``ansys-fluent-core`` package supports Python 3.8 through Python
+The ``ansys-fluent-core`` package supports Python 3.9 through Python
 3.11 on Windows and Linux.
 
 Install the latest release from `PyPI

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -144,7 +144,7 @@ all PyFluent packages in a Python *virtual environment*:
 
 Which version of Python should you use?
 ---------------------------------------
-PyFluent supports Python 3.8 through Python 3.11 on Windows and Linux. Python
+PyFluent supports Python 3.9 through Python 3.11 on Windows and Linux. Python
 3.10 is shipped with Ansys 2023 R2 and later. For example, in a 2023 R2 Windows
 installation, the executable file Python 3.10 is typically located at:
 ``C:\Program Files\ANSYS Inc\v232\commonfiles\CPython\3_10\winx64\Release\python.exe``.

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ============
 
-The ``ansys-fluent-core`` package supports Python 3.8 through
+The ``ansys-fluent-core`` package supports Python 3.9 through
 Python 3.11 on Windows and Linux.
 
 .. note::

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     url="https://github.com/ansys/pyfluent",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=install_requires,
     project_urls={
         "Documentation": "https://fluent.docs.pyansys.com/",


### PR DESCRIPTION
We are dropping python 3.8 as of now and later we can include 3.12