### PR TITLE
Remove timeout loop in FluentConnection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ markers = [
     "nightly: Tests that run under nightly CI",
     "codegen_required: Tests that requires codegen",
     "fluent_version(version): Tests that runs with specified Fluent version",
+    "standalone: Tests that cannot be run within container"
 ]
 
 

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -239,6 +239,7 @@ class FluentConnection:
         """
         self.error_state = ErrorState()
         self._data_valid = False
+        self._channel_str = None
         self.finalizer_cbs = []
         if channel is not None:
             self._channel = channel
@@ -247,6 +248,7 @@ class FluentConnection:
                 ip = os.getenv("PYFLUENT_FLUENT_IP", "127.0.0.1")
             if not port:
                 port = os.getenv("PYFLUENT_FLUENT_PORT")
+            self._channel_str = f"{ip}:{port}"
             if not port:
                 raise ValueError(
                     "The port to connect to Fluent session is not provided."

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -239,7 +239,6 @@ class FluentConnection:
         """
         self.error_state = ErrorState()
         self._data_valid = False
-        self._channel_str = None
         self.finalizer_cbs = []
         if channel is not None:
             self._channel = channel
@@ -248,7 +247,6 @@ class FluentConnection:
                 ip = os.getenv("PYFLUENT_FLUENT_IP", "127.0.0.1")
             if not port:
                 port = os.getenv("PYFLUENT_FLUENT_PORT")
-            self._channel_str = f"{ip}:{port}"
             if not port:
                 raise ValueError(
                     "The port to connect to Fluent session is not provided."
@@ -271,7 +269,7 @@ class FluentConnection:
         )
         # At this point, the server must be running. If the following check_health()
         # throws, we should not proceed.
