### PR TITLE
Updating project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,11 @@ setup(
     maintainer_email="pyansys.maintainers@ansys.com",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Fixes this badge: 
![image](https://github.com/ansys/pyfluent/assets/132297401/c02b5326-3932-4c46-8027-28dda965b50b)
Should now look similar to:
![image](https://github.com/ansys/pyfluent/assets/132297401/4e8300be-708b-46d2-a370-324cc7fcfd07)


And the metadata on PyPI:
![image](https://github.com/ansys/pyfluent/assets/132297401/cefb451b-3c95-47e1-92ae-e327be2a6ff6)
After new release, should look like:
![image](https://github.com/ansys/pyfluent/assets/132297401/5ab91872-385e-464e-8a75-4b9d1d52036f)
(without Python 3.12 as we don't fully support it yet)
