### PR TITLE
fix tensor type for displacement variable

### DIFF
--- a/src/ansys/fluent/core/systemcoupling.py
+++ b/src/ansys/fluent/core/systemcoupling.py
@@ -101,7 +101,7 @@ class SystemCoupling:
             if tensor_type_elem is not None:
                 return tensor_type_elem.text
 
-            if get_name(variable) in {"force", "lorentz-force"}:
+            if get_name(variable) in {"displacement", "force", "lorentz-force"}:
                 return "Vector"
             else:
                 return "Scalar"


### PR DESCRIPTION
For System Coupling FSI case, when setting up the Fluent problem, the tensor type for the displacement variable was mistakenly set to `Scalar`.