### PR TITLE
Prepend working dir to .scp file name

### DIFF
--- a/src/ansys/fluent/core/systemcoupling.py
+++ b/src/ansys/fluent/core/systemcoupling.py
@@ -72,7 +72,8 @@ class SystemCoupling:
     def __get_syc_setup(self) -> dict:
         def get_scp_string() -> str:
             """Get SCP file contents in the form of the XML string."""
-            scp_file_name = "fluent.scp"
+            fluent_cwd = self._solver.connection_properties.cortex_pwd
+            scp_file_name = os.path.join(fluent_cwd, "fluent.scp")
             self._solver.setup.models.system_coupling.write_scp_file(
                 file_name=scp_file_name
             )


### PR DESCRIPTION
To correct issue https://github.com/ansys/pyfluent/issues/2179

Obtains Fluent's working directory using the `cortex_pwd` variable and prepends that to the `.scp` file name in `get_scp_string()`.