### PR TITLE
Support Slurm options in launch_fluent

### DIFF
--- a/doc/source/api/general/launcher/index.rst
+++ b/doc/source/api/general/launcher/index.rst
@@ -16,3 +16,4 @@ Fluent launcher
     :hidden:
 
     fluent_container
+    slurm

--- a/doc/source/api/general/launcher/slurm.rst
+++ b/doc/source/api/general/launcher/slurm.rst
@@ -1,0 +1,11 @@
+.. _ref_launcher_slurm:
+
+Slurm launcher
+==============
+
+.. automodule:: ansys.fluent.core.launcher.slurm_launcher
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :exclude-members: __weakref__, __dict__
+   :autosummary:

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -53,6 +53,7 @@ class DockerLauncher:
         cwd: Optional[str] = None,
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
+        scheduler_options: Optional[dict] = None,
         **kwargs,
     ):
         """Launch Fluent session in container mode.

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -170,6 +170,8 @@ class DockerLauncher:
         _process_invalid_args(dry_run, "container", argvals)
         args = _get_argvals(argvals, mode)
         argvals.update(args)
+        if argvals["start_timeout"] is None:
+            argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():
             setattr(self, arg_name, arg_values)
         self.argvals = argvals

--- a/src/ansys/fluent/core/launcher/fluent_launcher_options.json
+++ b/src/ansys/fluent/core/launcher/fluent_launcher_options.json
@@ -58,5 +58,21 @@
             "false": ""
         },
         "fluent_format": "{}"
+    },
+    "scheduler": {
+        "type": "str",
+        "fluent_format": " -scheduler={}"
+    },
+    "scheduler_headnode": {
+        "type": "str",
+        "fluent_format": " -scheduler_headnode={}"
+    },
+    "scheduler_queue": {
+        "type": "str",
+        "fluent_format": " -scheduler_queue={}"
+    },
+    "scheduler_account": {
+        "type": "str",
+        "fluent_format": " -scheduler_account={}"
     }
 }

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -80,7 +80,7 @@ def launch_fluent(
     precision: Optional[str] = None,
     processor_count: Optional[int] = None,
     journal_file_names: Union[None, str, list[str]] = None,
-    start_timeout: int = 60,
+    start_timeout: Optional[int] = None,
     additional_arguments: Optional[str] = "",
     env: Optional[Dict[str, Any]] = None,
     start_container: Optional[bool] = None,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -126,7 +126,8 @@ def launch_fluent(
         journal(s). The default is ``None``.
     start_timeout : int, optional
         Maximum allowable time in seconds for connecting to the Fluent
-        server. The default is ``60``.
+        server. The default is ``60`` if Fluent is launched outside a Slurm environment,
+        no timeout if Fluent is launched within a Slurm environment.
     additional_arguments : str, optional
         Additional arguments to send to Fluent as a string in the same
         format they are normally passed to Fluent on the command line.

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -21,6 +21,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _process_kwargs,
 )
 from ansys.fluent.core.launcher.pim_launcher import PIMLauncher
+from ansys.fluent.core.launcher.slurm_launcher import SlurmFuture, SlurmLauncher
 from ansys.fluent.core.launcher.standalone_launcher import StandaloneLauncher
 import ansys.fluent.core.launcher.watchdog as watchdog
 from ansys.fluent.core.session_meshing import Meshing
@@ -52,7 +53,7 @@ def create_launcher(fluent_launch_mode: str = None, **kwargs):
     DisallowedValuesError
         If an unknown Fluent launch mode is passed.
     """
