### PR TITLE
Test to catch Watchdog launch errors, and improved Watchdog behavior on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include src/ansys/fluent/core/launcher/fluent_launcher_options.json
 include src/ansys/fluent/core/docs/README.rst
 include src/ansys/fluent/core/logging_config.yaml
 include src/ansys/fluent/core/quantity/cfg.yaml
+include src/ansys/fluent/core/launcher/watchdog_exec
 recursive-include src/ansys/fluent/core *pyi
 recursive-include src/ansys/fluent/core/data api_tree_*.pickle

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -1,4 +1,5 @@
 """Module to launch the PyFluent Watchdog to monitor PyFluent and the Fluent server.
+
 Should not be used manually, PyFluent automatically manages it.
 See :func:`~ansys.fluent.core.launcher.launcher.launch_fluent()` `start_watchdog` argument for more details.
 """

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -1,3 +1,8 @@
+"""Module to launch the PyFluent Watchdog to monitor PyFluent and the Fluent server.
+Should not be used manually, PyFluent automatically manages it.
+See :func:`~ansys.fluent.core.launcher.launcher.launch_fluent()` `start_watchdog` argument for more details.
+"""
+
 import os
 from pathlib import Path
 import random
@@ -16,7 +21,27 @@ IDLE_PERIOD = 2  # seconds
 WATCHDOG_INIT_FILE = "watchdog_{}_init"
 
 
