### PR TITLE
Fix skipped solvermode tests

### DIFF
--- a/tests/test_solvermode/boundaries_periodic_expDict
+++ b/tests/test_solvermode/boundaries_periodic_expDict
@@ -1,1223 +1,1688 @@
 {
     "val_1": {
         "duct-pipe_1": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_1-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "inlet": {
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p_sup": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "initial_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "reference_frame": "Absolute",
+                "velocity": {
+                    "option": "value",
+                    "value": 0
+                },
+                "velocity_specification_method": "Magnitude, Normal to Boundary"
             },
-            "t": {
-                "option": "value",
-                "value": 300
+            "name": "inlet",
+            "thermal": {
+                "t": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10,
-            "velocity_spec": "Magnitude, Normal to Boundary",
-            "vmag": {
-                "option": "value",
-                "value": 0
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
             }
         },
         "inner_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "inner_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
-        "interior--duct": null,
-        "interior--pipe_1": null,
-        "interior--pipe_2": null,
-        "interior--pipe_3": null,
+        "interior--duct": {
+            "name": "interior--duct"
+        },
+        "interior--pipe_1": {
+            "name": "interior--pipe_1"
+        },
+        "interior--pipe_2": {
+            "name": "interior--pipe_2"
+        },
+        "interior--pipe_3": {
+            "name": "interior--pipe_3"
+        },
         "outer_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "outer_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "outlet": {
-            "avg_press_spec": false,
-            "direction_spec": "Normal to Boundary",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "avg_press_spec": false,
+                "direction_spec": "Normal to Boundary",
+                "frame_of_reference": "Absolute",
+                "gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "p_backflow_spec_gen": "Total Pressure",
+                "p_profile_multiplier": 1.0,
+                "prevent_reverse_flow": false,
+                "radial": false,
+                "targeted_mf_boundary": false
             },
-            "p_backflow_spec_gen": "Total Pressure",
-            "p_profile_multiplier": 1.0,
-            "prevent_reverse_flow": false,
-            "radial": false,
-            "t0": {
-                "option": "value",
-                "value": 300
+            "name": "outlet",
+            "thermal": {
+                "t0": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "targeted_mf_boundary": false,
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "periodic_1": {
-            "angular": true
+            "angular": true,
+            "name": "periodic_1"
         },
         "peripodic_2": {
-            "angular": true
+            "angular": true,
+            "name": "peripodic_2"
         },
         "pipe_1_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_1_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_2_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_2_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_2_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_2_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_3_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_3_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         }
     },
     "val_2": {
         "duct-pipe_1": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_1-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "inlet": {
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p_sup": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "initial_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "reference_frame": "Absolute",
+                "velocity": {
+                    "option": "value",
+                    "value": 0
+                },
+                "velocity_specification_method": "Magnitude, Normal to Boundary"
             },
-            "t": {
-                "option": "value",
-                "value": 300
+            "name": "inlet",
+            "thermal": {
+                "t": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10,
-            "velocity_spec": "Magnitude, Normal to Boundary",
-            "vmag": {
-                "option": "value",
-                "value": 0
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
             }
         },
         "inner_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "inner_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
-        "interior--duct": null,
-        "interior--pipe_1": null,
-        "interior--pipe_2": null,
-        "interior--pipe_3": null,
+        "interior--duct": {
+            "name": "interior--duct"
+        },
+        "interior--pipe_1": {
+            "name": "interior--pipe_1"
+        },
+        "interior--pipe_2": {
+            "name": "interior--pipe_2"
+        },
+        "interior--pipe_3": {
+            "name": "interior--pipe_3"
+        },
         "outer_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "outer_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "outlet": {
-            "avg_press_spec": false,
-            "direction_spec": "Normal to Boundary",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "avg_press_spec": false,
+                "direction_spec": "Normal to Boundary",
+                "frame_of_reference": "Absolute",
+                "gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "p_backflow_spec_gen": "Total Pressure",
+                "p_profile_multiplier": 1.0,
+                "prevent_reverse_flow": false,
+                "radial": false,
+                "targeted_mf_boundary": false
             },
-            "p_backflow_spec_gen": "Total Pressure",
-            "p_profile_multiplier": 1.0,
-            "prevent_reverse_flow": false,
-            "radial": false,
-            "t0": {
-                "option": "value",
-                "value": 300
+            "name": "outlet",
+            "thermal": {
+                "t0": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "targeted_mf_boundary": false,
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "periodic_1": {
-            "angular": true
+            "angular": true,
+            "name": "periodic_1"
         },
         "peripodic_2": {
-            "angular": true
+            "angular": true,
+            "name": "peripodic_2"
         },
         "pipe_1_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_1_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_2_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_2_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_2_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_2_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_3_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_3_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         }
     },
     "val_3": {
         "duct-pipe_1": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_1-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_1-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_2-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_2-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "duct-pipe_3-shadow": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q_dot": {
-                "option": "value",
-                "value": 0
+            "name": "duct-pipe_3-shadow",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Coupled",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Coupled"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "inlet": {
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p_sup": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "initial_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "reference_frame": "Absolute",
+                "velocity": {
+                    "option": "value",
+                    "value": 10.0
+                },
+                "velocity_specification_method": "Magnitude, Normal to Boundary"
             },
-            "t": {
-                "option": "value",
-                "value": 300
+            "name": "inlet",
+            "thermal": {
+                "t": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10,
-            "velocity_spec": "Magnitude, Normal to Boundary",
-            "vmag": {
-                "option": "value",
-                "value": 10.0
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
             }
         },
         "inner_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "inner_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
-        "interior--duct": null,
-        "interior--pipe_1": null,
-        "interior--pipe_2": null,
-        "interior--pipe_3": null,
+        "interior--duct": {
+            "name": "interior--duct"
+        },
+        "interior--pipe_1": {
+            "name": "interior--pipe_1"
+        },
+        "interior--pipe_2": {
+            "name": "interior--pipe_2"
+        },
+        "interior--pipe_3": {
+            "name": "interior--pipe_3"
+        },
         "out": {
-            "avg_press_spec": false,
-            "direction_spec": "Normal to Boundary",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "p": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "avg_press_spec": false,
+                "direction_spec": "Normal to Boundary",
+                "frame_of_reference": "Absolute",
+                "gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                },
+                "p_backflow_spec_gen": "Total Pressure",
+                "p_profile_multiplier": 1.0,
+                "prevent_reverse_flow": false,
+                "radial": false,
+                "targeted_mf_boundary": false
             },
-            "p_backflow_spec_gen": "Total Pressure",
-            "p_profile_multiplier": 1.0,
-            "prevent_reverse_flow": false,
-            "radial": false,
-            "t0": {
-                "option": "value",
-                "value": 300
+            "name": "out",
+            "thermal": {
+                "t0": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "targeted_mf_boundary": false,
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "outer_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "outer_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "periodic_1": {
-            "angular": true
+            "angular": true,
+            "name": "periodic_1"
         },
         "peripodic_2": {
-            "angular": true
+            "angular": true,
+            "name": "peripodic_2"
         },
         "pipe2_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe2_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_1_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_1_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_1_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         },
         "pipe_2_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_2_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_3_end": {
-            "direction_spec": "Normal to Boundary",
-            "flow_spec": "Mass Flow Rate",
-            "frame_of_reference": "Absolute",
-            "ke_spec": "Intensity and Viscosity Ratio",
-            "mass_flow": {
-                "option": "value",
-                "value": 0
+            "momentum": {
+                "direction_specification": "Normal to Boundary",
+                "mass_flow_rate": {
+                    "option": "value",
+                    "value": 0
+                },
+                "mass_flow_specification": "Mass Flow Rate",
+                "reference_frame": "Absolute",
+                "supersonic_gauge_pressure": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "supersonic_or_initial_gauge_pressure": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_end",
+            "thermal": {
+                "total_temperature": {
+                    "option": "value",
+                    "value": 300
+                }
             },
-            "t0": {
-                "option": "value",
-                "value": 300
-            },
-            "turb_intensity": 0.05,
-            "turb_viscosity_ratio": 10
+            "turbulence": {
+                "turbulent_intensity": 0.05,
+                "turbulent_specification": "Intensity and Viscosity Ratio",
+                "turbulent_viscosity_ratio_real": 10
+            }
         },
         "pipe_3_wall": {
-            "caf": {
-                "option": "value",
-                "value": 1
+            "momentum": {
+                "motion_bc": "Stationary Wall",
+                "shear_bc": "No Slip"
             },
-            "d": 0,
-            "material": "aluminum",
-            "motion_bc": "Stationary Wall",
-            "planar_conduction": false,
-            "q": {
-                "option": "value",
-                "value": 0
+            "name": "pipe_3_wall",
+            "thermal": {
+                "caf": {
+                    "option": "value",
+                    "value": 1
+                },
+                "material": "aluminum",
+                "planar_conduction": false,
+                "q": {
+                    "option": "value",
+                    "value": 0
+                },
+                "q_dot": {
+                    "option": "value",
+                    "value": 0
+                },
+                "thermal_bc": "Heat Flux",
+                "wall_thickness": {
+                    "option": "value",
+                    "value": 0
+                }
             },
-            "q_dot": {
-                "option": "value",
-                "value": 0
-            },
-            "rough_bc": "rough-bc-standard",
-            "roughness_const": {
-                "option": "value",
-                "value": 0.5
-            },
-            "roughness_height": {
-                "option": "value",
-                "value": 0
-            },
-            "shear_bc": "No Slip",
-            "thermal_bc": "Heat Flux"
+            "turbulence": {
+                "rough_bc": "rough-bc-standard",
+                "roughness_const": {
+                    "option": "value",
+                    "value": 0.5
+                },
+                "roughness_height": {
+                    "option": "value",
+                    "value": 0
+                }
+            }
         }
     }
 }

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -95,7 +95,7 @@ def test_boundaries_periodic(load_periodic_rot_cas):
     for (
         boundary_type
     ) in solver_session.setup.boundary_conditions.get_active_child_names():
-        if boundary_type in ['non_reflecting_bc', 'perforated_wall', 'settings']:
+        if boundary_type in ["non_reflecting_bc", "perforated_wall", "settings"]:
             continue
         for name, boundary in getattr(
             solver_session.setup.boundary_conditions, boundary_type

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -79,7 +79,7 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_boundaries_periodic(load_periodic_rot_cas):
     solver_session = load_periodic_rot_cas
     print(__file__)
@@ -97,7 +97,7 @@ def test_boundaries_periodic(load_periodic_rot_cas):
     for (
         boundary_type
     ) in solver_session.setup.boundary_conditions.get_active_child_names():
-        if boundary_type == "matching_tolerance":
+        if boundary_type in ['non_reflecting_bc', 'perforated_wall', 'settings']:
             continue
         for name, boundary in getattr(
             solver_session.setup.boundary_conditions, boundary_type

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -75,11 +75,9 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
     )
 
 
-# TODO: Skipped for the nightly test run to be successful. Later decide what to do with this test (discard?).
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-# @pytest.mark.skip
 def test_boundaries_periodic(load_periodic_rot_cas):
     solver_session = load_periodic_rot_cas
     print(__file__)

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -6,7 +6,6 @@ import pytest
 import ansys.fluent.core as pyfluent
 
 
-# @pytest.mark.skip("Fluent side bug")
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -69,7 +69,9 @@ def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
     assert auto_save.case_frequency() == "each-time"
     auto_save.root_name = "file_auto_save"
     assert auto_save.root_name() == "file_auto_save"
-    solver_session.setup.reference_values.compute(from_zone_name="outlet", from_zone_type='pressure-outlet')
+    solver_session.setup.reference_values.compute(
+        from_zone_name="outlet", from_zone_type="pressure-outlet"
+    )
     solver_session.journal.stop()
     solver_session.tui.file.read_journal(file_name.as_posix())
     assert auto_save.root_name() == "file_auto_save"

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -6,7 +6,7 @@ import pytest
 import ansys.fluent.core as pyfluent
 
 
-@pytest.mark.skip("Fluent side bug")
+# @pytest.mark.skip("Fluent side bug")
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
@@ -70,7 +70,7 @@ def test_solver_import_mixingelbow(load_mixing_elbow_mesh):
     assert auto_save.case_frequency() == "each-time"
     auto_save.root_name = "file_auto_save"
     assert auto_save.root_name() == "file_auto_save"
-    solver_session.setup.reference_values.compute(from_zone_name="outlet")
+    solver_session.setup.reference_values.compute(from_zone_name="outlet", from_zone_type='pressure-outlet')
     solver_session.journal.stop()
     solver_session.tui.file.read_journal(file_name.as_posix())
     assert auto_save.root_name() == "file_auto_save"

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -4,7 +4,6 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.quick
 @pytest.mark.setup
-# @pytest.mark.skip("Too sensitive to settings API; test doesn't initialize at all")
 def test_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -4,7 +4,7 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.quick
 @pytest.mark.setup
-@pytest.mark.skip("Too sensitive to settings API; test doesn't initialize at all")
+# @pytest.mark.skip("Too sensitive to settings API; test doesn't initialize at all")
 def test_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")
@@ -36,13 +36,19 @@ def test_initialize(launch_fluent_solver_3ddp_t2):
         },
     }
     solver.setup.boundary_conditions.pressure_outlet["outflow"].phase["mixture"] = {
-        "open_channel": True,
-        "ht_bottom": -0.941875,
-        "den_spec": "From Free Surface Level",
-        "direction_spec": "Normal to Boundary",
-        "turbulent_intensity": 0.01,
-        "turbulent_viscosity_ratio_real": 1,
-        "p_backflow_spec_gen": "Static Pressure",
+        "multiphase": {
+            "open_channel": True,
+            "ht_bottom": -0.941875,
+            "den_spec": "From Free Surface Level"
+        },
+        "momentum": {
+            "direction_spec": "Normal to Boundary",
+            "p_backflow_spec_gen": "Static Pressure"
+        },
+        "turbulence": {
+            "turbulent_intensity": 0.01,
+            "turbulent_viscosity_ratio_real": 1
+        }
     }
 
     solver.solution.methods.p_v_coupling.flow_scheme = "Coupled"
@@ -51,11 +57,11 @@ def test_initialize(launch_fluent_solver_3ddp_t2):
         True
     )
     solver.solution.initialization.open_channel_auto_init = {
-        "boundary_thread": 3,
+        "boundary_zone": 3,
         "flat_init": True,
     }
     assert solver.solution.initialization.open_channel_auto_init() == {
-        "boundary_thread": 3,
+        "boundary_zone": 3,
         "flat_init": True,
     }
     # solver.solution.initialization.hybrid_initialize()

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -38,16 +38,16 @@ def test_initialize(launch_fluent_solver_3ddp_t2):
         "multiphase": {
             "open_channel": True,
             "ht_bottom": -0.941875,
-            "den_spec": "From Free Surface Level"
+            "den_spec": "From Free Surface Level",
         },
         "momentum": {
             "direction_spec": "Normal to Boundary",
-            "p_backflow_spec_gen": "Static Pressure"
+            "p_backflow_spec_gen": "Static Pressure",
         },
         "turbulence": {
             "turbulent_intensity": 0.01,
-            "turbulent_viscosity_ratio_real": 1
-        }
+            "turbulent_viscosity_ratio_real": 1,
+        },
     }
 
     solver.solution.methods.p_v_coupling.flow_scheme = "Coupled"

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -4,7 +4,6 @@ import pytest
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-@pytest.mark.skip("Too sensitive to settings API")
 def test_methods(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     solver.setup.models.multiphase.models = "vof"
@@ -32,9 +31,9 @@ def test_methods(load_mixing_elbow_mesh):
     solver.solution.methods.gradient_scheme = "least-square-cell-based"
     assert solver.solution.methods.gradient_scheme() == "least-square-cell-based"
 
-    enable_warped_face = solver.solution.methods.warped_face_gradient_correction.enable
-    enable_warped_face(enable=True, gradient_correction_mode="fast-mode")
-    enable_warped_face(enable=False, gradient_correction_mode="fast-mode")
+    enable_warped_face = solver.solution.methods.warped_face_gradient_correction
+    enable_warped_face(enable=True, mode="fast")
+    enable_warped_face(enable=False, mode="fast")
 
     solver.solution.methods.expert.numerics_pbns.velocity_formulation = "relative"
     assert (
@@ -47,7 +46,7 @@ def test_methods(load_mixing_elbow_mesh):
         "physical_velocity_formulation": True,
         "disable_rhie_chow_flux": True,
         "presto_pressure_scheme": False,
-        "first_to_second_order_blending": 2.0,
+        "first_to_second_order_blending": 1.0,
     }
     assert solver.solution.methods.expert.numerics_pbns() == {
         "implicit_bodyforce_treatment": True,
@@ -55,12 +54,12 @@ def test_methods(load_mixing_elbow_mesh):
         "physical_velocity_formulation": True,
         "disable_rhie_chow_flux": True,
         "presto_pressure_scheme": False,
-        "first_to_second_order_blending": 2.0,
+        "first_to_second_order_blending": 1.0,
     }
     solver.solution.methods.expert.numerics_pbns.presto_pressure_scheme = True
     assert solver.solution.methods.expert.numerics_pbns.presto_pressure_scheme() == True
     solver.solution.methods.gradient_scheme = "green-gauss-node-based"
     assert solver.solution.methods.gradient_scheme() == "green-gauss-node-based"
-    solver.solution.methods.warped_face_gradient_correction.enable(
-        enable=True, gradient_correction_mode="memory-saving-mode"
+    solver.solution.methods.warped_face_gradient_correction(
+        enable=True, mode="memory-saving"
     )


### PR DESCRIPTION
Fix the following failing tests:

- ```tests\test_solvermode\test_boundaries.py```
    -  update json comparison file
    - change boundary_type for valid .items() calls

- ```tests\test_solvermode\test_general.py```
- ```tests\test_solvermode\test_initialization.py```
    - general command updates
   
- ```tests\test_solvermode\test_methods.py```
    - first_to_second_order_blending limit of 0 - 1
    - general commands