### PR TITLE
Upgrade unit tests to use lightweight case load where possible

### DIFF
--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -12,12 +12,12 @@ from util.solver import assign_settings_value_from_value_dict as assign_dict_val
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.codegen_required
-def test_boundaries_elbow(load_mixing_elbow_mesh):
-    solver_session = load_mixing_elbow_mesh
+def test_boundaries_elbow(load_mixing_elbow_settings_only):
+    solver_session = load_mixing_elbow_settings_only
     solver_session.setup.models.energy.enabled = True
 
     cold_inlet = solver_session.setup.boundary_conditions.velocity_inlet["cold-inlet"]
-    assert D(0) == cold_inlet.momentum.velocity()
+    assert D(1) == cold_inlet.momentum.velocity()
     assign_dict_val(cold_inlet.momentum.velocity, 0.4)
     assert D(0.4) == cold_inlet.momentum.velocity()
 
@@ -78,8 +78,8 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
 @pytest.mark.integration
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_boundaries_periodic(load_periodic_rot_cas):
-    solver_session = load_periodic_rot_cas
+def test_boundaries_periodic(load_periodic_rot_settings_only):
+    solver_session = load_periodic_rot_settings_only
     print(__file__)
     _THIS_DIR = os.path.dirname(__file__)
     _DATA_FILE = os.path.join(_THIS_DIR, "boundaries_periodic_expDict")

--- a/tests/test_solvermode/test_controls.py
+++ b/tests/test_solvermode/test_controls.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_controls(load_mixing_elbow_mesh):
-    solver = load_mixing_elbow_mesh
+def test_controls(load_mixing_elbow_settings_only):
+    solver = load_mixing_elbow_settings_only
     solver.setup.models.multiphase.models = "vof"
     assert solver.setup.models.multiphase.models() == "vof"
     solver.setup.general.operating_conditions.gravity = {
@@ -83,6 +83,7 @@ def test_controls(load_mixing_elbow_mesh):
             "omega": 0.75,
             "mp": 0.5,
             "density": 1.0,
+            "temperature": 0.75,
         }
     }
     solver.solution.controls.pseudo_time_explicit_relaxation_factor = {
@@ -96,6 +97,7 @@ def test_controls(load_mixing_elbow_mesh):
             "omega": 0.75,
             "mp": 0.5,
             "density": 1.0,
+            "temperature": 0.75,
         }
     }
     solver.solution.methods.p_v_coupling.flow_scheme = "SIMPLE"
@@ -110,6 +112,7 @@ def test_controls(load_mixing_elbow_mesh):
         "body-force": 1.0,
         "pressure": 0.9,
         "k": 0.8,
+        "temperature": 1.0,
     }
     solver.solution.controls.under_relaxation = {
         "body-force": 0.7,
@@ -125,4 +128,5 @@ def test_controls(load_mixing_elbow_mesh):
         "body-force": 0.7,
         "pressure": 0.9,
         "k": 0.8,
+        "temperature": 1.0,
     }

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -4,10 +4,17 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.quick
 @pytest.mark.setup
-def test_initialize(launch_fluent_solver_3ddp_t2):
-    solver = launch_fluent_solver_3ddp_t2
-    input_type, input_name = download_input_file("pyfluent/wigley_hull", "wigley.msh")
-    solver.file.read(file_type=input_type, file_name=input_name)
+def test_initialize(launch_fluent_solver_3ddp):
+    solver = launch_fluent_solver_3ddp
+    input_type, input_name = download_input_file(
+        "pyfluent/wigley_hull",
+        "wigley.cas.h5",
+    )
+    solver.file.read(
+        file_type=input_type,
+        file_name=input_name,
+        lightweight_setup=True,
+    )
     solver.parallel.partition.set.laplace_smoothing.enabled = True
     solver.parallel.partition.method(partition_method="metis", count=2)
     copy_by_name = solver.setup.materials.database.copy_by_name

