### PR TITLE
Strongly Typed Version Checks

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -14,7 +14,6 @@ logging.configure_env_var()
 from ansys.fluent.core._version import __version__  # noqa: F401
 from ansys.fluent.core.launcher.launcher import (  # noqa: F401
     FluentMode,
-    FluentVersion,
     connect_to_fluent,
     launch_fluent,
 )

--- a/src/ansys/fluent/core/launcher/fluent_version.py
+++ b/src/ansys/fluent/core/launcher/fluent_version.py
@@ -1,0 +1,87 @@
+"""Provides the Fluent version."""
+
+from enum import Enum
+import os
+
+supported_versions = ["24.2.0", "24.1.0", "23.2.0", "23.1.0", "22.2.0"]
+
+
+def get_current_version() -> str:
+    """Return the version string corresponding to the most recent, available ANSYS
+    installation.
+
+    The returned value is the string component of one of the members of the
+    FluentVersion class.
+
+    Returns
+    -------
+    str
+        Ansys version string
+
+    Raises
+    ------
+    RuntimeError
+        If an Ansys version cannot be found.
+    """
+    for v in supported_versions:
+        if "AWP_ROOT" + "".join(str(v).split("."))[:-1] in os.environ:
+            return v
+
+    raise RuntimeError("An Ansys version cannot be found.")
+
+
+class FluentVersion(Enum):
+    """An enumeration over supported Fluent versions."""
+
+    _24R2 = supported_versions[0]
+    _24R1 = supported_versions[1]
+    _23R2 = supported_versions[2]
+    _23R1 = supported_versions[3]
+    _22R2 = supported_versions[4]
+
+    current = get_current_version()
+
+    @classmethod
+    def _missing_(cls, version):
+        if isinstance(version, (float, str)):
+            version = str(version) + ".0"
+            for v in FluentVersion:
+                if version == v.value:
+                    return FluentVersion(version)
+            else:
+                raise RuntimeError(
+                    f"The specified version '{version[:-2]}' is not supported."
+                    + " Supported versions are: "
+                    + ", ".join([ver.value for ver in FluentVersion][::-1])
+                )
+
+    def __str__(self):
+        return str(self.value)
+
+    def __lt__(self, other):
+        if isinstance(other, FluentVersion):
+            return self.value < other.value
+        return RuntimeError(
+            "'<' is only supported between instances of 'FluentVersion' and 'FluentVersion'."
+        )
+
+    def __le__(self, other):
+        if isinstance(other, FluentVersion):
+            return self.value <= other.value
+        return RuntimeError(
+            "'<=' is only supported between instances of 'FluentVersion' and 'FluentVersion'."
+        )
+
+    def __gt__(self, other):
+        if isinstance(other, FluentVersion):
+            return self.value > other.value
+        return RuntimeError(
+            "'>' is only supported between instances of 'FluentVersion' and 'FluentVersion'."
+        )
+
+    def __ge__(self, other):
+        if isinstance(other, FluentVersion):
+            return self.value >= other.value
+        return RuntimeError(
+            "'>=' is only supported between instances of 'FluentVersion' and 'FluentVersion'."
+        )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -19,6 +19,7 @@ from ansys.fluent.core.launcher.fluent_container import (
     configure_container_dict,
     start_fluent_container,
 )
+from ansys.fluent.core.launcher.fluent_version import FluentVersion
 import ansys.fluent.core.launcher.watchdog as watchdog
 from ansys.fluent.core.scheduler import build_parallel_options, load_machines
 from ansys.fluent.core.session import _parse_server_info_file
@@ -56,56 +57,6 @@ def check_docker_support():
     except docker.errors.DockerException:
         return False
     return True
-
-
-class FluentVersion(Enum):
-    """An enumeration over supported Fluent versions."""
-
-    version_24R1 = "24.1.0"
-    version_23R2 = "23.2.0"
-    version_23R1 = "23.1.0"
-    version_22R2 = "22.2.0"
-
-    @classmethod
-    def _missing_(cls, version):
-        if isinstance(version, (float, str)):
-            version = str(version) + ".0"
-            for v in FluentVersion:
-                if version == v.value:
-                    return FluentVersion(version)
-            else:
-                raise RuntimeError(
-                    f"The specified version '{version[:-2]}' is not supported."
-                    + " Supported versions are: "
-                    + ", ".join([ver.value for ver in FluentVersion][::-1])
-                )
-
-    def __str__(self):
-        return str(self.value)
-
-
-def get_ansys_version() -> str:
-    """Return the version string corresponding to the most recent, available ANSYS
-    installation.
-
-    The returned value is the string component of one of the members of the
-    FluentVersion class.
-
-    Returns
-    -------
-    str
-        Ansys version string
-
-    Raises
-    ------
-    RuntimeError
-        If an Ansys version cannot be found.
-    """
-    for v in FluentVersion:
-        if "AWP_ROOT" + "".join(str(v).split("."))[:-1] in os.environ:
-            return str(v)
-
-    raise RuntimeError("An Ansys version cannot be found.")
 
 
 def get_fluent_exe_path(**launch_argvals) -> Path:

--- a/src/ansys/fluent/core/systemcoupling.py
+++ b/src/ansys/fluent/core/systemcoupling.py
@@ -5,6 +5,8 @@ import os
 from typing import List
 import xml.etree.ElementTree as XmlET
 
+from ansys.fluent.core.launcher.fluent_version import FluentVersion
+
 
 @dataclass
 class Variable:
@@ -42,10 +44,9 @@ class SystemCoupling:
     def __init__(self, solver):
         self._solver = solver
         # version check - this requires Fluent 2024 R1 or newer.
-        fluent_version = self._solver.get_fluent_version()
-        if float(fluent_version[:-2]) < 24.1:
+        if FluentVersion.current < FluentVersion._24R1:
             raise RuntimeError(
-                f"Fluent version is {fluent_version}. PySystemCoupling integration requires Fluent 24.1.0 or later."
+                f"Fluent version is {FluentVersion.current}. PySystemCoupling integration requires Fluent 24.1.0 or later."
             )
 
     @property

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pickle
 from typing import Any, Optional
 
-from ansys.fluent.core.launcher.launcher import FluentVersion
+from ansys.fluent.core.launcher.fluent_version import FluentVersion
 from ansys.fluent.core.services.datamodel_se import PyMenu, PyNamedObjectContainer
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
 from ansys.fluent.core.session_pure_meshing import PureMeshing


### PR DESCRIPTION
Moved the FluentVersion Enum class.

Is there a cleaner way to accomplish the same access style for `FluentVersion.current`?

It looks like the version values that come back from a session are ints. Should the FluentVersion values be changed to int for consistency?
![image](https://github.com/ansys/pyfluent/assets/143635850/f4420cd5-3ad0-4f50-824b-c9ce37bf19e3)

There is another fluent_version.py in utils. Should these be consolidated?

