### PR TITLE
Fix for #2188

### DIFF
--- a/src/ansys/fluent/core/streaming_services/monitor_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/monitor_streaming.py
@@ -192,6 +192,8 @@ class MonitorsManager(StreamingService):
             self._monitors_info = self._streaming_service.get_monitors_info()
             self._data_frames = {}
             for monitor_set_name, monitor_set_info in self._monitors_info.items():
+                if "monitors" not in monitor_set_info:
+                    continue
                 self._data_frames[monitor_set_name] = {}
                 monitors_name = list(monitor_set_info["monitors"]) + ["xvalues"]
                 df = pd.DataFrame([], columns=monitors_name)

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -73,6 +73,7 @@ def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     sample_report_plot.report_defs = "mass-bal"
 
     solver_session.solution.initialization.hybrid_initialize()
+    solver_session.tui.solve.iterate()
 
     new_monitors_list = solver_session.monitors_manager.get_monitor_set_names()
 

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -33,6 +33,7 @@ def test_allowed_values_on_report_definitions_1364(new_solver_session):
     assert report_def.expr_list.allowed_values() == None
 
 
+@pytest.mark.fluent_version(">=23.2")
 def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     solver_session = new_solver_session
 

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -6,7 +6,7 @@ from ansys.fluent.core import examples
 
 @pytest.mark.nightly
 @pytest.mark.fluent_version("==23.2")
-def test_allowed_values_of_report_definitions_1364(new_solver_session):
+def test_allowed_values_on_report_definitions_1364(new_solver_session):
     solver = new_solver_session
 
     import_file_name = examples.download_file(
@@ -33,7 +33,7 @@ def test_allowed_values_of_report_definitions_1364(new_solver_session):
     assert report_def.expr_list.allowed_values() == None
 
 
-def test_monitors_list_and_monitor_set_data_637_974_1744(new_solver_session):
+def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     solver_session = new_solver_session
 
     import_case = examples.download_file(
@@ -66,3 +66,21 @@ def test_monitors_list_and_monitor_set_data_637_974_1744(new_solver_session):
     )
 
     assert mp
+
+    sample_report_plot = solver_session.solution.monitor.report_plots.create(
+        "sample-report-plot"
+    )
+    sample_report_plot.report_defs = "mass-bal"
+
+    solver_session.solution.initialization.hybrid_initialize()
+
+    new_monitors_list = solver_session.monitors_manager.get_monitor_set_names()
+
+    assert new_monitors_list == [
+        "residual",
+        "mass-bal-rplot",
+        "mass-tot-rplot",
+        "mass-in-rplot",
+        "point-vel-rplot",
+        "sample-report-plot",
+    ]

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -6,7 +6,7 @@ from ansys.fluent.core import examples
 
 @pytest.mark.nightly
 @pytest.mark.fluent_version("==23.2")
-def test_1364(new_solver_session):
+def test_allowed_values_of_report_definitions_1364(new_solver_session):
     solver = new_solver_session
 
     import_file_name = examples.download_file(
@@ -33,7 +33,7 @@ def test_1364(new_solver_session):
     assert report_def.expr_list.allowed_values() == None
 
 
-def test_637_974_1744(new_solver_session):
+def test_monitors_list_and_monitor_set_data_637_974_1744(new_solver_session):
     solver_session = new_solver_session
 
     import_case = examples.download_file(


### PR DESCRIPTION
```
>>> import ansys.fluent.core as pyfluent
>>> from ansys.fluent.core import examples
>>> import_case = examples.download_file(file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system")
Checking if specified file already exists...
File already exists. File path:
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.cas.h5
>>> import_data = examples.download_file(file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system")
Checking if specified file already exists...
File already exists. File path:
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.dat.h5
>>> solver_session = pyfluent.launch_fluent(precision="double", processor_count=2, start_transcript=False, mode="solver", show_gui=True)         
>>> solver_session.tui.file.read_case(import_case)
pyfluent.tui WARNING: Currently calling the TUI commands in a generic manner. Please run `python codegen/allapigen.py` from the top-level pyfluent directory to generate the local TUI commands classes.
The following solver settings object method could also be used to execute the above command:
<solver_session>.file.read_case(file_name = r"C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.cas.h5")
>>> solver_session.tui.file.read_data(import_data)
The following solver settings object method could also be used to execute the above command:
<solver_session>.file.read_data(file_name = r"C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\exhaust_system.dat.h5")
>>> solver_session.tui.solve.set.number_of_iterations(15)
The following solver settings object method could also be used to execute the above command:
<solver_session>.solution.run_calculation.iter_count = 15
>>> solver_session.tui.solve.iterate()
The following solver settings object method could also be used to execute the above command:
<solver_session>.solution.run_calculation.iterate(iter_count = 15)
>>> solver_session.monitors_manager.get_monitor_set_names()
['residual', 'mass-bal-rplot', 'mass-tot-rplot', 'mass-in-rplot', 'point-vel-rplot']
>>> solver_session.monitors_manager.get_monitor_set_names()
['residual', 'mass-bal-rplot', 'mass-tot-rplot', 'mass-in-rplot', 'point-vel-rplot']
>>> solver_session.monitors_manager.get_monitor_set_names()
['residual', 'mass-bal-rplot', 'mass-tot-rplot', 'mass-in-rplot', 'point-vel-rplot', 'report-plot-0']
>>>
```
