### PR TITLE
Support SolverLite mode

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -30,6 +30,7 @@ from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.session_solver_icing import SolverIcing
+from ansys.fluent.core.session_solver_lite import SolverLite
 from ansys.fluent.core.utils.file_transfer_service import (
     PimFileTransferService,
     RemoteFileHandler,
@@ -197,6 +198,7 @@ class FluentMode(Enum):
     PURE_MESHING_MODE = ("pure-meshing", PureMeshing, True, [])
     SOLVER = ("solver", Solver, False, [])
     SOLVER_ICING = ("solver-icing", SolverIcing, False, [("fluent_icing", True)])
+    SOLVER_LITE = ("solver-lite", SolverLite, False, [("fluent_lite", True)])
 
     @staticmethod
     def get_mode(mode: str) -> "FluentMode":
@@ -311,7 +313,7 @@ def launch_remote_fluent(
     meshing_mode: bool = False,
     dimensionality: Optional[str] = None,
     launcher_args: Optional[Dict[str, Any]] = None,
-) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
+) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SolverLite]:
     """Launch Fluent remotely using `PyPIM <https://pypim.docs.pyansys.com>`.
 
     When calling this method, you must ensure that you are in an
@@ -321,7 +323,7 @@ def launch_remote_fluent(
 
     Parameters
     ----------
-    session_cls: Union[type(Meshing), type(PureMeshing), type(Solver), type(SolverIcing)]
+    session_cls: Union[type(Meshing), type(PureMeshing), type(Solver), type(SolverIcing), type(SolverLite)]
         Session type.
     start_transcript: bool
         Whether to start streaming the Fluent transcript in the client. The
@@ -347,7 +349,8 @@ def launch_remote_fluent(
     :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
     :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
     :class:`~ansys.fluent.core.session_solver.Solver`, \
-    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`]
+    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`], \
+    :class:`~ansys.fluent.core.session_solver_lite.SolverLite`]
         Session object.
     """
     pim = pypim.connect()
@@ -584,7 +587,7 @@ def launch_fluent(
     topy: Optional[Union[str, list]] = None,
     start_watchdog: Optional[bool] = None,
     **kwargs,
-) -> Union[Meshing, PureMeshing, Solver, SolverIcing, dict]:
+) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SolverLite, dict]:
     """Launch Fluent locally in server mode or connect to a running Fluent server
     instance.
 
@@ -678,7 +681,8 @@ def launch_fluent(
     :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
     :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
     :class:`~ansys.fluent.core.session_solver.Solver`, \
-    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`, dict]
+    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`,
+    :class:`~ansys.fluent.core.session_solver_lite.SolverLite`], dict]
         Session object or configuration dictionary if ``dry_run = True``.
 
     Raises
@@ -932,7 +936,7 @@ def connect_to_fluent(
     server_info_file_name: Optional[str] = None,
     password: Optional[str] = None,
     start_watchdog: Optional[bool] = None,
-) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
+) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SolverLite]:
     """Connect to an existing Fluent server instance.
 
     Parameters
