### PR TITLE
Making h5py an optional dependency, not installed by default

### DIFF
--- a/requirements/requirements_tests.txt
+++ b/requirements/requirements_tests.txt
@@ -2,3 +2,4 @@ pytest
 pytest-mock
 pytest-cov
 psutil>=5.9.1
+h5py>=3.8.0

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,15 @@ install_requires = [
     "numpy>=1.21.5",
     "platformdirs>=3.5.1",
     "pandas>=1.1.5",
-    "h5py>=3.8.0",
     "lxml>=4.9.2",
     "pyyaml>=6.0",
     "docker>=6.1.3",
     "psutil>=5.9.5",
 ]
 
+extras_require = {
+    "reader": ["h5py>=3.8.0"],
+}
 
 packages = []
 for package in find_namespace_packages(where="src", include="ansys*"):
@@ -65,6 +67,7 @@ setup(
     url="https://github.com/ansys/pyfluent",
     python_requires=">=3.9",
     install_requires=install_requires,
+    extras_require=extras_require,
     project_urls={
         "Documentation": "https://fluent.docs.pyansys.com/",
         "Source": "https://github.com/ansys/pyfluent",

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -34,9 +34,11 @@ logger = logging.getLogger("pyfluent.general")
 
 try:
     import h5py
-except ModuleNotFoundError:
-    logger.error("Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install.")
-    raise
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install them."
+    ) from exc
+
 
 class InputParameterOld:
     """Represents an input parameter (old format).

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -16,13 +16,13 @@ Example
 """
 import codecs
 import gzip
+import logging
 import os
 from os.path import dirname
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 import xml.etree.ElementTree as ET
 
-import h5py
 from lxml import etree
 import numpy as np
 
@@ -30,6 +30,13 @@ from ansys.fluent.core.solver.error_message import allowed_name_error_message
 
 from . import lispy
 
+logger = logging.getLogger("pyfluent.general")
+
+try:
+    import h5py
+except ModuleNotFoundError:
+    logger.error("Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install.")
+    raise
 
 class InputParameterOld:
     """Represents an input parameter (old format).

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -16,7 +16,6 @@ Example
 """
 import codecs
 import gzip
-import logging
 import os
 from os.path import dirname
 from pathlib import Path
@@ -29,8 +28,6 @@ import numpy as np
 from ansys.fluent.core.solver.error_message import allowed_name_error_message
 
 from . import lispy
-
-logger = logging.getLogger("pyfluent.general")
 
 try:
     import h5py

--- a/src/ansys/fluent/core/filereader/data_file.py
+++ b/src/ansys/fluent/core/filereader/data_file.py
@@ -28,9 +28,10 @@ logger = logging.getLogger("pyfluent.general")
 
 try:
     import h5py
-except ModuleNotFoundError:
-    logger.error("Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install.")
-    raise
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install them."
+    ) from exc
 
 
 class DataFile:

--- a/src/ansys/fluent/core/filereader/data_file.py
+++ b/src/ansys/fluent/core/filereader/data_file.py
@@ -12,17 +12,25 @@ Example
 
     >>> reader = DataFile(data_file_name=data_file_name) # Instantiate a DataFile class
 """
+import logging
 import os
 from os.path import dirname
 from pathlib import Path
 from typing import Optional
 import xml.etree.ElementTree as ET
 
-import h5py
 from lxml import etree
 import numpy as np
 
 from . import lispy
+
+logger = logging.getLogger("pyfluent.general")
+
+try:
+    import h5py
+except ModuleNotFoundError:
+    logger.error("Missing dependencies, use 'pip install ansys-fluent-core[reader]' to install.")
+    raise
 
 
 class DataFile:

--- a/src/ansys/fluent/core/filereader/data_file.py
+++ b/src/ansys/fluent/core/filereader/data_file.py
@@ -12,7 +12,6 @@ Example
 
     >>> reader = DataFile(data_file_name=data_file_name) # Instantiate a DataFile class
 """
-import logging
 import os
 from os.path import dirname
 from pathlib import Path
@@ -23,8 +22,6 @@ from lxml import etree
 import numpy as np
 
 from . import lispy
-
-logger = logging.getLogger("pyfluent.general")
 
 try:
     import h5py


### PR DESCRIPTION
Addresses remaining vulnerability in https://github.com/ansys/pyfluent/issues/1552

To be superseded by https://github.com/ansys/pyfluent/issues/2096 when the `pyfluent-reader` package is published

By default, `pip install ansys-fluent-core` or installing from a pre-built wheel file won't install `h5py` anymore.

To get data and case file reader functionality, users will need to: 
- `pip install ansys-fluent-core[reader]`
- `pip install -e .[reader]` for development
- `pip install ansys_fluent_core-0.19.dev0-py3-none-any.whl[reader]` from a wheel file