### PR TITLE
Expose settings root like in pyconsole.

### DIFF
--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -228,3 +228,9 @@ class Solver(BaseSession):
             fut.add_done_callback(functools.partial(Solver._sync_from_future, self))
         else:
             self.file.read(file_type="case", file_name=file_name)
+
+    def __call__(self):
+        return self._root.get_state()
+
+    def __getattr__(self, attr):
+        return getattr(self._root, attr)

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -231,6 +231,3 @@ class Solver(BaseSession):
 
     def __call__(self):
         return self._root.get_state()
-
-    def __getattr__(self, attr):
-        return getattr(self._root, attr)


### PR DESCRIPTION
```
>>> import ansys.fluent.core as pf
>>> solver = pf.launch_fluent(...)
>>> solver()
```
Solver object is callable now.