--- a/tests/test_solvermode/test_materials.py
+++ b/tests/test_solvermode/test_materials.py
@@ -5,8 +5,8 @@ from util.solver import copy_database_material
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_solver_material(load_mixing_elbow_mesh):
-    solver_session = load_mixing_elbow_mesh
+def test_solver_material(load_mixing_elbow_settings_only):
+    solver_session = load_mixing_elbow_settings_only
     setup_materials = solver_session.setup.materials
     copy_database_material(materials=setup_materials, type="fluid", name="water-liquid")
     elbow_fluid = solver_session.setup.cell_zone_conditions.fluid["elbow-fluid"]

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -4,8 +4,8 @@ import pytest
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_methods(load_mixing_elbow_mesh):
-    solver = load_mixing_elbow_mesh
+def test_methods(load_mixing_elbow_settings_only):
+    solver = load_mixing_elbow_settings_only
     solver.setup.models.multiphase.models = "vof"
     solver.setup.general.operating_conditions.gravity = {
         "enable": True,
@@ -27,6 +27,7 @@ def test_methods(load_mixing_elbow_mesh):
         "mp": "compressive",
         "pressure": "presto!",
         "k": "second-order-upwind",
+        "temperature": "second-order-upwind",
     }
     solver.solution.methods.gradient_scheme = "least-square-cell-based"
     assert solver.solution.methods.gradient_scheme() == "least-square-cell-based"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -5,12 +5,12 @@ import pytest
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_solver_models(load_mixing_elbow_mesh):
-    solver_session = load_mixing_elbow_mesh
+def test_solver_models(load_mixing_elbow_settings_only):
+    solver_session = load_mixing_elbow_settings_only
     models = solver_session.setup.models
-    assert not models.energy.enabled()
-    models.energy.enabled = True
     assert models.energy.enabled()
+    models.energy.enabled = False
+    assert not models.energy.enabled()
     models.multiphase.models = "vof"
     assert models.multiphase.models() == "vof"
     models.viscous.model = "laminar"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -26,8 +26,8 @@ def test_solver_models(load_mixing_elbow_settings_only):
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version("latest")
-def test_disk_2d_models(load_disk_mesh):
-    solver_session = load_disk_mesh
+def test_disk_2d_models(load_disk_settings_only):
+    solver_session = load_disk_settings_only
     models = solver_session.setup.models
     solver_session.setup.general.solver.two_dim_space = "axisymmetric"
     solver_session.setup.general.solver.two_dim_space = "swirl"

--- a/tests/test_solvermode/test_named_expressions.py
+++ b/tests/test_solvermode/test_named_expressions.py
@@ -4,9 +4,10 @@ import pytest
 @pytest.mark.quick
 @pytest.mark.setup
 @pytest.mark.fluent_version(">=24.1")
-def test_expression(load_mixing_elbow_mesh):
-    solver_session = load_mixing_elbow_mesh
-    solver_session.setup.models.energy.enabled = True
+def test_expression(load_mixing_elbow_settings_only):
+    solver_session = load_mixing_elbow_settings_only
+    # Case file already has energy model turned on
+    # solver_session.setup.models.energy.enabled = True
     expressions = solver_session.setup.named_expressions
     expressions["r"] = {}
     expressions["r"] = {"definition": "(Position.z**2.0 +Position.x**2.0)**0.5"}

--- a/tests/util/fixture_fluent.py
+++ b/tests/util/fixture_fluent.py
@@ -65,9 +65,28 @@ def launch_fluent_pure_meshing():
 
 
 @pytest.fixture
+def launch_fluent_solver_3ddp():
+    solver_session = pyfluent.launch_fluent(
+        precision="double",
+        mode="solver",
+    )
+    yield solver_session
+    solver_session.exit()
+
+
+@pytest.fixture
 def launch_fluent_solver_3ddp_t2():
     solver_session = pyfluent.launch_fluent(
         precision="double", processor_count=2, mode="solver"
+    )
+    yield solver_session
+    solver_session.exit()
+
+
+@pytest.fixture
+def launch_fluent_solver_2ddp():
+    solver_session = pyfluent.launch_fluent(
+        version="2d", precision="double", mode="solver"
     )
     yield solver_session
     solver_session.exit()