@@ -972,7 +976,8 @@ def connect_to_fluent(
     :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \
     :class:`~ansys.fluent.core.session_pure_meshing.PureMeshing`, \
     :class:`~ansys.fluent.core.session_solver.Solver`, \
-    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`]
+    :class:`~ansys.fluent.core.session_solver_icing.SolverIcing`], \
+    :class:`~ansys.fluent.core.session_solver_lite.SolverLite`]
         Session object.
     """
     ip, port, password = _get_server_info(server_info_file_name, ip, port, password)

--- a/src/ansys/fluent/core/session_solver_lite.py
+++ b/src/ansys/fluent/core/session_solver_lite.py
@@ -2,6 +2,7 @@
 
 **********PRESENTLY SAME AS SOLVER WITH A SWITCH TO SOLVER***********
 """
+from typing import Any, Optional
 from ansys.fluent.core.session_solver import Solver
 
 
@@ -13,14 +14,16 @@ class SolverLite(Solver):
     def __init__(
         self,
         fluent_connection=None,
+        remote_file_handler: Optional[Any] = None,
     ):
         """SolverLite session.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
+            remote_file_handler: Supports file upload and download.
         """
-        super().__init__(
-            fluent_connection=fluent_connection,
+        super(SolverLite, self).__init__(
+            fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
         )
         self._tui_service = self.datamodel_service_tui
         self._settings_service = self.settings_service

--- a/tests/test_solver_lite_session.py
+++ b/tests/test_solver_lite_session.py
@@ -1,0 +1,10 @@
+import pytest
+
+import ansys.fluent.core as pyfluent
+
+
+@pytest.mark.fluent_version(">=23.1")
+def test_solver_lite_session():
+    solver_lite_session = pyfluent.launch_fluent(mode=pyfluent.FluentMode.SOLVER_LITE)
+    assert solver_lite_session.__class__.__name__ == "SolverLite"
+    assert "switch_to_full_solver" in dir(solver_lite_session)


### PR DESCRIPTION
Now we can use `solver-lite` mode.

```
>>> import ansys.fluent.core as pyfluent
>>> session = pyfluent.launch_fluent(mode="solver-lite", precision="double", processor_count=2, lightweight_mode=True, show_gui=True)

>>> session.__class__
<class 'ansys.fluent.core.session_solver_lite.SolverLite'>

>>> from ansys.fluent.core import examples
>>> import_file_name = examples.download_file("mixing_elbow.msh.h5", "pyfluent/mixing_elbow")
File already exists. File path:
C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\mixing_elbow.msh.h5

>>> session.file.read(file_name=import_file_name, file_type="mesh", lightweight_setup=True)   
Fast-loading "D:\ANSYSDev\vNNN\fluent\fluent24.2\\addons\afd\lib\hdfio.bin"
Done.
Multicore SMT processors detected. Processor affinity set!

Reading from AAPQ13pUvWxQtxN:"C:\Users\hpohekar\AppData\Local\Ansys\ansys_fluent_core\examples\mixing_elbow.msh.h5" in NODE0 mode ...
  Reading mesh info ...
       17822 cells,     1 cell zone  ...
          17822 mixed cells,  zone id: 87
       91581 faces,     7 face zones ...
           2168 polygonal wall faces,  zone id: 34
            268 polygonal wall faces,  zone id: 33
            155 polygonal pressure-outlet faces,  zone id: 32
            152 polygonal velocity-inlet faces,  zone id: 31
             55 polygonal velocity-inlet faces,  zone id: 30
           2001 polygonal symmetry faces,  zone id: 29
          86782 mixed interior faces,  zone id: 89
       66417 nodes,     3 node zones ...

Building...
     mesh
        distributing mesh
                parts..,
                faces..,
                nodes..,
                cells..,
     materials,
     interface,
     domains,
     zones,
        Skipping thread 20 of domain 1 (not referenced by grid).
        Skipping thread 21 of domain 1 (not referenced by grid).
        Skipping thread 22 of domain 1 (not referenced by grid).
        Skipping thread 23 of domain 1 (not referenced by grid).
        Skipping thread 24 of domain 1 (not referenced by grid).
        Skipping thread 25 of domain 1 (not referenced by grid).
        Skipping thread 26 of domain 1 (not referenced by grid).
        Skipping thread 27 of domain 1 (not referenced by grid).
        Skipping thread 28 of domain 1 (not referenced by grid).
        wall-elbow
        wall-inlet
        outlet
        cold-inlet
        hot-inlet
        symmetry-xyplane
        interior--elbow-fluid
        elbow-fluid
     parallel,
Done.

Only case settings are read, in order to review and/or modify the settings.
It is not possible to manipulate the mesh or run calculations unless you read the entire case file.
True
>>> 
>>> dir(session)
['__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__
', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_batch_ops_service', '_build_from_fluent_connection', '_field_dat
a_service', '_lck', '_monitors_service', '_pim_methods', '_preferences', '_reduction_service', '_remote_file_handler', '_root', '_se_service', '_settings_root', '_settings_service', '_sync_from_future', '_system_coupling', '_tui', '
_tui_service', '_version', '_workflow', '_workflow_se', 'build_from_fluent_connection', 'connection_properties', 'create_from_server_info_file', 'current_parametric_study', 'datamodel_events', 'datamodel_service_se', 'datamodel_serv
ice_tui', 'error_state', 'events_manager', 'events_service', 'execute_tui', 'exit', 'field_data', 'field_data_streaming', 'field_info', 'file', 'fluent_connection', 'force_exit', 'force_exit_container', 'get_fluent_version', 'health
_check_service', 'id', 'journal', 'mesh', 'monitors_manager', 'parallel', 'parameters', 'parametric_studies', 'preferences', 'read_case', 'read_case_lightweight', 'reduction', 'report', 'results', 'rp_vars', 'scheme_eval', 'server',
 'settings_service', 'setup', 'solution', 'start_journal', 'stop_journal', 'svar_data', 'svar_info', 'svar_service', 'switch_to_full_solver', 'system_coupling', 'transcript', 'tui', 'version', 'workflow', 'write_case']

>>> full_solver_session = session.switch_to_full_solver()

>>> dir(full_solver_session)
['__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__
', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_batch_ops_service', '_build_from_fluent_connection', '_field_dat
a_service', '_lck', '_monitors_service', '_pim_methods', '_preferences', '_reduction_service', '_remote_file_handler', '_root', '_se_service', '_settings_root', '_settings_service', '_sync_from_future', '_system_coupling', '_tui', '
_tui_service', '_version', '_workflow', '_workflow_se', 'build_from_fluent_connection', 'connection_properties', 'create_from_server_info_file', 'current_parametric_study', 'datamodel_events', 'datamodel_service_se', 'datamodel_serv
ice_tui', 'error_state', 'events_manager', 'events_service', 'execute_tui', 'exit', 'field_data', 'field_data_streaming', 'field_info', 'file', 'fluent_connection', 'force_exit', 'force_exit_container', 'get_fluent_version', 'health
_check_service', 'id', 'journal', 'mesh', 'monitors_manager', 'parallel', 'parameters', 'parametric_studies', 'preferences', 'read_case', 'read_case_lightweight', 'reduction', 'report', 'results', 'rp_vars', 'scheme_eval', 'server',
 'settings_service', 'setup', 'solution', 'start_journal', 'stop_journal', 'svar_data', 'svar_info', 'svar_service', 'system_coupling', 'transcript', 'tui', 'version', 'workflow', 'write_case']

>>> full_solver_session.__class__
<class 'ansys.fluent.core.session_solver.Solver'>

>>> full_solver_session.file.read_case(file_name=import_file_name) 
True

>>> full_solver_session.exit()
>>>
```