-    allowed_options = ["container", "pim", "standalone"]
+    allowed_options = ["container", "pim", "standalone", "slurm"]
     if (
         not isinstance(fluent_launch_mode, str)
         or str(fluent_launch_mode) not in allowed_options
@@ -68,6 +69,8 @@ def create_launcher(fluent_launch_mode: str = None, **kwargs):
         return DockerLauncher(**kwargs)
     elif fluent_launch_mode == "pim":
         return PIMLauncher(**kwargs)
+    elif fluent_launch_mode == "slurm":
+        return SlurmLauncher(**kwargs)
 
 
 #   pylint: disable=unused-argument
@@ -95,8 +98,9 @@ def launch_fluent(
     cwd: Optional[str] = None,
     topy: Optional[Union[str, list]] = None,
     start_watchdog: Optional[bool] = None,
+    scheduler_options: Optional[dict] = None,
     **kwargs,
-) -> Union[Meshing, PureMeshing, Solver, SolverIcing, dict]:
+) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SlurmFuture, dict]:
     """Launch Fluent locally in server mode or connect to a running Fluent server
     instance.
 
@@ -184,6 +188,8 @@ def launch_fluent(
         which means an independent watchdog process is run to ensure
         that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
         when the current Python process ends.
+    scheduler_options : dict, optional
+        Dictionary containing scheduler options. Default is None.
 
     Returns
     -------
@@ -209,7 +215,9 @@ def launch_fluent(
     _process_kwargs(kwargs)
     del kwargs
     fluent_launch_mode = _get_fluent_launch_mode(
-        start_container=start_container, container_dict=container_dict
+        start_container=start_container,
+        container_dict=container_dict,
+        scheduler_options=scheduler_options,
     )
     del start_container
     argvals = locals().copy()

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -359,9 +359,10 @@ def _await_fluent_launch(
             raise TimeoutError("The launch process has timed out.")
         time.sleep(1)
         start_timeout -= 1
+        logger.info(f"Waiting for Fluent to launch...")
         if start_timeout >= 0:
             logger.info(
-                f"Waiting for Fluent to launch...{start_timeout} seconds remaining"
+                f"...{start_timeout} seconds remaining"
             )
 
 

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -361,9 +361,7 @@ def _await_fluent_launch(
         start_timeout -= 1
         logger.info(f"Waiting for Fluent to launch...")
         if start_timeout >= 0:
-            logger.info(
-                f"...{start_timeout} seconds remaining"
-            )
+            logger.info(f"...{start_timeout} seconds remaining")
 
 
 def _get_server_info(

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -359,7 +359,10 @@ def _await_fluent_launch(
             raise TimeoutError("The launch process has timed out.")
         time.sleep(1)
         start_timeout -= 1
-        logger.info(f"Waiting for Fluent to launch...{start_timeout} seconds remaining")
+        if start_timeout >= 0:
+            logger.info(
+                f"Waiting for Fluent to launch...{start_timeout} seconds remaining"
+            )
 
 
 def _get_server_info(

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -46,6 +46,7 @@ class PIMLauncher:
         cwd: Optional[str] = None,
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
+        scheduler_options: Optional[dict] = None,
         **kwargs,
     ):
         """Launch Fluent session in `PIM<https://pypim.docs.pyansys.com/version/stable/>` mode.

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -163,6 +163,8 @@ class PIMLauncher:
         _process_invalid_args(dry_run, "pim", argvals)
         args = _get_argvals(argvals, mode)
         argvals.update(args)
+        if argvals["start_timeout"] is None:
+            argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():
             setattr(self, arg_name, arg_values)
         self.argvals = argvals

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -1,3 +1,22 @@
+"""Provides a module for launching Fluent within a Slurm environment.
+
+Examples
+--------
+>>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm"})
+>>> type(slurm)
+<class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
+>>> slurm.pending(), slurm.running(), slurm.done() # before Fluent is launched
+(True, False, False)
+>>>  slurm.pending(), slurm.running(), slurm.done() # after Fluent is launched
+(False, True, False)
+>>> session = slurm.result()
+>>> type(session)
+<class 'ansys.fluent.core.session_solver.Solver'>
+>>> session.exit()
+>>> slurm.pending(), slurm.running(), slurm.done()
+(False, False, True)
+"""
+
 from concurrent.futures import Future, ThreadPoolExecutor
 import logging
 from pathlib import Path
@@ -34,22 +53,6 @@ class SlurmFuture:
     """Encapsulates asynchronous launch of Fluent within a Slurm environment. The
     interface is similar to Python's
     `future object <https://docs.python.org/3/library/asyncio-future.html#future-object>`_.
-
-    Examples
-    --------
-    >>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm"})
-    >>> type(slurm)
-    <class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
-    >>> slurm.pending(), slurm.running(), slurm.done() # before Fluent is launched
-    (True, False, False)
-    >>>  slurm.pending(), slurm.running(), slurm.done() # after Fluent is launched
-    (False, True, False)
-    >>> session = slurm.result()
-    >>> type(session)
-    <class 'ansys.fluent.core.session_solver.Solver'>
-    >>> session.exit()
-    >>> slurm.pending(), slurm.running(), slurm.done()
-    (False, False, True)
     """
 
     def __init__(self, future: Future, job_id: int):
