### PR TITLE
Change name of test_initialize

### DIFF
--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -4,7 +4,7 @@ from util.fixture_fluent import download_input_file
 
 @pytest.mark.quick
 @pytest.mark.setup
-def test_initialize(launch_fluent_solver_3ddp):
+def test_initialize_settings(launch_fluent_solver_3ddp):
     solver = launch_fluent_solver_3ddp
     input_type, input_name = download_input_file(
         "pyfluent/wigley_hull",
@@ -70,8 +70,6 @@ def test_initialize(launch_fluent_solver_3ddp):
         "boundary_zone": 3,
         "flat_init": True,
     }
-    # solver.solution.initialization.hybrid_initialize()
-    # solver.exit()
 
 
 @pytest.mark.quick

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -3,7 +3,7 @@ from util.fixture_fluent import download_input_file
 
 
 @pytest.mark.settings_only
-def test_initialize(launch_fluent_solver_3ddp):
+def test_initialization_settings(launch_fluent_solver_3ddp):
     solver = launch_fluent_solver_3ddp
     input_type, input_name = download_input_file(
         "pyfluent/wigley_hull",


### PR DESCRIPTION
Currently, the `test_initialize`  solver mode test changes the initialization settings, but never actually calls `hybrid_initialize` as that line is commented out.

This PR changes the name of the test to `test_initialization_settings` and removes the commented-out calls to `root.solution.initialization.hybrid_initialize()` and to `root.exit()` for clarity.