-        self.check_health()
+        self.health_check_service.check_health()
 
         self._id = f"session-{next(FluentConnection._id_iter)}"
 

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -260,7 +260,6 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
 def launch_remote_fluent(
     session_cls,
     start_transcript: bool,
-    start_timeout: int = 100,
     product_version: Optional[str] = None,
     cleanup_on_exit: bool = True,
     meshing_mode: bool = False,
@@ -282,9 +281,6 @@ def launch_remote_fluent(
         Whether to start streaming the Fluent transcript in the client. The
         default is ``True``. You can stop and start the streaming of the
         Fluent transcript subsequently via method calls on the session object.
-    start_timeout : int, optional
-        Maximum allowable time in seconds for connecting to the Fluent
-        server. The default is ``100``.
     product_version : str, optional
         Select an installed version of ANSYS. The string must be in a format like
         ``"23.2.0"`` (for 2023 R2) matching the documented version format in the
@@ -797,7 +793,6 @@ def launch_fluent(
 
         return launch_remote_fluent(
             session_cls=new_session,
-            start_timeout=start_timeout,
             start_transcript=start_transcript,
             product_version=fluent_product_version,
             cleanup_on_exit=cleanup_on_exit,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -325,7 +325,6 @@ def launch_remote_fluent(
             channel=channel,
             cleanup_on_exit=cleanup_on_exit,
             remote_instance=instance,
-            start_timeout=start_timeout,
             start_transcript=start_transcript,
             launcher_args=launcher_args,
         )
@@ -833,7 +832,6 @@ def launch_fluent(
 
         session = new_session(
             fluent_connection=FluentConnection(
-                start_timeout=start_timeout,
                 port=port,
                 password=password,
                 cleanup_on_exit=cleanup_on_exit,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import os
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -27,6 +28,12 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
+    if (
+        any(mark.name == "standalone" for mark in item.iter_markers())
+        and os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1"
+    ):
+        pytest.skip()
+
     is_nightly = item.config.getoption("--nightly")
     if not is_nightly and any(mark.name == "nightly" for mark in item.iter_markers()):
         pytest.skip()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -161,10 +161,11 @@ def test_create_session_from_server_info_file_with_wrong_password(
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
         MockSchemeEvalServicer(), server
     )
+    health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     server.start()
     server_info_file = tmp_path / "server_info.txt"
     server_info_file.write_text(f"{ip}:{port}\n1234")
-    with pytest.raises(grpc.RpcError) as ex:
+    with pytest.raises(RuntimeError) as ex:
         session = BaseSession.create_from_server_info_file(
             server_info_file_name=str(server_info_file),
             cleanup_on_exit=False,
@@ -172,7 +173,7 @@ def test_create_session_from_server_info_file_with_wrong_password(
         session.scheme_eval.scheme_eval("")
         server.stop(None)
         session.exit()
-    assert ex.value.code() == grpc.StatusCode.UNAUTHENTICATED
+    assert ex.value.__context__.code() == grpc.StatusCode.UNAUTHENTICATED
 
 
 def test_create_session_from_launch_fluent_by_passing_ip_and_port_and_password() -> (

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -327,14 +327,11 @@ def test_help_does_not_throw(new_solver_session):
 
 
 def test_recover_grpc_error_from_launch_error(monkeypatch: pytest.MonkeyPatch):
+    orig_parse_server_info_file = session._parse_server_info_file
+
     def mock_parse_server_info_file(file_name):
-        with open(file_name, encoding="utf-8") as f:
-            lines = f.readlines()
-        ip_and_port = lines[0].strip().split(":")
-        ip = ip_and_port[0]
-        port = int(ip_and_port[1]) - 1  # provide wrong port in client
-        password = lines[1].strip()
-        return ip, port, password
+        ip, port, password = orig_parse_server_info_file(file_name)
+        return ip, port - 1, password  # provide wrong port
 
     monkeypatch.setattr(session, "_parse_server_info_file", mock_parse_server_info_file)
     with pytest.raises(LaunchFluentError) as ex:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -327,9 +327,7 @@ def test_help_does_not_throw(new_solver_session):
     help(new_solver_session.file.read)
 
 
-@pytest.mark.skipif(
-    os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1", reason="tests Fluent launch scenario"
-)
+@pytest.mark.standalone
 def test_recover_grpc_error_from_launch_error(monkeypatch: pytest.MonkeyPatch):
     orig_parse_server_info_file = session._parse_server_info_file
 
@@ -342,3 +340,9 @@ def test_recover_grpc_error_from_launch_error(monkeypatch: pytest.MonkeyPatch):
         solver = pyfluent.launch_fluent()
     # grpc.RpcError -> RuntimeError -> LaunchFluentError
     assert ex.value.__context__.__context__.code() == grpc.StatusCode.UNAVAILABLE
+
+
+def test_recover_grpc_error_from_connection_error():
+    with pytest.raises(RuntimeError) as ex:
+        pyfluent.connect_to_fluent(ip="127.0.0.1", port=50000, password="abcdefg")
+    assert ex.value.__context__.code() == grpc.StatusCode.UNAVAILABLE

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -167,7 +167,6 @@ def test_create_session_from_server_info_file_with_wrong_password(
         session = BaseSession.create_from_server_info_file(
             server_info_file_name=str(server_info_file),
             cleanup_on_exit=False,
-            start_timeout=2,
         )
         session.scheme_eval.scheme_eval("")
         server.stop(None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -163,7 +163,7 @@ def test_create_session_from_server_info_file_with_wrong_password(
     server.start()
     server_info_file = tmp_path / "server_info.txt"
     server_info_file.write_text(f"{ip}:{port}\n1234")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(grpc.RpcError) as ex:
         session = BaseSession.create_from_server_info_file(
             server_info_file_name=str(server_info_file),
             cleanup_on_exit=False,
@@ -171,6 +171,7 @@ def test_create_session_from_server_info_file_with_wrong_password(
         session.scheme_eval.scheme_eval("")
         server.stop(None)
         session.exit()
+    assert ex.value.code() == grpc.StatusCode.UNAUTHENTICATED
 
 
 def test_create_session_from_launch_fluent_by_passing_ip_and_port_and_password() -> (

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -327,6 +327,9 @@ def test_help_does_not_throw(new_solver_session):
     help(new_solver_session.file.read)
 
 
+@pytest.mark.skipif(
+    os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1", reason="tests Fluent launch scenario"
+)
 def test_recover_grpc_error_from_launch_error(monkeypatch: pytest.MonkeyPatch):
     orig_parse_server_info_file = session._parse_server_info_file
 


### PR DESCRIPTION
~trying to understand the impact~

Looking at how we are launching Fluent from PyFluent, the timeout loop in `FluentConnection` is unnecessary. I have replaced it with a `check_health` call which will fail only if there is some issue at grpc communication level and it will expose the grpc error message in that case. Exposing the grpc error message here will help us to triage issues in user's system.

The `start_timeout` is used only when we wait for the server to finish writing the server-info file.


Tested by hardcoding a port in `FluentConnection`, so grpc connection will fail due to port-mismatch:
Old behaviour (fails after 60 s):
```
>>> solver = pyfluent.launch_fluent()
pyfluent.launcher ERROR: Exception caught - RuntimeError: The connection to the Fluent server could not be established within the configurable 60 second time limit.
Traceback (most recent call last):
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\launcher\launcher.py", line 750, in launch_fluent
    session = new_session.create_from_server_info_file(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\session.py", line 226, in create_from_server_info_file
    fluent_connection=FluentConnection(
                      ^^^^^^^^^^^^^^^^^
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\fluent_connection.py", line 283, in __init__
    raise RuntimeError(
RuntimeError: The connection to the Fluent server could not be established within the configurable 60 second time limit.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\launcher\launcher.py", line 784, in launch_fluent
    raise LaunchFluentError(launch_cmd) from ex
ansys.fluent.core.launcher.launcher.LaunchFluentError:
Fluent Launch string: start "" "D:\ANSYSDev\vNNN\fluent\ntbin\win64\fluent.exe" 3ddp   -sifile="C:\Users\mkundu\AppData\Local\Temp\serverinfo-1aqp0o22.txt" -nm -hidden
```

New behaviour (fails immediately after Fluent is launched and shows the grpc error message):
```
>>> solver = pyfluent.launch_fluent()
pyfluent.launcher ERROR: Exception caught - RuntimeError: failed to connect to all addresses; last error: UNAVAILABLE: ipv6:%5B::1%5D:12345: Connection refused
Traceback (most recent call last):
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\launcher\launcher.py", line 745, in launch_fluent
    session = new_session.create_from_server_info_file(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\session.py", line 226, in create_from_server_info_file
    fluent_connection=FluentConnection(
                      ^^^^^^^^^^^^^^^^^
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\fluent_connection.py", line 272, in __init__
    self.health_check_service.check_health()
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\services\error_handler.py", line 15, in func
    raise RuntimeError(ex.details()) from None
RuntimeError: failed to connect to all addresses; last error: UNAVAILABLE: ipv6:%5B::1%5D:12345: Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\launcher\launcher.py", line 779, in launch_fluent
    raise LaunchFluentError(launch_cmd) from ex
ansys.fluent.core.launcher.launcher.LaunchFluentError:
Fluent Launch string: start "" "D:\ANSYSDev\vNNN\fluent\ntbin\win64\fluent.exe" 3ddp   -sifile="C:\Users\mkundu\AppData\Local\Temp\serverinfo-z5hlusk9.txt" -nm -hidden
```