@@ -122,7 +125,10 @@ class SlurmFuture:
 
         Returns
         -------
-        Union[Meshing, PureMeshing, Solver, SolverIcing]
+        :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
+        :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
+        :class:`~ansys.fluent.core.session_solver.Solver`, \
+        :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`]
             The session instance corresponding to the Fluent launch.
         """
         return self._future.result(timeout)

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -51,8 +51,9 @@ def _get_slurm_job_id(proc: subprocess.Popen):
 
 
 class SlurmFuture:
-    """Encapsulates asynchronous launch of Fluent within a Slurm environment. The
-    interface is similar to Python's
+    """Encapsulates asynchronous launch of Fluent within a Slurm environment.
+
+    The interface is similar to Python's
     `future object <https://docs.python.org/3/library/asyncio-future.html#future-object>`_.
     """
 
@@ -102,15 +103,13 @@ class SlurmFuture:
         return self._get_state() == "RUNNING" and self._future.done()
 
     def pending(self) -> bool:
-        """Return ``True`` if the Fluent launch is currently waiting for Slurm allocation
-        or Fluent is being launched, otherwise ``False``.
-        """
+        """Return ``True`` if the Fluent launch is currently waiting for Slurm
+        allocation or Fluent is being launched, otherwise ``False``."""
         return self._future.running()
 
     def done(self) -> bool:
         """Return ``True`` if the Fluent launch was successfully cancelled or Fluent was
-        finished running, otherwise ``False``.
-        """
+        finished running, otherwise ``False``."""
         return self._get_state() in ["", "CANCELLED", "COMPLETED"]
 
     def result(

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -72,6 +72,9 @@ class SlurmFuture:
         )
         return out.decode().strip().strip('"')
 
+    def _cancel(self):
+        subprocess.run(["scancel", f"{self._job_id}"])
+
     def cancel(self, timeout: int = 60) -> bool:
         """Attempt to cancel the Fluent launch within timeout seconds.
 
@@ -87,7 +90,7 @@ class SlurmFuture:
         """
         if self.done():
             return False
-        subprocess.run(["scancel", f"{self._job_id}"])
+        self._cancel()
         for _ in range(timeout):
             if self._get_state() in ["", "CANCELLED"]:
                 return True

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -90,6 +90,8 @@ class SlurmLauncher:
         _process_invalid_args(dry_run, "slurm", argvals)
         args = _get_argvals(argvals, mode)
         argvals.update(args)
+        if argvals["start_timeout"] is None:
+            argvals["start_timeout"] = -1
         for arg_name, arg_values in argvals.items():
             setattr(self, f"_{arg_name}", arg_values)
         self._argvals = argvals
@@ -127,7 +129,9 @@ class SlurmLauncher:
         return slurm_job_id
 
     def _launch(self, slurm_job_id) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