-def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] = None):
+def launch(
+    main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] = None
+) -> None:
+    """Function to launch the Watchdog. Automatically used and managed by PyFluent.
+
+    Parameters
+    ----------
+    main_pid : int
+        Process ID of the Python interpreter used to launch PyFluent and the Watchdog.
+    sv_port : int
+        Fluent server port number.
+    sv_password : str
+        Fluent server password.
+    sv_ip : str, optional
+        Fluent server IP.
+
+    Raises
+    ------
+    RuntimeError
+        If Watchdog fails to launch.
+    """
     watchdog_id = "".join(
         random.choices(
             string.ascii_uppercase + string.ascii_lowercase + string.digits, k=6
@@ -142,3 +167,5 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
         logger.warning(
             "PyFluent Watchdog did not initialize correctly, proceeding without it..."
         )
+        if os.getenv("PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR"):
+            raise RuntimeError("PyFluent Watchdog did not initialize correctly.")

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -10,6 +10,8 @@ from typing import Optional
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.utils.execution import timeout_loop
 
+logger = pyfluent.logging.get_logger("pyfluent.launcher")
+
 IDLE_PERIOD = 2  # seconds
 WATCHDOG_INIT_FILE = "watchdog_{}_init"
 
@@ -23,12 +25,10 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
 
     env_watchdog_debug = os.getenv("PYFLUENT_WATCHDOG_DEBUG", "off").upper()
     if env_watchdog_debug in ("1", "ON"):
-        print(
+        logger.debug(
             f"PYFLUENT_WATCHDOG_DEBUG environment variable found, "
             f"enabling debugging for watchdog ID {watchdog_id}..."
         )
-
-    logger = pyfluent.logging.get_logger("pyfluent.launcher")
 
     watchdog_env = os.environ.copy()
 
@@ -59,8 +59,7 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
 
-    watchdog_exec = Path(__file__).parents[0] / "watchdog_exec.pyw"
-    print(watchdog_exec)
+    watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
 
     # Command to be executed by the new process
     command_list = [

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -8,7 +8,7 @@ import time
 from typing import Optional
 
 import ansys.fluent.core as pyfluent
-from ansys.fluent.core.utils.execution import timeout_exec, timeout_loop
+from ansys.fluent.core.utils.execution import timeout_loop
 
 IDLE_PERIOD = 2  # seconds
 WATCHDOG_INIT_FILE = "watchdog_{}_init"
@@ -48,7 +48,7 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
         )
         return
 
-    logger.debug(f"sys.executable: {python_executable}")
+    logger.debug(f"Python sys.executable: {python_executable}")
 
     python_executable = Path(python_executable)
 
@@ -59,10 +59,13 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
 
+    watchdog_exec = Path(__file__).parents[0] / "watchdog_exec.pyw"
+    print(watchdog_exec)
+
     # Command to be executed by the new process
     command_list = [
         python_executable,
-        Path(__file__),
+        watchdog_exec,
         str(main_pid),
         str(sv_ip),
         str(sv_port),
@@ -70,7 +73,8 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
         watchdog_id,
     ]
 
-    logger.debug(f"Starting Watchdog logging to directory {os.getcwd()}")
+    if env_watchdog_debug in ("1", "ON"):
+        logger.debug(f"Starting Watchdog logging to directory {os.getcwd()}")
 
     kwargs = {"env": watchdog_env, "stdin": subprocess.DEVNULL, "close_fds": True}
 
@@ -130,175 +134,11 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
     else:
         if watchdog_err.is_file():
             with open(watchdog_err) as f:
-                err_content = f.read()
+                err_content = f.read().replace("\n", "")
             watchdog_err.unlink()
-            logger.error("Watchdog - %s" % err_content.replace("\n", ""))
+            logger.error("Watchdog - %s" % err_content)
+            if os.getenv("PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR"):
+                raise RuntimeError(err_content)
         logger.warning(
             "PyFluent Watchdog did not initialize correctly, proceeding without it..."
         )
-
-
-if __name__ == "__main__":
-    try:
-        import signal
-
-        import psutil
-
-        from ansys.fluent.core.fluent_connection import FluentConnection, get_container
-
-        print(
-            "Starting PyFluent Watchdog process, do not manually close or terminate this process, "
-            "it will automatically exit once finished.".upper()
-        )
-
-        watchdog_id = sys.argv[5]
-
-        launcher_pid = int(sys.argv[1])
-
-        # Configure logger for Watchdog process
-        log_config = pyfluent.logging.get_default_config()
-        log_config["handlers"]["pyfluent_file"][
-            "filename"
-        ] = f"pyfluent_watchdog_{watchdog_id}.log"
-
-        logger = pyfluent.logging.get_logger("pyfluent.watchdog")
-
-        if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "OFF").upper() in ("1", "ON"):
-            pyfluent.logging.enable(custom_config=log_config)
-            logger.setLevel("DEBUG")
-            logger.handlers = pyfluent.logging.get_logger(
-                "pyfluent.general"
-            ).handlers  # using same handlers as already defined
-
-        def got_sig(signum, _):
-            logger.warning(f"Received {signal.Signals(signum).name}, ignoring it")
-
-        signals = signal.valid_signals()
-        if os.name == "posix":
-            try:
-                signals.remove(signal.SIGCHLD)
-            except AttributeError:
-                pass
-
-        for sig in signals:
-            try:
-                logger.debug(f"Handling signal {sig}")
-                signal.signal(sig, got_sig)
-            except OSError:
-                logger.debug(f"Unable to handle signal {sig}")
-
-        logger.debug(f"Number of arguments: {len(sys.argv)} arguments.")
-        logger.debug(f"Argument list: {sys.argv}")
-        logger.debug(f"Watchdog pid: {os.getpid()}")
-        logger.debug(f"Python launcher pid: {launcher_pid}")
-
-        ip, port, password = sys.argv[2:5]
-
-        logger.debug(f"ip:{ip} port:{port} pass:{password}")
-
-        if ip == "None":
-            ip = None
-
-        logger.info("Attempting to connect to existing Fluent session...")
-
-        kwargs = {
-            "ip": ip,
-            "port": int(port),
-            "password": password,
-            "launcher_args": None,
-            "start_transcript": False,
-            "cleanup_on_exit": True,
-        }
-
-        fluent = timeout_exec(FluentConnection, timeout=IDLE_PERIOD * 5, kwargs=kwargs)
-        if not fluent:
-            logger.error("Fluent connection timeout.")
-            sys.exit()
-
-        if fluent._remote_instance:
-            logger.error("PyFluentWatchdog does not work with remote Fluent instances.")
-            sys.exit()
-
-        logger.info("Fluent connection successful")
-
-        open(WATCHDOG_INIT_FILE.format(watchdog_id), "w").close()
-
-        fluent_host_pid = fluent.connection_properties.fluent_host_pid
-        cortex_pid = fluent.connection_properties.cortex_pid
-        cortex_host = fluent.connection_properties.cortex_host
-
-        logger.debug(f"fluent_host_pid: {fluent_host_pid}")
-        logger.debug(f"cortex_pid: {cortex_pid}")
-        logger.debug(f"cortex_host: {cortex_host}")
-
-        down = []
-        while True:
-            if not psutil.pid_exists(launcher_pid):
-                logger.debug("Python launcher down")
-                down.append("Python")
-            if not fluent.connection_properties.inside_container:
-                if not psutil.pid_exists(cortex_pid):
-                    logger.debug("Cortex down")
-                    down.append("Cortex")
-                if not psutil.pid_exists(fluent_host_pid):
-                    logger.debug("Fluent down")
-                    down.append("Fluent")
-            else:
-                if not get_container(cortex_host):
-                    logger.debug("Fluent container down")
-                    down.append("Fluent container")
-            if down:
-                break
-            logger.info("Waiting...")
-            time.sleep(IDLE_PERIOD)
-
-        logger.info(", ".join(down) + " not running anymore")
-
-        if not fluent.wait_process_finished(wait=IDLE_PERIOD * 5):
-            logger.info(
-                "Fluent processes remain. Checking if Fluent gRPC service is healthy..."
-            )
-            is_serving = timeout_exec(
-                fluent.health_check_service.is_serving, timeout=IDLE_PERIOD * 3
-            )
-
-            if is_serving:
-                logger.info("Fluent client healthy, trying soft exit with timeout...")
-                fluent.exit(timeout=IDLE_PERIOD * 2, timeout_force=False)
-                if not fluent.wait_process_finished(wait=IDLE_PERIOD * 5):
-                    logger.info("Fluent client or container remains...")
-                else:
-                    logger.info("Exit call succeeded.")
-            else:
-                logger.info("Fluent client not healthy.")
-
-        if fluent.connection_properties.inside_container:
-            logger.info(
-                "Running Fluent cleanup scripts inside container if they are still available..."
-            )
-            fluent.force_exit_container()
-            response = timeout_loop(
-                get_container,
-                IDLE_PERIOD * 3,
-                args=(cortex_host,),
-                expected="falsy",
-            )
-            if response:
-                logger.info(
-                    "Fluent container still alive somehow, directly terminating it..."
-                )
-                subprocess.run(["docker", "kill", cortex_host])
-            else:
-                logger.info("Fluent container successfully shut down.")
-        else:
-            logger.info(
-                "Running local Fluent cleanup scripts if they are still available..."
-            )
-            fluent.force_exit()
-
-        logger.info("Done.")
-
-    except Exception as exc:
-        with open("pyfluent_watchdog.err", "w") as file:
-            file.write(f"{type(exc).__name__}: {exc}")
-        raise

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -134,11 +134,12 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
     else:
         if watchdog_err.is_file():
             with open(watchdog_err) as f:
-                err_content = f.read().replace("\n", "")
+                err_content = "Watchdog - %s" % f.read().replace("\n", "")
             watchdog_err.unlink()
-            logger.error("Watchdog - %s" % err_content)
             if os.getenv("PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR"):
                 raise RuntimeError(err_content)
+            else:
+                logger.error(err_content)
         logger.warning(
             "PyFluent Watchdog did not initialize correctly, proceeding without it..."
         )

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -135,10 +135,10 @@ def launch(main_pid: int, sv_port: int, sv_password: str, sv_ip: Optional[str] =
             with open(watchdog_err) as f:
                 err_content = "Watchdog - %s" % f.read().replace("\n", "")
             watchdog_err.unlink()
+            logger.error(err_content)
             if os.getenv("PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR"):
                 raise RuntimeError(err_content)
-            else:
-                logger.error(err_content)
+
         logger.warning(
             "PyFluent Watchdog did not initialize correctly, proceeding without it..."
         )

--- a/src/ansys/fluent/core/launcher/watchdog_exec
+++ b/src/ansys/fluent/core/launcher/watchdog_exec
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Watchdog execution script, should not be manually executed or imported as a module.
+
 PyFluent will handle the Watchdog process, see ``launch_fluent`` documentation.
 """
 

--- a/src/ansys/fluent/core/launcher/watchdog_exec
+++ b/src/ansys/fluent/core/launcher/watchdog_exec
@@ -99,17 +99,17 @@ if __name__ == "__main__":
         logger.debug(f"cortex_host: {cortex_host}")
 
         down = []
+
+        def check_pid_down(pid, name):
+            if not psutil.pid_exists(pid):
+                logger.debug(name + " down")
+                down.append(name)
+
         while True:
-            if not psutil.pid_exists(launcher_pid):
-                logger.debug("Python launcher down")
-                down.append("Python")
+            check_pid_down(launcher_pid, "Python launcher")
             if not fluent.connection_properties.inside_container:
-                if not psutil.pid_exists(cortex_pid):
-                    logger.debug("Cortex down")
-                    down.append("Cortex")
-                if not psutil.pid_exists(fluent_host_pid):
-                    logger.debug("Fluent down")
-                    down.append("Fluent")
+                check_pid_down(cortex_pid, "Cortex")
+                check_pid_down(fluent_host_pid, "Fluent")
             else:
                 if not get_container(cortex_host):
                     logger.debug("Fluent container down")

--- a/src/ansys/fluent/core/launcher/watchdog_exec
+++ b/src/ansys/fluent/core/launcher/watchdog_exec
@@ -1,23 +1,22 @@
-"""Watchdog execution script, should not be executed directly or imported as a module.
-PyFluent will handle the Watchdog process, see the ``launch_fluent`` documentation.
+#!/usr/bin/env python
+"""Watchdog execution script, should not be manually executed or imported as a module.
+PyFluent will handle the Watchdog process, see ``launch_fluent`` documentation.
 """
 
 if __name__ == "__main__":
     try:
         import os
+        import signal
         import subprocess
         import sys
         import time
 
-        import ansys.fluent.core as pyfluent
-        from ansys.fluent.core.utils.execution import timeout_exec, timeout_loop
+        import psutil
         from watchdog import IDLE_PERIOD, WATCHDOG_INIT_FILE
 
-        import signal
-
-        import psutil
-
+        import ansys.fluent.core as pyfluent
         from ansys.fluent.core.fluent_connection import FluentConnection, get_container
+        from ansys.fluent.core.utils.execution import timeout_exec, timeout_loop
 
         watchdog_id = sys.argv[5]
 
@@ -38,10 +37,8 @@ if __name__ == "__main__":
                 "pyfluent.general"
             ).handlers  # using same handlers as already defined
 
-
         def got_sig(signum, _):
             logger.warning(f"Received {signal.Signals(signum).name}, ignoring it")
-
 
         signals = signal.valid_signals()
         if os.name == "posix":

--- a/src/ansys/fluent/core/launcher/watchdog_exec.pyw
+++ b/src/ansys/fluent/core/launcher/watchdog_exec.pyw
@@ -1,0 +1,174 @@
+"""Watchdog execution script, should not be executed directly or imported as a module.
+PyFluent will handle the Watchdog process, see the ``launch_fluent`` documentation.
+"""
+
+if __name__ == "__main__":
+    try:
+        import os
+        import subprocess
+        import sys
+        import time
+
+        import ansys.fluent.core as pyfluent
+        from ansys.fluent.core.utils.execution import timeout_exec, timeout_loop
+        from watchdog import IDLE_PERIOD, WATCHDOG_INIT_FILE
+
+        import signal
+
+        import psutil
+
+        from ansys.fluent.core.fluent_connection import FluentConnection, get_container
+
+        watchdog_id = sys.argv[5]
+
+        launcher_pid = int(sys.argv[1])
+
+        # Configure logger for Watchdog process
+        log_config = pyfluent.logging.get_default_config()
+        log_config["handlers"]["pyfluent_file"][
+            "filename"
+        ] = f"pyfluent_watchdog_{watchdog_id}.log"
+
+        logger = pyfluent.logging.get_logger("pyfluent.watchdog")
+
+        if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "OFF").upper() in ("1", "ON"):
+            pyfluent.logging.enable(custom_config=log_config)
+            logger.setLevel("DEBUG")
+            logger.handlers = pyfluent.logging.get_logger(
+                "pyfluent.general"
+            ).handlers  # using same handlers as already defined
+
+
+        def got_sig(signum, _):
+            logger.warning(f"Received {signal.Signals(signum).name}, ignoring it")
+
+
+        signals = signal.valid_signals()
+        if os.name == "posix":
+            try:
+                signals.remove(signal.SIGCHLD)
+            except AttributeError:
+                pass
+
+        for sig in signals:
+            try:
+                logger.debug(f"Handling signal {sig}")
+                signal.signal(sig, got_sig)
+            except OSError:
+                logger.debug(f"Unable to handle signal {sig}")
+
+        logger.debug(f"Number of arguments: {len(sys.argv)} arguments.")
+        logger.debug(f"Argument list: {sys.argv}")
+        logger.debug(f"Watchdog pid: {os.getpid()}")
+        logger.debug(f"Python launcher pid: {launcher_pid}")
+
+        ip, port, password = sys.argv[2:5]
+
+        logger.debug(f"ip:{ip} port:{port} pass:{password}")
+
+        if ip == "None":
+            ip = None
+
+        logger.info("Attempting to connect to existing Fluent session...")
+
+        kwargs = {
+            "ip": ip,
+            "port": int(port),
+            "password": password,
+            "launcher_args": None,
+            "start_transcript": False,
+            "cleanup_on_exit": True,
+        }
+
+        fluent = timeout_exec(FluentConnection, timeout=IDLE_PERIOD * 5, kwargs=kwargs)
+        if not fluent:
+            logger.error("Fluent connection timeout.")
+            sys.exit()
+
+        if fluent._remote_instance:
+            logger.error("PyFluentWatchdog does not work with remote Fluent instances.")
+            sys.exit()
+
+        logger.info("Fluent connection successful")
+
+        open(WATCHDOG_INIT_FILE.format(watchdog_id), "w").close()
+
+        fluent_host_pid = fluent.connection_properties.fluent_host_pid
+        cortex_pid = fluent.connection_properties.cortex_pid
+        cortex_host = fluent.connection_properties.cortex_host
+
+        logger.debug(f"fluent_host_pid: {fluent_host_pid}")
+        logger.debug(f"cortex_pid: {cortex_pid}")
+        logger.debug(f"cortex_host: {cortex_host}")
+
+        down = []
+        while True:
+            if not psutil.pid_exists(launcher_pid):
+                logger.debug("Python launcher down")
+                down.append("Python")
+            if not fluent.connection_properties.inside_container:
+                if not psutil.pid_exists(cortex_pid):
+                    logger.debug("Cortex down")
+                    down.append("Cortex")
+                if not psutil.pid_exists(fluent_host_pid):
+                    logger.debug("Fluent down")
+                    down.append("Fluent")
+            else:
+                if not get_container(cortex_host):
+                    logger.debug("Fluent container down")
+                    down.append("Fluent container")
+            if down:
+                break
+            logger.info("Waiting...")
+            time.sleep(IDLE_PERIOD)
+
+        logger.info(", ".join(down) + " not running anymore")
+
+        if not fluent.wait_process_finished(wait=IDLE_PERIOD * 5):
+            logger.info(
+                "Fluent processes remain. Checking if Fluent gRPC service is healthy..."
+            )
+            is_serving = timeout_exec(
+                fluent.health_check_service.is_serving, timeout=IDLE_PERIOD * 3
+            )
+
+            if is_serving:
+                logger.info("Fluent client healthy, trying soft exit with timeout...")
+                fluent.exit(timeout=IDLE_PERIOD * 2, timeout_force=False)
+                if not fluent.wait_process_finished(wait=IDLE_PERIOD * 5):
+                    logger.info("Fluent client or container remains...")
+                else:
+                    logger.info("Exit call succeeded.")
+            else:
+                logger.info("Fluent client not healthy.")
+
+        if fluent.connection_properties.inside_container:
+            logger.info(
+                "Running Fluent cleanup scripts inside container if they are still available..."
+            )
+            fluent.force_exit_container()
+            response = timeout_loop(
+                get_container,
+                IDLE_PERIOD * 3,
+                args=(cortex_host,),
+                expected="falsy",
+            )
+            if response:
+                logger.info(
+                    "Fluent container still alive somehow, directly terminating it..."
+                )
+                subprocess.run(["docker", "kill", cortex_host])
+            else:
+                logger.info("Fluent container successfully shut down.")
+        else:
+            logger.info(
+                "Running local Fluent cleanup scripts if they are still available..."
+            )
+            fluent.force_exit()
+
+        logger.info("Done.")
+
+    except Exception as exc:
+        with open("pyfluent_watchdog.err", "w") as file:
+            file.write(f"{type(exc).__name__}: {exc}")
+        raise

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -182,3 +182,8 @@ def test_get_fluent_exe_path_from_pyfluent_fluent_root(monkeypatch):
     else:
         expected_path = Path("dev/vNNN/fluent") / "bin" / "fluent"
     assert get_fluent_exe_path(product_version="23.1.0") == expected_path
+
+
+def test_watchdog_launch(monkeypatch):
+    monkeypatch.setenv("PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR", "1")
+    pyfluent.launch_fluent(start_watchdog=True)


### PR DESCRIPTION
- New test that fails when Watchdog launch errors occur: `test_watchdog_launch`
- Now using no file extension for the script of the Watchdog process (code script was simply moved from `watchdog.py` to `watchdog_exec` file, no significant changes, see below). Changing the file extension makes no difference on Linux, but can circumvent inappropriately configured user environments on Windows (e.g., when for some reason a Windows code editor is configured to interfere with the execution of `.py` files).
- Few minor watchdog updates.
- Added docstrings and a bit of code documentation (note this shouldn't show up anywhere in the online documentation to users).

Diff between original `watchdog.py` and new `watchdog_exec` (as of `c427e2f`):
![image](https://github.com/ansys/pyfluent/assets/132297401/8a09d423-cbc4-4c18-a988-f621c71a490c)
