### PR TITLE
Run docformatter only on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Run pre-commit for docformatter
+        run: pre-commit run --hook-stage manual --all-files docformatter
+
       - name: Running Vale
         uses: errata-ai/vale-action@reviewdog
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
   rev: v1.7.5
   hooks:
   - id: docformatter
+    stages: [manual]
     args: ["--config", "pyproject.toml"]
 
 #- repo: https://github.com/pycqa/pydocstyle

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -89,7 +89,7 @@ class DatamodelService(StreamingService):
     def initialize_datamodel(
         self, request: DataModelProtoModule.InitDatamodelRequest
     ) -> DataModelProtoModule.InitDatamodelResponse:
-        """initDatamodel rpc of DataModel service"""
+        """initDatamodel rpc of DataModel service."""
         return self._stub.initDatamodel(request, metadata=self._metadata)
 
     @catch_grpc_error

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -89,7 +89,7 @@ class DatamodelService(StreamingService):
     def initialize_datamodel(
         self, request: DataModelProtoModule.InitDatamodelRequest
     ) -> DataModelProtoModule.InitDatamodelResponse:
-        """initDatamodel rpc of DataModel service."""
+        """initDatamodel rpc of DataModel service"""
         return self._stub.initDatamodel(request, metadata=self._metadata)
 
     @catch_grpc_error


### PR DESCRIPTION
docfromatter will be run only on CI (similar to vale) with a specific Python version. Locally it can still be run as `pre-commit run --hook-stage manual --all-files docformatter` if needed. Note that, the manual run will give wrong report for Python version < 3.11.