### PR TITLE
datamodel_se refactoring for pyconsole implementation

### DIFF
--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -306,7 +306,7 @@ class DataModelGenerator:
             f.write(f'{indent}        """\n')
             f.write(
                 _build_command_query_docstring(
-                    k, info.queries[k].queryinfo, f"{indent}        ", False
+                    k, info["queries"][k]["queryinfo"], f"{indent}        ", False
                 )
             )
             f.write(f'{indent}        """\n')

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import shutil
 from typing import Any, Dict
 
-from ansys.api.fluent.v0 import datamodel_se_pb2 as DataModelProtoModule
 from ansys.fluent.core.session import BaseSession as Session
 from ansys.fluent.core.utils.fluent_version import get_version_for_file_name
 
@@ -67,14 +66,14 @@ def _build_parameter_docstring(name: str, t: str):
 
 def _build_command_query_docstring(name: str, info: Any, indent: str, is_command: bool):
     doc = f"{indent}Command {name}.\n\n" if is_command else f"{indent}Query {name}.\n\n"
-    if info.args:
+    if info.get("args"):
         doc += f"{indent}Parameters\n"
         doc += f"{indent}{'-' * len('Parameters')}\n"
-        for arg in info.args:
-            doc += f"{indent}{arg.name} : {_PY_TYPE_BY_DM_TYPE[arg.type]}\n"
+        for arg in info.get("args"):
+            doc += f'{indent}{arg["name"]} : {_PY_TYPE_BY_DM_TYPE[arg["type"]]}\n'
     doc += f"\n{indent}Returns\n"
     doc += f"{indent}{'-' * len('Returns')}\n"
-    doc += f"{indent}{_PY_TYPE_BY_DM_TYPE[info.returntype]}\n"
+    doc += f'{indent}{_PY_TYPE_BY_DM_TYPE[info["returntype"]]}\n'
     return doc
 
 
@@ -155,10 +154,8 @@ class DataModelGenerator:
         self._populate_static_info()
 
     def _get_static_info(self, rules: str, session: Session):