-        _await_fluent_launch(self._server_info_file_name, -1, self._sifile_last_mtime)
+        _await_fluent_launch(
+            self._server_info_file_name, self._start_timeout, self._sifile_last_mtime
+        )
         session = self._new_session.create_from_server_info_file(
             server_info_file_name=self._server_info_file_name,
             remote_file_handler=None,

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -1,0 +1,154 @@
+from concurrent.futures import Future, ThreadPoolExecutor
+import logging
+from pathlib import Path
+import subprocess
+from typing import Any, Union
+
+from ansys.fluent.core.exceptions import InvalidArgument
+from ansys.fluent.core.launcher.launcher_utils import (
+    _await_fluent_launch,
+    _build_journal_argument,
+    _generate_launch_string,
+    _get_server_info_file_name,
+    _get_subprocess_kwargs_for_fluent,
+)
+from ansys.fluent.core.session_meshing import Meshing
+from ansys.fluent.core.session_pure_meshing import PureMeshing
+from ansys.fluent.core.session_solver import Solver
+from ansys.fluent.core.session_solver_icing import SolverIcing
+
+logger = logging.getLogger("pyfluent.launcher")
+
+
+def _get_slurm_job_id(proc: subprocess.Popen):
+    prefix = "Submitted batch job"
+    for line in proc.stdout:
+        if line.startswith(prefix.encode()):
+            line = line.decode().removeprefix(prefix).strip()
+            return int(line)
+
+
+class SlurmFuture:
+    def __init__(self, future: Future, job_id: int):
+        self._future = future
+        self._job_id = job_id
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
+        self.cancel()
+
+    def _get_state(self) -> str:
+        out = subprocess.check_output(
+            ["squeue", "-j", f"{self._job_id}", "-o", '"%T"', "-h"]
+        )
+        return out.decode().strip().strip('"')
+
+    def cancel(self, timeout: int = 60) -> bool:
+        if self.done():
+            return False
+        subprocess.run(["scancel", f"{self._job_id}"])
+        for _ in range(timeout):
+            if self.cancelled():
+                return True
+        return False
+
+    def cancelled(self) -> bool:
+        return self._get_state() == "CANCELLED"
+
+    def running(self) -> bool:
+        return self._get_state() == "RUNNING" and self._future.done()
+
+    def pending(self) -> bool:
+        return self._future.running()
+
+    def done(self) -> bool:
+        return self._get_state() in ["", "CANCELLED", "COMPLETED"]
+
+    def result(self, timeout=None):
+        return self._future.result(timeout)
+
+    def exception(self, timeout=None):
+        return self._future.exception(timeout)
+
+    def add_done_callback(self, fn):
+        self._future.add_done_callback(fn)
+
+
+class SlurmLauncher:
+    def __init__(
+        self,
+        argvals,
+        meshing_mode,
+        show_gui,
+        additional_arguments,
+        env,
+        topy,
+        journal_file_names,
+        new_session,
+        cleanup_on_exit,
+        start_transcript,
+        **kwargs,
+    ):
+        self._argvals = argvals
+        self._meshing_mode = meshing_mode
+        self._show_gui = show_gui
+        self._additional_arguments = additional_arguments
+        self._env = env
+        self._topy = topy
+        self._journal_file_names = journal_file_names
+        self._new_session = new_session
+        self._cleanup_on_exit = cleanup_on_exit
+        self._start_transcript = start_transcript
+
+        scheduler_options = self._argvals["scheduler_options"]
+        if scheduler_options:
+            if "scheduler" not in scheduler_options:
+                raise InvalidArgument(
+                    "The scheduler must be specified within scheduler options."
+                )
+            elif scheduler_options["scheduler"] != "slurm":
+                raise InvalidArgument("Only slurm is supported as scheduler.")
+
+    def _prepare(self):
+        self._server_info_file_name = _get_server_info_file_name(use_tmpdir=False)
+        self._argvals.update(self._argvals["scheduler_options"])
+        launch_cmd = _generate_launch_string(
+            self._argvals,
+            self._meshing_mode,
+            self._show_gui,
+            self._additional_arguments,
+            self._server_info_file_name,
+        )
+
+        self._sifile_last_mtime = Path(self._server_info_file_name).stat().st_mtime
+        if self._env is None:
+            self._env = {}
+        kwargs = _get_subprocess_kwargs_for_fluent(self._env, self._argvals)
+        launch_cmd += _build_journal_argument(self._topy, self._journal_file_names)
+
+        logger.debug(f"Launching Fluent with command: {launch_cmd}")
+        proc = subprocess.Popen(launch_cmd, **kwargs)
+        slurm_job_id = _get_slurm_job_id(proc)
+        logger.info(f"Slurm job id = {slurm_job_id}")
+        self._argvals["slurm_job_id"] = slurm_job_id
+        return slurm_job_id
+
+    def _launch(self, slurm_job_id) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
+        _await_fluent_launch(self._server_info_file_name, -1, self._sifile_last_mtime)
+        session = self._new_session.create_from_server_info_file(
+            server_info_file_name=self._server_info_file_name,
+            remote_file_handler=None,
+            cleanup_on_exit=self._cleanup_on_exit,
+            start_transcript=self._start_transcript,
+            inside_container=False,
+        )
+        return session
+
+    def __call__(self) -> SlurmFuture:
+        slurm_job_id = self._prepare()
+        return SlurmFuture(
+            ThreadPoolExecutor(max_workers=1).submit(self._launch, slurm_job_id),
+            slurm_job_id,
+        )

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -21,6 +21,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 import logging
 from pathlib import Path
 import subprocess
+import time
 from typing import Any, Callable, Union
 
 from ansys.fluent.core.exceptions import InvalidArgument
@@ -90,6 +91,7 @@ class SlurmFuture:
         for _ in range(timeout):
             if self._get_state() in ["", "CANCELLED"]:
                 return True
+            time.sleep(1)
         return False
 
     def running(self) -> bool:

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -177,6 +177,8 @@ class StandaloneLauncher:
         _process_invalid_args(dry_run, "standalone", argvals)
         args = _get_argvals(argvals, mode)
         argvals.update(args)
+        if argvals["start_timeout"] is None:
+            argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():
             setattr(self, arg_name, arg_values)
         self.argvals = argvals

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -59,6 +59,7 @@ class StandaloneLauncher:
         cwd: Optional[str] = None,
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
+        scheduler_options: Optional[dict] = None,
         **kwargs,
     ):
         """Launch Fluent session in standalone mode.
@@ -204,7 +205,7 @@ class StandaloneLauncher:
         sifile_last_mtime = Path(server_info_file_name).stat().st_mtime
         if self.env is None:
             setattr(self, "env", {})
-        kwargs = _get_subprocess_kwargs_for_fluent(self.env)
+        kwargs = _get_subprocess_kwargs_for_fluent(self.env, self.argvals)
         if self.cwd:
             kwargs.update(cwd=self.cwd)
         launch_string += _build_journal_argument(self.topy, self.journal_file_names)

--- a/tests/test_slurm_future.py
+++ b/tests/test_slurm_future.py
@@ -1,0 +1,67 @@
+from concurrent.futures import Future
+
+import pytest
+
+from ansys.fluent.core.launcher.slurm_launcher import SlurmFuture
+
+
+class SlurmEnvironment:
+    def __init__(self):
+        self.state = None
+
+    def set_state(self, state):
+        self.state = state
+
+
+class SlurmFutureResult:
+    pass
+
+
+class SlurmFutureException:
+    pass
+
+
+@pytest.fixture
+def slurm_future(monkeypatch: pytest.MonkeyPatch) -> SlurmFuture:
+    env = SlurmEnvironment()
+    future = Future()
+    future.set_running_or_notify_cancel()
+    slurm_future = SlurmFuture(future, 0)
+    monkeypatch.setattr(slurm_future, "_get_state", lambda: env.state)
+    monkeypatch.setattr(slurm_future, "_cancel", lambda: env.set_state(""))
+    env.set_state("RUNNING")
+    slurm_future.env = env
+    return slurm_future
+
+
+def test_cancel_slurm_future(slurm_future: SlurmFuture):
+    assert slurm_future.cancel()
+
+
+def test_slurm_future_lifecycle(slurm_future: SlurmFuture):
+    assert slurm_future.pending()
+    assert not slurm_future.running()
+    assert not slurm_future.done()
+    slurm_future._future.set_result(SlurmFutureResult())
+    assert not slurm_future.pending()
+    assert slurm_future.running()
+    assert not slurm_future.done()
+    assert isinstance(slurm_future.result(), SlurmFutureResult)
+    slurm_future.env.set_state("")
+    assert not slurm_future.pending()
+    assert not slurm_future.running()
+    assert slurm_future.done()
+
+
+def test_slurm_future_exception(slurm_future: SlurmFuture):
+    slurm_future._future.set_exception(SlurmFutureException())
+    assert isinstance(slurm_future.exception(), SlurmFutureException)
+
+
+def test_slurm_future_done_callback(slurm_future: SlurmFuture):
+    called = []
+    slurm_future.add_done_callback(lambda session: called.append(True))
+    assert not called
+    slurm_future._future.set_result(SlurmFutureResult())
+    assert called
+    assert called[0]


### PR DESCRIPTION
```
>>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm"})
>>> slurm
<ansys.fluent.core.launcher.launcher.SlurmFuture object at 0x2b9238af63b0>
>>> slurm.pending(), slurm.running(), slurm.done()
(True, False, False)  # before Fluent is launched
>>>  slurm.pending(), slurm.running(), slurm.done()
(False, True, False) # after Fluent is launched
>>> session = slurm.result()
>>> session.exit()
>>> slurm.pending(), slurm.running(), slurm.done()
(False, False, True)
```