### PR TITLE
feat: Expose new methods in datamodel service.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _DOCS_FILE = os.path.join(
 shutil.copy2(_README_FILE, _DOCS_FILE)
 
 install_requires = [
-    "ansys-api-fluent>=0.3.18",
+    "ansys-api-fluent>=0.3.20",
     "ansys-platform-instancemanagement~=1.0",
     "grpcio>=1.30.0",
     "grpcio-health-checking>=1.30.0",

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -331,6 +331,38 @@ class DatamodelService(StreamingService):
         response = self._impl.get_state(request)
         return _convert_variant_to_value(response.state)
 
+    def get_object_names(self, rules, path):
+        request = DataModelProtoModule.GetStateRequest()
+        request.rules = rules
+        request.path = convert_path_to_se_path(path)
+        response = self._impl.get_object_names(request)
+        return response.names
+
+    def rename(self, new_name, rules, path) -> None:
+        request = DataModelProtoModule.RenameRequest()
+        request.rules = rules
+        request.path = convert_path_to_se_path(path)
+        request.new_name = new_name
+        request.wait = True
+        self._impl.rename(request)
+
+    def delete_child_objects(self, child_names, rules, path) -> None:
+        request = DataModelProtoModule.DeleteChildObjectsRequest()
+        request.rules = rules
+        request.path = convert_path_to_se_path(path)
+        for name in child_names:
+            request.child_names.names.append(name)
+        request.wait = True
+        self._impl.delete_child_objects(request)
+
+    def delete_all_child_objects(self, rules, path):
+        request = DataModelProtoModule.DeleteChildObjectsRequest()
+        request.rules = rules
+        request.path = convert_path_to_se_path(path)
+        request.delete_all = True
+        request.wait = True
+        self._impl.delete_child_objects(request)
+
     def set_state(self, rules: str, path: str, state: _TValue) -> None:
         request = DataModelProtoModule.SetStateRequest(
             rules=rules, path=path, wait=True
@@ -1146,40 +1178,20 @@ class PyNamedObjectContainer:
         return child_object_display_names
 
     def get_object_names(self) -> Any:
-        request = DataModelProtoModule.GetStateRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        response = self.service.get_object_names(request)
-        return response.names
+        return self.service.get_object_names(self.rules, self.path)
 
     getChildObjectDisplayNames = get_object_names
 
     def rename(self, new_name) -> None:
-        request = DataModelProtoModule.RenameRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.new_name = new_name
-        request.wait = True
-        self.service.rename(request)
+        self.service.rename(new_name, self.rules, self.path)
 
     def delete_child_objects(self, child_names):
-        request = DataModelProtoModule.DeleteChildObjectsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        for name in child_names:
-            request.child_names.names.append(name)
-        request.wait = True
-        self.service.delete_child_objects(request)
+        self.service.delete_child_objects(child_names, self.rules, self.path)
 
     deleteChildObjects = delete_child_objects
 
     def delete_all_child_objects(self):
-        request = DataModelProtoModule.DeleteChildObjectsRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        request.delete_all = True
-        request.wait = True
-        self.service.delete_child_objects(request)
+        self.service.delete_all_child_objects(self.rules, self.path)
 
     deleteAllChildObjects = delete_all_child_objects
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -370,6 +370,12 @@ class DatamodelService(StreamingService):
         _convert_value_to_variant(state, request.state)
         self._impl.set_state(request)
 
+    def fix_state(self, rules, path) -> None:
+        request = DataModelProtoModule.FixStateRequest()
+        request.rules = rules
+        request.path = convert_path_to_se_path(path)
+        self._impl.fix_state(request)
+
     def update_dict(
         self, rules: str, path: str, dict_state: dict[str, _TValue]
     ) -> None:
@@ -592,10 +598,7 @@ class PyStateContainer(PyCallableStateObject):
     getState = get_state
 
     def fix_state(self) -> None:
-        request = DataModelProtoModule.FixStateRequest()
-        request.rules = self.rules
-        request.path = convert_path_to_se_path(self.path)
-        self.service.fix_state(request)
+        self.service.fix_state(self.rules, self.path)
 
     fixState = fix_state
 

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -282,7 +282,7 @@ def test_datamodel_streaming_no_commands_diff_state(
     assert "ImportGeometry:ImportGeometry1" not in (y for x in cb.states for y in x)
 
 
-@pytest.mark.fluent_version(">=23.2")
+@pytest.mark.fluent_version(">=24.2")
 @pytest.mark.codegen_required
 def test_get_object_names_wtm(new_mesh_session):
     meshing = new_mesh_session

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -354,3 +354,115 @@ def test_generic_datamodel(new_solver_session):
     solver.scheme_eval.scheme_eval("(init-flserver)")
     flserver = PyMenuGeneric(solver.datamodel_service_se, "flserver")
     assert flserver.Case.Solution.Calculation.TimeStepSize() == 1.0
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_named_object_specific_methods_using_flserver(new_solver_session):
+    import_file_name = examples.download_file(
+        "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+    )
+    solver = new_solver_session
+    solver.file.read(file_type="case", file_name=import_file_name)
+    solver.solution.initialization.hybrid_initialize()
+    solver.solution.run_calculation.iterate(iter_count=10)
+    solver.tui.display.objects.create(
+        "contour",
+        "contour-z1",
+        "field",
+        "velocity-magnitude",
+        "surfaces-list",
+        "cold-inlet",
+    )
+    solver.tui.display.objects.create(
+        "contour",
+        "contour-z2",
+        "field",
+        "velocity-magnitude",
+        "surfaces-list",
+        "hot-inlet",
+    )
+    solver.tui.display.objects.create(
+        "contour",
+        "contour-z3",
+        "field",
+        "velocity-magnitude",
+        "surfaces-list",
+        "outlet",
+    )
+    solver.tui.display.objects.create(
+        "contour",
+        "contour-z4",
+        "field",
+        "velocity-magnitude",
+        "surfaces-list",
+        "wall-elbow",
+    )
+    solver.tui.display.objects.create(
+        "contour",
+        "contour-z5",
+        "field",
+        "velocity-magnitude",
+        "surfaces-list",
+        "wall-inlet",
+    )
+
+    flserver = PyMenuGeneric(solver.datamodel_service_se, "flserver")
+
+    assert set(flserver.Case.Results.Graphics.Contour.get_object_names()) == {
+        "contour-z1",
+        "contour-z2",
+        "contour-z3",
+        "contour-z4",
+        "contour-z5",
+    }
+
+    assert "contour-x1" not in flserver.Case.Results.Graphics.Contour.get_object_names()
+
+    flserver.Case.Results.Graphics.Contour["contour-z1"].rename("contour-x1")
+
+    assert "contour-x1" in flserver.Case.Results.Graphics.Contour.get_object_names()
+
+    flserver.Case.Results.Graphics.Contour.delete_child_objects(
+        ["contour-x1", "contour-z2"]
+    )
+
+    assert set(flserver.Case.Results.Graphics.Contour.get_object_names()) == {
+        "contour-z3",
+        "contour-z4",
+        "contour-z5",
+    }
+
+    flserver.Case.Results.Graphics.Contour.delete_all_child_objects()
+
+    assert not flserver.Case.Results.Graphics.Contour.get_object_names()
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_named_object_specific_methods(new_mesh_session):
+    meshing = new_mesh_session
+
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+
+    assert set(meshing.workflow.TaskObject.get_object_names()) == {
+        "Import Geometry",
+        "Add Local Sizing",
+        "Generate the Surface Mesh",
+        "Describe Geometry",
+        "Apply Share Topology",
+        "Enclose Fluid Regions (Capping)",
+        "Update Boundaries",
+        "Create Regions",
+        "Update Regions",
+        "Add Boundary Layers",
+        "Generate the Volume Mesh",
+    }
+
+    assert "xyz" not in meshing.workflow.TaskObject.get_object_names()
+
+    meshing.workflow.TaskObject["Import Geometry"].rename("xyz")
+
+    assert "xyz" in meshing.workflow.TaskObject.get_object_names()
+
+    meshing.workflow.TaskObject.delete_all_child_objects()
+
+    assert not meshing.workflow.TaskObject.get_object_names()


### PR DESCRIPTION
New methods like 'get_object_names', 'rename', 'delete_child_objects', 'delete_all_child_objects' and 'fix_state' has been implemented in the server side for pyconsole integration (migrating these methods to datamodel instead of PyStateEngine).

This PR contains client side updates to expose those methods as well as test cases to check the implementation.