### PR TITLE
Monthly dependency bot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,10 @@ updates:
     directory: "/requirements" # Location of package manifests
     insecure-external-code-execution: allow
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "Maintenance"
       - "Dependencies"
-    ignore:
-      - dependency-name: "vtk"
-      - dependency-name: "grpcio"
     groups:
       dependencies:
         patterns:
@@ -22,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "Maintenance"
     groups:


### PR DESCRIPTION
- As discussed in the team meeting, let's try monthly dependabot PRs rather than weekly or daily.
- Removed unnecessary ignores: `vtk` as `pyfluent` core does not depend on `vtk`, that dependency is in `pyfluent-visualization`; and `grpcio` as that one is in the `setup.py` file which is not managed by dependabot.