@@ -118,8 +137,8 @@ def load_mixing_elbow_case_dat(launch_fluent_solver_3ddp_t2):
 
 
 @pytest.fixture
-def load_mixing_elbow_settings_only(sample_solver_session):
-    solver_session = sample_solver_session
+def load_mixing_elbow_settings_only(launch_fluent_solver_3ddp):
+    solver_session = launch_fluent_solver_3ddp
     input_type, input_name = download_input_file(
         "pyfluent/mixing_elbow", "mixing_elbow.cas.h5"
     )
@@ -207,8 +226,8 @@ def load_periodic_rot_cas(launch_fluent_solver_3ddp_t2):
 
 
 @pytest.fixture
-def load_periodic_rot_settings_only(sample_solver_session):
-    solver_session = sample_solver_session
+def load_periodic_rot_settings_only(launch_fluent_solver_3ddp):
+    solver_session = launch_fluent_solver_3ddp
     input_type, input_name = download_input_file(
         "pyfluent/periodic_rot", "periodic_rot.cas.h5"
     )
@@ -226,5 +245,20 @@ def load_disk_mesh(launch_fluent_solver_2ddp_t2):
     solver_session = launch_fluent_solver_2ddp_t2
     input_type, input_name = download_input_file("pyfluent/rotating_disk", "disk.msh")
     solver_session.file.read(file_type=input_type, file_name=input_name)
+    yield solver_session
+    solver_session.exit()
+
+
+@pytest.fixture
+def load_disk_settings_only(launch_fluent_solver_2ddp):
+    solver_session = launch_fluent_solver_2ddp
+    input_type, input_name = download_input_file(
+        "pyfluent/rotating_disk", "disk.cas.h5"
+    )
+    solver_session.file.read(
+        file_type=input_type,
+        file_name=input_name,
+        lightweight_setup=True,
+    )
     yield solver_session
     solver_session.exit()

--- a/tests/util/fixture_fluent.py
+++ b/tests/util/fixture_fluent.py
@@ -118,6 +118,21 @@ def load_mixing_elbow_case_dat(launch_fluent_solver_3ddp_t2):
 
 
 @pytest.fixture
+def load_mixing_elbow_settings_only(sample_solver_session):
+    solver_session = sample_solver_session
+    input_type, input_name = download_input_file(
+        "pyfluent/mixing_elbow", "mixing_elbow.cas.h5"
+    )
+    solver_session.file.read(
+        file_type=input_type,
+        file_name=input_name,
+        lightweight_setup=True,
+    )
+    yield solver_session
+    solver_session.exit()
+
+
+@pytest.fixture
 def load_static_mixer_case(sample_solver_session):
     solver = sample_solver_session
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
@@ -187,6 +202,21 @@ def load_periodic_rot_cas(launch_fluent_solver_3ddp_t2):
         "pyfluent/periodic_rot", "periodic_rot.cas.h5"
     )
     solver_session.file.read(file_type=input_type, file_name=input_name)
+    yield solver_session
+    solver_session.exit()
+
+
+@pytest.fixture
+def load_periodic_rot_settings_only(sample_solver_session):
+    solver_session = sample_solver_session
+    input_type, input_name = download_input_file(
+        "pyfluent/periodic_rot", "periodic_rot.cas.h5"
+    )
+    solver_session.file.read(
+        file_type=input_type,
+        file_name=input_name,
+        lightweight_setup=True,
+    )
     yield solver_session
     solver_session.exit()
 


### PR DESCRIPTION
To speed up solver mode unit tests, tests that don't require loading the mesh have been set to call `root.file.read` with the parameter `lightweight_setup=True`.