### PR TITLE
fix for case file

### DIFF
--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -625,4 +625,14 @@ def _get_case_filepath_from_flprj(flprj_file):
     tree = ET.parse(flprj_file, parser)
     root = tree.getroot()
     folder_name = root.find("Metadata").find("CurrentSimulation").get("value")[5:-1]
-    return root.find(folder_name).find("Input").find("Case").find("Target").get("value")
+    # If the project file name begins with a digit then the node to find will be prepended
+    # with "_". Rather than making any assumptions that this is a hard rule, or what
+    # the scope of the rule is, simply retry with the name prepended:
+    find_folder = lambda retry=False: root.find(("_" if retry else "") + folder_name)
+    return (
+        (find_folder() or find_folder(retry=True))
+        .find("Input")
+        .find("Case")
+        .find("Target")
+        .get("value")
+    )


### PR DESCRIPTION
fix for case file reading where a project file is specified and it starts with a digit, whcih requires special handling in the xml.