### PR TITLE
Remove solver lite from solver.rst

### DIFF
--- a/doc/source/api/general/sessions/Solver/index.rst
+++ b/doc/source/api/general/sessions/Solver/index.rst
@@ -7,8 +7,6 @@ Solver sessions
 :ref:`ref_session_solver`          | Module containing class encapsulating Fluent connection.
 
 :ref:`ref_session_solver_icing`    Module containing class encapsulating Fluent connection.
-
-:ref:`ref_session_solver_lite`     Module containing class encapsulating Fluent connection.
 =================================  ===========================================================
 
 .. toctree::


### PR DESCRIPTION
solver_lite.rst was removed but it's info was not removed from solver.rst. 

It's removed now.

![image](https://github.com/ansys/pyfluent/assets/106588300/bc001220-f131-4e34-a50c-6bf099b28032)
