### PR TITLE
fix: decompress artifact for doc indexing (#2136)

### DIFF
--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -95,6 +95,7 @@ jobs:
         uses: ansys/actions/doc-deploy-index@v4
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          decompress-artifact: true
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
           index-name: pyfluent-vdev
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}

--- a/.github/workflows/release-doc-build.yml
+++ b/.github/workflows/release-doc-build.yml
@@ -114,6 +114,7 @@ jobs:
         uses: ansys/actions/doc-deploy-index@v4
         with:
           doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+          decompress-artifact: true
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pyfluent-v${{ env.VERSION_MEILI }}
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -5,6 +5,7 @@ from ansys.fluent.core.examples import download_file, path
 from ansys.fluent.core.filereader.casereader import CaseReader
 
 
+@pytest.mark.skip("Temporarily skipping till the docker image is updated, see #2141")
 def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
     solver = new_solver_session_no_transcript
@@ -25,6 +26,7 @@ def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
     assert before_init_mod_2[1][1][1] == ("value", True)
 
 
+@pytest.mark.skip("Temporarily skipping till the docker image is updated, see #2141")
 @pytest.mark.fluent_version(">=23.1")
 def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
@@ -49,6 +51,7 @@ def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     assert len(case_vars) == pytest.approx(9000, 450)
 
 
+@pytest.mark.skip("Temporarily skipping till the docker image is updated, see #2141")
 @pytest.mark.fluent_version(">=23.2")
 def test_rp_vars_allowed_values(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript


### PR DESCRIPTION
Cherry-picking #2136 for release 0.18 branch to fix the release doc index. We don't need to create a release as there is no code change.

I'll run the release doc CI manually after merging the PR.