### PR TITLE
More robust Windows launch command for Watchdog

### DIFF
--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -78,16 +78,15 @@ def launch(
 
     python_executable = Path(python_executable)
 
+    watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
+
     if os.name == "nt":
         pythonw_executable = python_executable.parent / "pythonw.exe"
         if pythonw_executable.exists():
             python_executable = '"' + str(pythonw_executable) + '"'
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
-        watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
         watchdog_exec = '"' + str(watchdog_exec) + '"'
-    else:
-        watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
 
     # Command to be executed by the new process
     command_list = [

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -83,9 +83,10 @@ def launch(
     if os.name == "nt":
         pythonw_executable = python_executable.parent / "pythonw.exe"
         if pythonw_executable.exists():
-            python_executable = '"' + str(pythonw_executable) + '"'
+            python_executable = pythonw_executable
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
+        python_executable = '"' + str(python_executable) + '"'
         watchdog_exec = '"' + str(watchdog_exec) + '"'
 
     # Command to be executed by the new process
@@ -149,7 +150,7 @@ def launch(
 
     logger.info(f"Waiting for Watchdog to initialize, then proceeding...")
     file_exists = timeout_loop(
-        lambda: init_file.is_file() or watchdog_err.is_file(), 10.0
+        lambda: init_file.is_file() or watchdog_err.is_file(), 30.0
     )
 
     if file_exists and init_file.is_file():

--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -81,11 +81,13 @@ def launch(
     if os.name == "nt":
         pythonw_executable = python_executable.parent / "pythonw.exe"
         if pythonw_executable.exists():
-            python_executable = pythonw_executable
+            python_executable = '"' + str(pythonw_executable) + '"'
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
-
-    watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
+        watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
+        watchdog_exec = '"' + str(watchdog_exec) + '"'
+    else:
+        watchdog_exec = Path(__file__).parents[0] / "watchdog_exec"
 
     # Command to be executed by the new process
     command_list = [
@@ -129,12 +131,11 @@ def launch(
 
     if os.name == "nt":
         # https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start
-        os_cmd = ["start"]
+        cmd_send = 'start "" ' + " ".join(command_list)
     else:
-        os_cmd = []
+        cmd_send = command_list
 
-    cmd_send = os_cmd + command_list
-    logger.info(f"Watchdog command list: {cmd_send}")
+    logger.info(f"Watchdog command: {cmd_send}")
 
     init_file = Path(WATCHDOG_INIT_FILE.format(watchdog_id))
     watchdog_err = Path("pyfluent_watchdog.err")


### PR DESCRIPTION
Attempting to make the command as explicit as possible, to see if this error, that only occurs in some systems, and that I have been unable to reproduce, is finally resolved without requiring the user to change anything about their system

Changing from command list, which seems to have behavior that can be system dependent on Windows, to a command string, which should be more robust