-        request = DataModelProtoModule.GetStaticInfoRequest()
-        request.rules = rules
-        response = session.datamodel_service_se.get_static_info(request)
-        return response.info
+        response = session.datamodel_service_se.get_static_info(rules)
+        return response
 
     def _populate_static_info(self):
         run_meshing_mode = any(
@@ -194,9 +191,9 @@ class DataModelGenerator:
                     try:
                         if (
                             len(
-                                info.static_info.singletons["Case"]
-                                .singletons["App"]
-                                .singletons
+                                info.static_info["singletons"]["Case"]["singletons"][
+                                    "App"
+                                ]["singletons"]
                             )
                             == 0
                         ):
@@ -222,13 +219,11 @@ class DataModelGenerator:
         f.write(f"{indent}    {_build_singleton_docstring(name)}\n")
         f.write(f'{indent}    """\n')
         f.write(f"{indent}    def __init__(self, service, rules, path):\n")
-        named_objects = sorted(info.namedobjects)
-        singletons = sorted(info.singletons)
-        parameters = sorted(info.parameters)
-        commands = sorted(info.commands)
-        queries = []
-        if hasattr(info, "queries"):
-            queries = sorted(info.queries)
+        named_objects = sorted(info.get("namedobjects", []))
+        singletons = sorted(info.get("singletons", []))
+        parameters = sorted(info.get("parameters", []))
+        commands = sorted(info.get("commands", []))
+        queries = sorted(info.get("queries", []))
         for k in named_objects:
             f.write(
                 f"{indent}        self.{k} = "
@@ -263,7 +258,7 @@ class DataModelGenerator:
             f.write(f"{indent}        .\n")
             f.write(f'{indent}        """\n')
             api_tree[f"{k}:<name>"] = self._write_static_info(
-                f"_{k}", info.namedobjects[k], f, level + 2
+                f"_{k}", info["namedobjects"][k], f, level + 2
             )
             # Specify the concrete named object type for __getitem__
             f.write(f"{indent}        def __getitem__(self, key: str) -> " f"_{k}:\n")
@@ -272,13 +267,13 @@ class DataModelGenerator:
             if k.isidentifier():
                 # print("included", k)
                 api_tree[k] = self._write_static_info(
-                    k, info.singletons[k], f, level + 1
+                    k, info["singletons"][k], f, level + 1
                 )
             else:
                 # print("\t\texcluded", k)
                 pass
         for k in parameters:
-            k_type = _PY_TYPE_BY_DM_TYPE[info.parameters[k].type]
+            k_type = _PY_TYPE_BY_DM_TYPE[info["parameters"][k]["type"]]
             if k_type in ["str", "List[str]"]:
                 f.write(f"{indent}    class {k}(PyTextual):\n")
             elif k_type in ["int", "float"]:
@@ -290,7 +285,7 @@ class DataModelGenerator:
             f.write(f'{indent}        """\n')
             f.write(
                 f"{indent}        "
-                f"{_build_parameter_docstring(k, info.parameters[k].type)}\n"
+                f'{_build_parameter_docstring(k, info["parameters"][k]["type"])}\n'
             )
             f.write(f'{indent}        """\n')
             f.write(f"{indent}        pass\n\n")
@@ -300,7 +295,7 @@ class DataModelGenerator:
             f.write(f'{indent}        """\n')
             f.write(
                 _build_command_query_docstring(
-                    k, info.commands[k].commandinfo, f"{indent}        ", True
+                    k, info["commands"][k]["commandinfo"], f"{indent}        ", True
                 )
             )
             f.write(f'{indent}        """\n')
@@ -335,13 +330,11 @@ class DataModelGenerator:
             f.write(f"{'=' * len(heading_)}\n")
             f.write("\n")
 
-            named_objects = sorted(info.namedobjects)
-            singletons = sorted(info.singletons)
-            parameters = sorted(info.parameters)
-            commands = sorted(info.commands)
-            queries = []
-            if hasattr(info, "queries"):
-                queries = sorted(info.queries)
+            named_objects = sorted(info.get("namedobjects", []))
+            singletons = sorted(info.get("singletons", []))
+            parameters = sorted(info.get("parameters", []))
+            commands = sorted(info.get("commands", []))
+            queries = sorted(info.get("queries", []))
 
             f.write(f".. autoclass:: {module_name}.{class_name}\n")
             if noindex:
@@ -361,7 +354,7 @@ class DataModelGenerator:
                     if k.isidentifier():
                         f.write(f"   {k}/index\n")
                         self._write_doc_for_model_object(
-                            info.singletons[k],
+                            info["singletons"][k],
                             doc_dir / k,
                             heading + "." + k,
                             module_name,
@@ -371,7 +364,7 @@ class DataModelGenerator:
                 for k in named_objects:
                     f.write(f"   {k}/index\n")
                     self._write_doc_for_model_object(
-                        info.namedobjects[k],
+                        info["namedobjects"][k],
                         doc_dir / k,
                         heading + "." + k,
                         module_name,

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -340,7 +340,7 @@ class DatamodelService(StreamingService):
         self, rules: str, path: str, query: str, args: dict[str, _TValue]
     ) -> _TValue:
         request = DataModelProtoModule.ExecuteQueryRequest(
-            rules=rules, path=path, query=query, wait=True
+            rules=rules, path=path, query=query
         )
         _convert_value_to_variant(args, request.args)
         response = self._impl.execute_query(request)

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -36,7 +36,7 @@ member_specs_oneof_fields = [
 def _get_value_from_message_dict(
     d: dict[str, Any], key: list[Union[str, Sequence[str]]]
 ):
-    """Get value from a protobuf message dict"""
+    """Get value from a protobuf message dict."""
     for k in key:
         if isinstance(k, str):
             d = d[k]

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1619,7 +1619,7 @@ class PyMenuGeneric(PyMenu):
 
     attrs = ("service", "rules", "path", "cached_attrs")
 
-    def _get_child_names(self) -> tuple[list, list, list]:
+    def _get_child_names(self) -> tuple[list, list, list, list]:
         response = self.service.get_specs(
             self.rules, convert_path_to_se_path(self.path)
         )

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -3,8 +3,9 @@ from enum import Enum
 import functools
 import itertools
 import logging
-from typing import Any, Callable, Iterator, NoReturn, Optional, Union
+from typing import Any, Callable, Iterator, NoReturn, Optional, Sequence, Union
 
+from google.protobuf.json_format import MessageToDict, ParseDict
 import grpc
 
 from ansys.api.fluent.v0 import datamodel_se_pb2 as DataModelProtoModule
@@ -18,12 +19,31 @@ from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
     TracingInterceptor,
+    WrapApiCallInterceptor,
 )
 from ansys.fluent.core.services.streaming import StreamingService
 
 Path = list[tuple[str, str]]
+_TValue = Union[None, bool, int, float, str, Sequence["_TValue"], dict[str, "_TValue"]]
 
 logger: logging.Logger = logging.getLogger("pyfluent.datamodel")
+
+member_specs_oneof_fields = [
+    x.name
+    for x in DataModelProtoModule.MemberSpecs.DESCRIPTOR.oneofs_by_name["as"].fields
+]
+
+
+def _get_value_from_message_dict(
+    d: dict[str, Any], key: list[Union[str, Sequence[str]]]
+):
+    """Get value from a protobuf message dict"""
+    for k in key:
+        if isinstance(k, str):
+            d = d[k]
+        else:
+            d = next(filter(None, (d.get(x) for x in k)))
+    return d
 
 
 class InvalidNamedObject(RuntimeError):
@@ -82,7 +102,7 @@ class Attribute(Enum):
     DEPRECATED_VERSION: str = "deprecatedVersion"
 
 
-class DatamodelService(StreamingService):
+class DatamodelServiceImpl:
     """Wraps the StateEngine-based datamodel gRPC service of Fluent.
 
     Using the methods from the ``PyMenu`` class is recommended.
@@ -91,21 +111,16 @@ class DatamodelService(StreamingService):
     def __init__(
         self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
     ) -> None:
-        """__init__ method of DatamodelService class."""
+        """__init__ method of DatamodelServiceImpl class."""
         intercept_channel = grpc.intercept_channel(
             channel,
             ErrorStateInterceptor(fluent_error_state),
             TracingInterceptor(),
             BatchInterceptor(),
+            WrapApiCallInterceptor(),
         )
         self._stub = DataModelGrpcModule.DataModelStub(intercept_channel)
         self._metadata = metadata
-        super().__init__(
-            stub=self._stub,
-            metadata=metadata,
-        )
-        self.event_streaming = None
-        self.events = {}
 
     @catch_grpc_error
     def initialize_datamodel(
@@ -214,14 +229,8 @@ class DatamodelService(StreamingService):
         """unsubscribeEvents RPC of DataModel service."""
         return self._stub.unsubscribeEvents(request, metadata=self._metadata)
 
-    def unsubscribe_all_events(self) -> None:
-        """Unsubscribe all subscribed events."""
-        for event in list(self.events.values()):
-            event.unsubscribe()
-        self.events.clear()
 
-
-def _convert_value_to_variant(val: Any, var: Variant) -> None:
+def _convert_value_to_variant(val: _TValue, var: Variant) -> None:
     """Convert a Python data type to Fluent's variant type."""
     if isinstance(val, bool):
         var.bool_state = val
@@ -232,18 +241,17 @@ def _convert_value_to_variant(val: Any, var: Variant) -> None:
     elif isinstance(val, str):
         var.string_state = val
     elif isinstance(val, (list, tuple)):
-        # set the one_of to variant_vector_state
-        var.variant_vector_state.item.add()
-        var.variant_vector_state.item.pop()
+        var.variant_vector_state.SetInParent()
         for item in val:
             item_var = var.variant_vector_state.item.add()
             _convert_value_to_variant(item, item_var)
     elif isinstance(val, dict):
+        var.variant_map_state.SetInParent()
         for k, v in val.items():
             _convert_value_to_variant(v, var.variant_map_state.item[k])
 
 
-def _convert_variant_to_value(var: Variant) -> Any:
+def _convert_variant_to_value(var: Variant) -> _TValue:
     """Convert Fluent's variant type to a Python data type."""
     if var.HasField("bool_state"):
         return var.bool_state
@@ -271,6 +279,120 @@ def _convert_variant_to_value(var: Variant) -> Any:
         for k, v in var.variant_map_state.item.items():
             val[k] = _convert_variant_to_value(v)
         return val
+
+
+class DatamodelService(StreamingService):
+    def __init__(
+        self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
+    ) -> None:
+        """__init__ method of DatamodelService class."""
+        self._impl = DatamodelServiceImpl(channel, metadata, fluent_error_state)
+        super().__init__(
+            stub=self._impl._stub,
+            metadata=metadata,
+        )
+        self.event_streaming = None
+        self.events = {}
+
+    def get_attribute_value(self, rules: str, path: str, attribute: str) -> _TValue:
+        request = DataModelProtoModule.GetAttributeValueRequest(
+            rules=rules, path=path, attribute=attribute
+        )
+        response = self._impl.get_attribute_value(request)
+        return _convert_variant_to_value(response.result)
+
+    def get_state(self, rules: str, path: str) -> _TValue:
+        request = DataModelProtoModule.GetStateRequest(rules=rules, path=path)
+        response = self._impl.get_state(request)
+        return _convert_variant_to_value(response.state)
+
+    def set_state(self, rules: str, path: str, state: _TValue) -> None:
+        request = DataModelProtoModule.SetStateRequest(
+            rules=rules, path=path, wait=True
+        )
+        _convert_value_to_variant(state, request.state)
+        self._impl.set_state(request)
+
+    def update_dict(
+        self, rules: str, path: str, dict_state: dict[str, _TValue]
+    ) -> None:
+        request = DataModelProtoModule.UpdateDictRequest(
+            rules=rules, path=path, wait=True
+        )
+        _convert_value_to_variant(dict_state, request.dicttomerge)
+        self._impl.update_dict(request)
+
+    def delete_object(self, rules: str, path: str) -> None:
+        request = DataModelProtoModule.DeleteObjectRequest(
+            rules=rules, path=path, wait=True
+        )
+        self._impl.delete_object(request)
+
+    def execute_command(
+        self, rules: str, path: str, command: str, args: dict[str, _TValue]
+    ) -> _TValue:
+        request = DataModelProtoModule.ExecuteCommandRequest(
+            rules=rules, path=path, command=command, wait=True
+        )
+        _convert_value_to_variant(args, request.args)
+        response = self._impl.execute_command(request)
+        return _convert_variant_to_value(response.result)
+
+    def create_command_arguments(self, rules: str, path: str, command: str) -> str:
+        request = DataModelProtoModule.CreateCommandArgumentsRequest(
+            rules=rules, path=path, command=command
+        )
+        response = self._impl.create_command_arguments(request)
+        return response.commandid
+
+    def delete_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        request = DataModelProtoModule.DeleteCommandArgumentsRequest(
+            rules=rules, path=path, command=command, commandid=commandid
+        )
+        self._impl.delete_command_arguments(request)
+
+    def get_specs(
+        self,
+        rules: str,
+        path: str,
+    ) -> dict[str, Any]:
+        request = DataModelProtoModule.GetSpecsRequest(
+            rules=rules,
+            path=path,
+        )
+        return MessageToDict(
+            self._impl.get_specs(request).member, use_integers_for_enums=True
+        )
+
+    def get_static_info(self, rules: str) -> dict[str, Any]:
+        request = DataModelProtoModule.GetStaticInfoRequest(rules=rules)
+        return MessageToDict(
+            self._impl.get_static_info(request).info, use_integers_for_enums=True
+        )
+
+    def subscribe_events(self, request_dict: dict[str, Any]) -> dict[str, Any]:
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        ParseDict(request_dict, request)
+        return [
+            MessageToDict(x, use_integers_for_enums=True)
+            for x in self._impl.subscribe_events(request).response
+        ]
+
+    def unsubscribe_events(self, tags: list[str]) -> dict[str, Any]:
+        request = DataModelProtoModule.UnsubscribeEventsRequest()
+        request.tag[:] = tags
+        return [
+            MessageToDict(x, use_integers_for_enums=True)
+            for x in self._impl.unsubscribe_events(request).response
+        ]
+
+    def unsubscribe_all_events(self) -> None:
+        """Unsubscribe all subscribed events."""
+        for event in list(self.events.values()):
+            event.unsubscribe()
+        self.events.clear()
 
 
 def convert_path_to_se_path(path: Path) -> str:
@@ -313,7 +435,7 @@ class EventSubscription:
     def __init__(
         self,
         service: DatamodelService,
-        request: DataModelProtoModule.SubscribeEventsRequest,
+        request_dict: dict[str, Any],
     ) -> None:
         """Subscribe to a datamodel event.
 
@@ -323,12 +445,12 @@ class EventSubscription:
             If server fails to subscribe from event.
         """
         self._service = service
-        response = service.subscribe_events(request)
-        response = response.response[0]
-        if response.status != DataModelProtoModule.STATUS_SUBSCRIBED:
-            raise SubscribeEventError(request)
-        self.status = response.status
-        self.tag = response.tag
+        response = service.subscribe_events(request_dict)
+        response = response[0]
+        if response["status"] != DataModelProtoModule.STATUS_SUBSCRIBED:
+            raise SubscribeEventError(request_dict)
+        self.status = response["status"]
+        self.tag = response["tag"]
         self._service.events[self.tag] = self
 
     def unsubscribe(self) -> None:
@@ -341,14 +463,12 @@ class EventSubscription:
         """
         if self.status == DataModelProtoModule.STATUS_SUBSCRIBED:
             self._service.event_streaming.unregister_callback(self.tag)
-            request = DataModelProtoModule.UnsubscribeEventsRequest()
-            request.tag.append(self.tag)
-            response = self._service.unsubscribe_events(request)
-            response = response.response[0]
-            if response.status != DataModelProtoModule.STATUS_UNSUBSCRIBED:
-                raise UnsubscribeEventError(request)
-            self.status = response.status
-        self._service.events.pop(self.tag, None)
+            response = self._service.unsubscribe_events([self.tag])
+            response = response[0]
+            if response["status"] != DataModelProtoModule.STATUS_UNSUBSCRIBED:
+                raise UnsubscribeEventError(self.tag)
+            self.status = response["status"]
+            self._service.events.pop(self.tag, None)
 
     def __del__(self) -> None:
         """Unsubscribe the datamodel event."""
@@ -384,7 +504,7 @@ class PyStateContainer(PyCallableStateObject):
     ) -> None:
         """__init__ method of PyStateContainer class."""
         super().__init__()
-        self.service = service
+        self.service: DatamodelService = service
         self.rules = rules
         if path is None:
             self.path = []
@@ -394,11 +514,7 @@ class PyStateContainer(PyCallableStateObject):
 
     def get_remote_state(self) -> Any:
         """Get state of the current object."""
-        request = DataModelProtoModule.GetStateRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        response = self.service.get_state(request)
-        return _convert_variant_to_value(response.state)
+        return self.service.get_state(self.rules, convert_path_to_se_path(self.path))
 
     def get_state(self) -> Any:
         state = DataModelCache.get_state(self.rules, self, NameKey.DISPLAY)
@@ -410,23 +526,16 @@ class PyStateContainer(PyCallableStateObject):
 
     def set_state(self, state: Optional[Any] = None, **kwargs) -> None:
         """Set state of the current object."""
-        request = DataModelProtoModule.SetStateRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        _convert_value_to_variant(
-            kwargs, request.state
-        ) if kwargs else _convert_value_to_variant(state, request.state)
-        self.service.set_state(request)
+        self.service.set_state(
+            self.rules, convert_path_to_se_path(self.path), kwargs or state
+        )
 
     setState = set_state
 
     def _get_remote_attr(self, attrib: str) -> Any:
-        request = DataModelProtoModule.GetAttributeValueRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.attribute = attrib
-        response = self.service.get_attribute_value(request)
-        return _convert_variant_to_value(response.result)
+        return self.service.get_attribute_value(
+            self.rules, convert_path_to_se_path(self.path), attrib
+        )
 
     def _get_cached_attr(self, attrib: str) -> Any:
         cached_val = self.cached_attrs.get(attrib)
@@ -471,13 +580,12 @@ class PyStateContainer(PyCallableStateObject):
 
     def help(self) -> None:
         """Print help string."""
-        request = DataModelProtoModule.GetSpecsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        response = self.service.get_specs(request)
-        help_string = getattr(
-            response.member, response.member.WhichOneof("as")
-        ).common.helpstring
+        response = self.service.get_specs(
+            self.rules, convert_path_to_se_path(self.path)
+        )
+        help_string = _get_value_from_message_dict(
+            response, [member_specs_oneof_fields, "common", "helpstring"]
+        )
         print(help_string)
 
     def __call__(self, *args, **kwargs) -> Any:
@@ -507,11 +615,18 @@ class PyStateContainer(PyCallableStateObject):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.attributeChangedEventRequest.path = convert_path_to_se_path(self.path)
-        e.attributeChangedEventRequest.attribute = attribute
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "attributeChangedEventRequest": {
+                        "path": convert_path_to_se_path(self.path),
+                        "attribute": attribute,
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -534,12 +649,19 @@ class PyStateContainer(PyCallableStateObject):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.commandAttributeChangedEventRequest.path = convert_path_to_se_path(self.path)
-        e.commandAttributeChangedEventRequest.command = command
-        e.commandAttributeChangedEventRequest.attribute = attribute
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "commandAttributeChangedEventRequest": {
+                        "path": convert_path_to_se_path(self.path),
+                        "command": command,
+                        "attribute": attribute,
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -642,12 +764,9 @@ class PyMenu(PyStateContainer):
         str
             Command ID
         """
-        request = DataModelProtoModule.CreateCommandArgumentsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.command = command
-        response = self.service.create_command_arguments(request)
-        return response.commandid
+        return self.service.create_command_arguments(
+            self.rules, convert_path_to_se_path(self.path), command
+        )
 
     def add_on_child_created(self, child_type: str, cb: Callable) -> EventSubscription:
         """Register a callback for when a child object is created.
@@ -664,11 +783,18 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.createdEventRequest.parentpath = convert_path_to_se_path(self.path)
-        e.createdEventRequest.childtype = child_type
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "createdEventRequest": {
+                        "parentpath": convert_path_to_se_path(self.path),
+                        "childtype": child_type,
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -685,10 +811,15 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.deletedEventRequest.path = convert_path_to_se_path(self.path)
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "deletedEventRequest": {"path": convert_path_to_se_path(self.path)},
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -705,10 +836,17 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.modifiedEventRequest.path = convert_path_to_se_path(self.path)
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "modifiedEventRequest": {
+                        "path": convert_path_to_se_path(self.path)
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -725,10 +863,17 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.affectedEventRequest.path = convert_path_to_se_path(self.path)
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "affectedEventRequest": {
+                        "path": convert_path_to_se_path(self.path)
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -749,11 +894,18 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.affectedEventRequest.path = convert_path_to_se_path(self.path)
-        e.affectedEventRequest.subtype = child_type
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "affectedEventRequest": {
+                        "path": convert_path_to_se_path(self.path),
+                        "subtype": child_type,
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -772,11 +924,18 @@ class PyMenu(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.commandExecutedEventRequest.path = convert_path_to_se_path(self.path)
-        e.commandExecutedEventRequest.command = command
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "commandExecutedEventRequest": {
+                        "path": convert_path_to_se_path(self.path),
+                        "command": command,
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -804,10 +963,17 @@ class PyParameter(PyStateContainer):
         EventSubscription
             EventSubscription instance which can be used to unregister the callback
         """
-        request = DataModelProtoModule.SubscribeEventsRequest()
-        e = request.eventrequest.add(rules=self.rules)
-        e.modifiedEventRequest.path = convert_path_to_se_path(self.path)
-        subscription = EventSubscription(self.service, request)
+        request_dict = {
+            "eventrequest": [
+                {
+                    "rules": self.rules,
+                    "modifiedEventRequest": {
+                        "path": convert_path_to_se_path(self.path)
+                    },
+                }
+            ]
+        }
+        subscription = EventSubscription(self.service, request_dict)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
@@ -874,11 +1040,9 @@ class PyDictionary(PyParameter):
         dict_state : dict[str, Any]
             Incoming dict state
         """
-        request = DataModelProtoModule.UpdateDictRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        _convert_value_to_variant(dict_state, request.dicttomerge)
-        self.service.update_dict(request)
+        self.service.update_dict(
+            self.rules, convert_path_to_se_path(self.path), dict_state
+        )
 
     updateDict = update_dict
 
@@ -913,17 +1077,16 @@ class PyNamedObjectContainer:
             self.path = path
 
     def _get_child_object_names(self) -> list[str]:
-        request = DataModelProtoModule.GetSpecsRequest()
-        request.rules = self.rules
         parent_path = self.path[0:-1]
         child_type_suffix = self.path[-1][0] + ":"
-        request.path = convert_path_to_se_path(parent_path)
-        response = self.service.get_specs(request)
+        response = self.service.get_specs(
+            self.rules, convert_path_to_se_path(parent_path)
+        )
         child_object_names = []
         for struct_type in ("singleton", "namedobject"):
-            if response.member.HasField(struct_type):
-                struct_field = getattr(response.member, struct_type)
-                for member in struct_field.members:
+            struct_field = response.get(struct_type)
+            if struct_field:
+                for member in struct_field["members"]:
                     if member.startswith(child_type_suffix):
                         child_object_names.append(member[len(child_type_suffix) :])
         return child_object_names
@@ -983,10 +1146,7 @@ class PyNamedObjectContainer:
         if key in self._get_child_object_display_names():
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
-            request = DataModelProtoModule.DeleteObjectRequest()
-            request.rules = self.rules
-            request.path = convert_path_to_se_path(child_path)
-            self.service.delete_object(request)
+            self.service.delete_object(self.rules, convert_path_to_se_path(child_path))
         else:
             raise LookupError(
                 f"{key} is not found at path " f"{convert_path_to_se_path(self.path)}"
@@ -1119,7 +1279,7 @@ class PyCommand:
         Print the command help string.
     """
 
-    _stored_static_info: dict[str, DataModelProtoModule.StaticInfo] = {}
+    _stored_static_info: dict[str, dict[str, Any]] = {}
 
     def __init__(
         self,
@@ -1145,43 +1305,33 @@ class PyCommand:
         Any
             Return value.
         """
-        request = DataModelProtoModule.ExecuteCommandRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.command = self.command
-        request.wait = True
-        _convert_value_to_variant(kwds, request.args)
-        response = self.service.execute_command(request)
-        return _convert_variant_to_value(response.result)
+        return self.service.execute_command(
+            self.rules, convert_path_to_se_path(self.path), self.command, kwds
+        )
 
     def help(self) -> None:
         """Prints help string."""
-        request = DataModelProtoModule.GetSpecsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        response = self.service.get_specs(request)
-        help_string = getattr(
-            response.member, response.member.WhichOneof("as")
-        ).common.helpstring
+        response = self.service.get_specs(
+            self.rules, convert_path_to_se_path(self.path)
+        )
+        help_string = _get_value_from_message_dict(
+            response, [member_specs_oneof_fields, "common", "helpstring"]
+        )
         print(help_string)
 
     def _create_command_arguments(self) -> str:
-        request = DataModelProtoModule.CreateCommandArgumentsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.command = self.command
-        response = self.service.create_command_arguments(request)
-        return response.commandid
+        commandid = self.service.create_command_arguments(
+            self.rules, convert_path_to_se_path(self.path), self.command
+        )
+        return commandid
 
-    def _get_static_info(self) -> DataModelProtoModule.StaticInfo:
+    def _get_static_info(self) -> dict[str, Any]:
         if self.rules not in PyCommand._stored_static_info.keys():
             # Populate the static info with respect to a rules only if the
             # same info has not been obtained in another context already.
             # If the information is available, we can use it without additional remote calls.
-            request = DataModelProtoModule.GetStaticInfoRequest()
-            request.rules = self.rules
-            response = self.service.get_static_info(request)
-            PyCommand._stored_static_info[self.rules] = response.info
+            response = self.service.get_static_info(self.rules)
+            PyCommand._stored_static_info[self.rules] = response
         return PyCommand._stored_static_info[self.rules]
 
     def create_instance(self) -> Optional["PyCommandArguments"]:
@@ -1281,20 +1431,22 @@ class PyCommandArguments(PyStateContainer):
         self.id = id
 
     def __del__(self) -> None:
-        request = DataModelProtoModule.DeleteCommandArgumentsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path[:-1])
-        request.command = self.path[-1][0]
-        request.commandid = self.path[-1][1]
         try:
-            self.service.delete_command_arguments(request)
+            self.service.delete_command_arguments(
+                self.rules,
+                convert_path_to_se_path(self.path[:-1]),
+                self.path[-1][0],
+                self.path[-1][1],
+            )
         except Exception as exc:
             logger.info("__del__ %s: %s" % (type(exc).__name__, exc))
 
     def __getattr__(self, attr: str) -> Optional[PyCommandArgumentsSubItem]:
-        for arg in self.static_info.commands[self.command].commandinfo.args:
-            if arg.name == attr:
-                mode = DataModelType.get_mode(arg.type)
+        for arg in _get_value_from_message_dict(
+            self.static_info, ["commands", self.command, "commandinfo", "args"]
+        ):
+            if arg["name"] == attr:
+                mode = DataModelType.get_mode(arg["type"])
                 py_class = mode.value[1]
                 return py_class(self, attr, self.service, self.rules, self.path, arg)
 
@@ -1408,9 +1560,9 @@ class PySingletonCommandArgumentsSubItem(PyCommandArgumentsSubItem):
         )
 
     def __getattr__(self, attr: str) -> PyCommandArgumentsSubItem:
-        arg = self.parent_arg.info.parameters[attr]
+        arg = self.parent_arg["info"]["parameters"][attr]
 
-        mode = DataModelType.get_mode(arg.type)
+        mode = DataModelType.get_mode(arg["type"])
         py_class = mode.value[1]
         return py_class(self, attr, self.service, self.rules, self.path, arg)
 
@@ -1465,25 +1617,30 @@ class PyMenuGeneric(PyMenu):
     attrs = ("service", "rules", "path", "cached_attrs")
 
     def _get_child_names(self) -> tuple[list, list, list]:
-        request = DataModelProtoModule.GetSpecsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        response = self.service.get_specs(request)
+        response = self.service.get_specs(
+            self.rules, convert_path_to_se_path(self.path)
+        )
         singleton_names = []
         creatable_type_names = []
         command_names = []
         query_names = []
         for struct_type in ("singleton", "namedobject"):
-            if response.member.HasField(struct_type):
-                struct_field = getattr(response.member, struct_type)
-                for member in struct_field.members:
+            struct_field = response.get(struct_type)
+            if struct_field:
+                for member in struct_field["members"]:
                     if ":" not in member:
                         singleton_names.append(member)
+<<<<<<< HEAD
                 creatable_type_names = struct_field.creatabletypes
                 command_names = [x.name for x in struct_field.commands]
                 if hasattr(struct_field, "queries"):
                     query_names = [x.name for x in struct_field.queries]
         return singleton_names, creatable_type_names, command_names, query_names
+=======
+                creatable_type_names = struct_field.get("creatabletypes", [])
+                command_names = [x["name"] for x in struct_field.get("commands", [])]
+        return singleton_names, creatable_type_names, command_names
+>>>>>>> 40dfceccf (Factor out pure service class from datamodel_se)
 
     def _get_child(
         self, name: str

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -244,7 +244,6 @@ def _convert_value_to_variant(val: _TValue, var: Variant) -> None:
             item_var = var.variant_vector_state.item.add()
             _convert_value_to_variant(item, item_var)
     elif isinstance(val, dict):
-        var.variant_map_state.SetInParent()
         for k, v in val.items():
             _convert_value_to_variant(v, var.variant_map_state.item[k])
 

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -1,5 +1,6 @@
 from time import sleep
 
+from google.protobuf.json_format import MessageToDict
 import pytest
 from util.meshing_workflow import new_mesh_session  # noqa: F401
 from util.solver_workflow import new_solver_session  # noqa: F401
@@ -53,21 +54,18 @@ def test_event_subscription(new_mesh_session):
     e8 = request.eventrequest.add(rules="workflow")
     e8.commandExecutedEventRequest.path = ""
     e8.commandExecutedEventRequest.command = "InitializeWorkflow"
-    response = session.datamodel_service_se.subscribe_events(request)
+    response = session.datamodel_service_se.subscribe_events(MessageToDict(request))
     assert all(
         [
-            r.status == datamodel_se_pb2.STATUS_SUBSCRIBED and r.tag == t
-            for r, t in zip(response.response, tags)
+            r["status"] == datamodel_se_pb2.STATUS_SUBSCRIBED and r["tag"] == t
+            for r, t in zip(response, tags)
         ]
     )
-
-    request = datamodel_se_pb2.UnsubscribeEventsRequest()
-    request.tag.extend(tags)
-    response = session.datamodel_service_se.unsubscribe_events(request)
+    response = session.datamodel_service_se.unsubscribe_events(tags)
     assert all(
         [
-            r.status == datamodel_se_pb2.STATUS_UNSUBSCRIBED and r.tag == t
-            for r, t in zip(response.response, tags)
+            r["status"] == datamodel_se_pb2.STATUS_UNSUBSCRIBED and r["tag"] == t
+            for r, t in zip(response, tags)
         ]
     )
 


### PR DESCRIPTION
For background, please see the draft PR #2220 and the corresponding Fluent side PR. The primary idea is to have a class wrapping the datamodel_se grpc calls. The class will pass pure Python types (instead of Protobuf types) and will be re-implemented on PyConsole side through local Python function calls.