### PR TITLE
Fix for #974 and #1744

### DIFF
--- a/src/ansys/fluent/core/streaming_services/monitor_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/monitor_streaming.py
@@ -117,7 +117,7 @@ class MonitorsManager(StreamingService):
                 if df.empty
                 else (
                     df.index.to_numpy(),
-                    {column: df[[column]].to_numpy() for column in df.columns},
+                    {column: df[column].to_numpy() for column in df.columns},
                 )
             )
 
@@ -177,9 +177,9 @@ class MonitorsManager(StreamingService):
                             new_df = pd.DataFrame([monitor_data], columns=monitors)
                             new_df.set_index("xvalues", inplace=True)
                             if df.empty:
-                                df = new_df
+                                df_data["df"] = new_df
                             else:
-                                df = pd.concat([df, new_df])
+                                df_data["df"] = pd.concat([df, new_df])
                             for callback_map in self._service_callbacks.values():
                                 callback, args, kwargs = callback_map
                                 callback(*args, **kwargs)

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -33,7 +33,7 @@ def test_1364(new_solver_session):
     assert report_def.expr_list.allowed_values() == None
 
 
-def test_974(new_solver_session):
+def test_637_974_1744(new_solver_session):
     solver_session = new_solver_session
 
     import_case = examples.download_file(
@@ -51,7 +51,15 @@ def test_974(new_solver_session):
     solver_session.tui.solve.set.number_of_iterations(15)
     solver_session.tui.solve.iterate()
 
-    solver_session.monitors_manager.get_monitor_set_names()
+    monitors_list = solver_session.monitors_manager.get_monitor_set_names()
+
+    assert monitors_list == [
+        "residual",
+        "mass-bal-rplot",
+        "mass-tot-rplot",
+        "mass-in-rplot",
+        "point-vel-rplot",
+    ]
 
     mp = solver_session.monitors_manager.get_monitor_set_data(
         monitor_set_name="residual"

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -31,3 +31,30 @@ def test_1364(new_solver_session):
     assert report_def.zone_names.allowed_values() == ["fluid"]
 
     assert report_def.expr_list.allowed_values() == None
+
+
+def test_974(new_solver_session):
+    solver_session = new_solver_session
+
+    import_case = examples.download_file(
+        file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
+    )
+
+    import_data = examples.download_file(
+        file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
+    )
+
+    solver_session.tui.file.read_case(import_case)
+
+    solver_session.tui.file.read_data(import_data)
+
+    solver_session.tui.solve.set.number_of_iterations(15)
+    solver_session.tui.solve.iterate()
+
+    solver_session.monitors_manager.get_monitor_set_names()
+
+    mp = solver_session.monitors_manager.get_monitor_set_data(
+        monitor_set_name="residual"
+    )
+
+    assert mp


### PR DESCRIPTION
```
import ansys.fluent.core as pyfluent 
from ansys.fluent.core import examples

import_case = examples.download_file(
    file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
)

import_data = examples.download_file(
    file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
)                    

solver_session = pyfluent.launch_fluent(                                        
    precision="double", processor_count=2, start_transcript=False, mode="solver",
    show_gui=True, cleanup_on_exit=False
)

solver_session.tui.file.read_case(import_case)

solver_session.tui.file.read_data(import_data)

solver_session.tui.solve.set.number_of_iterations(15)
solver_session.tui.solve.iterate()

solver_session.monitors_manager.get_monitor_set_names()

mp = solver_session.monitors_manager.get_monitor_set_data(monitor_set_name='residual')
print(mp)
```

Output - 

```
Checking if specified file already exists...
File already exists. File path:
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.cas.h5
Checking if specified file already exists...
File already exists. File path:
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.dat.h5
pyfluent.tui WARNING: Currently calling the TUI commands in a generic manner. Please run `python codegen/allapigen.py` from the top-level pyfluent directory to generate the local TUI commands classes.
The following solver settings object method could also be used to execute the above command:
<solver_session>.file.read_case(file_name = r"C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.cas.h5")
The following solver settings object method could also be used to execute the above command:
<solver_session>.file.read_data(file_name = r"C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.dat.h5")
The following solver settings object method could also be used to execute the above command:
<solver_session>.solution.run_calculation.iter_count = 15
The following solver settings object method could also be used to execute the above command:
<solver_session>.solution.run_calculation.iterate(iter_count = 15)
(array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
       35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 44, 45], dtype=int64), {'continuity': array([1.00000000e+00, 1.00000000e+00, 8.36917055e-01, 5.45950801e-01,
       3.47620491e-01, 2.32877531e-01, 1.59166752e-01, 1.11595319e-01,
       8.04296952e-02, 5.95899872e-02, 4.53222154e-02, 3.51197214e-02,
       2.76886175e-02, 2.19666663e-02, 1.74638376e-02, 1.40669007e-02,
       1.15818476e-02, 9.72061353e-03, 8.26304474e-03, 7.05184957e-03,
       5.98971189e-03, 5.04497684e-03, 4.22540179e-03, 3.52872348e-03,
       2.94162004e-03, 2.45218363e-03, 2.05642556e-03, 1.73663352e-03,
       1.48227186e-03, 1.28427999e-03, 1.12624318e-03, 1.00725462e-03,
       9.17881388e-04, 8.47028089e-04, 7.90419734e-04, 7.40851569e-04,
       6.93607822e-04, 6.44200382e-04, 5.94617753e-04, 5.43567871e-04,
       4.94113769e-04, 4.44761398e-04, 3.97861967e-04, 3.53216208e-04,
       3.53216208e-04, 3.11118026e-04]), 'x-velocity': array([1.48353216e+00, 1.20950124e-01, 2.64314515e-02, 1.56680408e-02,
       8.81542862e-03, 5.62448147e-03, 4.06140696e-03, 3.20630829e-03,
       2.63399054e-03, 2.19650274e-03, 1.82798270e-03, 1.52983718e-03,
       1.30228529e-03, 1.14535669e-03, 1.05295481e-03, 1.01759650e-03,
       1.01954890e-03, 1.01858392e-03, 9.91929929e-04, 9.35988664e-04,
       8.56528711e-04, 7.63426520e-04, 6.66008503e-04, 5.72268505e-04,
       4.86112358e-04, 4.09685478e-04, 3.43804537e-04, 2.87860890e-04,
       2.42132506e-04, 2.05864162e-04, 1.77956632e-04, 1.57722786e-04,
       1.43752815e-04, 1.34096439e-04, 1.26753484e-04, 1.20520230e-04,
       1.14385423e-04, 1.07694898e-04, 1.00277800e-04, 9.22655859e-05,
       8.39992760e-05, 7.57504256e-05, 6.77262982e-05, 6.00704230e-05,
       6.00704230e-05, 5.29154300e-05]), 'y-velocity': array([1.44363263e+02, 2.03493106e-01, 5.22753671e-02, 2.48859683e-02,
       1.30987577e-02, 8.09859769e-03, 5.70831376e-03, 4.32061679e-03,
       3.34023251e-03, 2.58169336e-03, 1.98894956e-03, 1.55253377e-03,
       1.24749486e-03, 1.03389006e-03, 8.82127172e-04, 7.70499479e-04,
       6.82751512e-04, 6.09493454e-04, 5.46829489e-04, 4.91450392e-04,
       4.40313699e-04, 3.94037479e-04, 3.49628538e-04, 3.07532802e-04,
       2.67728724e-04, 2.31592047e-04, 1.98563266e-04, 1.69474812e-04,
       1.44716326e-04, 1.24399356e-04, 1.08286876e-04, 9.56832610e-05,
       8.62368520e-05, 7.92775945e-05, 7.40927760e-05, 6.99424122e-05,
       6.63530501e-05, 6.28539298e-05, 5.91335431e-05, 5.51307934e-05,
       5.08278100e-05, 4.64302854e-05, 4.19765876e-05, 3.76057909e-05,
       3.76057909e-05, 3.34056275e-05]), 'z-velocity': array([1.42243312e+00, 7.14543119e-02, 1.52332013e-02, 9.99977058e-03,
       5.90739818e-03, 4.00064306e-03, 2.90344069e-03, 2.25638470e-03,
       1.82124609e-03, 1.50602629e-03, 1.24784990e-03, 1.03561065e-03,
       8.62696344e-04, 7.29185503e-04, 6.40461790e-04, 5.88694565e-04,
       5.62789594e-04, 5.43634802e-04, 5.18651683e-04, 4.85530582e-04,
       4.44238593e-04, 3.97150708e-04, 3.47629985e-04, 2.99403947e-04,
       2.54513593e-04, 2.14215991e-04, 1.79613441e-04, 1.50599279e-04,
       1.26963529e-04, 1.08032710e-04, 9.35082484e-05, 8.27241609e-05,
       7.48985288e-05, 6.94371616e-05, 6.56065956e-05, 6.28310447e-05,
       6.04479527e-05, 5.78098500e-05, 5.48129852e-05, 5.14801528e-05,
       4.78870430e-05, 4.40553060e-05, 4.01784962e-05, 3.63942736e-05,
       3.63942736e-05, 3.27288489e-05]), 'energy': array([1.58919034e-02, 4.96530114e-04, 2.98779112e-04, 1.74144137e-04,
       1.23322521e-04, 8.86261135e-05, 6.41658991e-05, 4.66811030e-05,
       3.47454474e-05, 2.68273903e-05, 2.14129742e-05, 1.80486446e-05,
       1.61780785e-05, 1.52052200e-05, 1.45279668e-05, 1.38999410e-05,
       1.31075192e-05, 1.21800075e-05, 1.11078075e-05, 9.92453922e-06,
       8.70707628e-06, 7.52409227e-06, 6.41609784e-06, 5.46671095e-06,
       4.63662393e-06, 3.91995633e-06, 3.33817626e-06, 2.89255257e-06,
       2.57611984e-06, 2.35826484e-06, 2.23039447e-06, 2.15928790e-06,
       2.11266348e-06, 2.05781556e-06, 1.97629062e-06, 1.86589657e-06,
       1.72691226e-06, 1.57001490e-06, 1.40402708e-06, 1.23767902e-06,
       1.07878835e-06, 9.31186815e-07, 8.03196106e-07, 6.91378423e-07,
       6.91378423e-07, 5.89180726e-07]), 'k': array([3.46353759e-04, 3.63649181e-01, 1.47020063e-01, 1.24311111e-01,
       1.04142225e-01, 8.70721125e-02, 6.91695870e-02, 5.25741356e-02,
       3.99372547e-02, 3.07555027e-02, 2.41649472e-02, 1.92788508e-02,
       1.56678257e-02, 1.26514800e-02, 1.03424641e-02, 9.02024886e-03,
       8.47480877e-03, 8.20429999e-03, 7.83584447e-03, 7.23936827e-03,
       6.49223063e-03, 5.69080643e-03, 4.89664703e-03, 4.16779064e-03,
       3.55469930e-03, 3.01434995e-03, 2.58337754e-03, 2.22894980e-03,
       1.94703507e-03, 1.72981411e-03, 1.56745948e-03, 1.45466224e-03,
       1.37841678e-03, 1.32021869e-03, 1.26797891e-03, 1.21577754e-03,
       1.15824859e-03, 1.08922757e-03, 1.01057123e-03, 9.26848381e-04,
       8.41942470e-04, 7.56933514e-04, 6.76101535e-04, 6.00374795e-04,
       6.00374795e-04, 5.30631510e-04]), 'omega': array([6.68779527e+03, 1.47903738e-01, 1.48400619e-01, 1.34565521e-01,
       1.07899619e-01, 8.57998915e-02, 6.65786549e-02, 5.09761101e-02,
       3.93529484e-02, 3.12233341e-02, 2.55616667e-02, 2.17436420e-02,
       1.87862994e-02, 1.65459470e-02, 1.48050278e-02, 1.33493873e-02,
       1.21494978e-02, 1.10761414e-02, 1.01033719e-02, 9.14989802e-03,
       8.23363173e-03, 7.35706290e-03, 6.54085199e-03, 5.75531688e-03,
       5.04914249e-03, 4.42218393e-03, 3.85254522e-03, 3.35144987e-03,
       2.94856312e-03, 2.63845130e-03, 2.42107057e-03, 2.27742390e-03,
       2.18295485e-03, 2.11530236e-03, 2.04325958e-03, 1.95972736e-03,
       1.86444093e-03, 1.75465474e-03, 1.62922909e-03, 1.49014612e-03,
       1.34344814e-03, 1.19605386e-03, 1.05424477e-03, 9.22703506e-04,
       9.22703506e-04, 8.03312192e-04])})
```