### PR TITLE
Fixing launch behavior for various Windows shell environments

### DIFF
--- a/src/ansys/fluent/core/launcher/watchdog.py
+++ b/src/ansys/fluent/core/launcher/watchdog.py
@@ -86,8 +86,12 @@ def launch(
             python_executable = pythonw_executable
         else:
             logger.debug("Could not find Windows 'pythonw.exe' executable.")
-        python_executable = '"' + str(python_executable) + '"'
-        watchdog_exec = '"' + str(watchdog_exec) + '"'
+        python_executable = str(python_executable)
+        watchdog_exec = str(watchdog_exec)
+        if " " in python_executable:
+            python_executable = '"' + str(python_executable) + '"'
+        if " " in watchdog_exec:
+            watchdog_exec = '"' + str(watchdog_exec) + '"'
 
     # Command to be executed by the new process
     command_list = [


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/2187

Two things were causing issues for custom shell environments on Windows and are fixed here:
- Unnecessary empty spaces between arguments
- Using quotes when they are not needed

Tested with Command Prompt, PowerShell and Cmder, this should not cause any regressions (famous last words)

Just to make sure no additional issues introduced, it would be helpful if some reviewers could test this branch on their own Windows systems: just `launch_fluent` and then see if any obvious issues occur, and if PyFluent and the Watchdog were launched correctly.