### PR TITLE
Multiple dependency updates per dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,28 @@ updates:
     directory: "/requirements" # Location of package manifests
     insecure-external-code-execution: allow
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "Maintenance"
       - "Dependencies"
     ignore:
       - dependency-name: "vtk"
       - dependency-name: "grpcio"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    labels:
+      - "Maintenance"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/2133

Changes:
- Dependabot should now group minor and patch (not major) dependency updates into a single PR
- Reduced frequency of dependency updates from daily to weekly
- GitHub actions dependency updates will all be grouped into a single weekly PR 
- Added `Maintenance` label to GitHub actions dependabot PRs

All of this should hopefully make dependabot dependency updates less annoying and more convenient to work with.