### PR TITLE
feat: Some refactoring of datamodel events registration code

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -75,4 +75,5 @@ DATAMODEL_USE_NOCOMMANDS_DIFF_STATE = True
 
 
 def wrap_api_call(f, *args, **kwargs):
+    # overwritten in PyConsole
     return f(*args, **kwargs)

--- a/src/ansys/fluent/core/services/__init__.py
+++ b/src/ansys/fluent/core/services/__init__.py
@@ -1,6 +1,7 @@
 from ansys.fluent.core.services.datamodel_se import (
     DatamodelService as DatamodelService_SE,
 )
+from ansys.fluent.core.services.field_data import FieldData, FieldInfo
 from ansys.fluent.core.services.scheme_eval import SchemeEval
 from ansys.fluent.core.services.settings import SettingsService
 
@@ -8,6 +9,8 @@ _service_cls_by_name = {
     "datamodel": DatamodelService_SE,
     "settings": SettingsService,
     "scheme_eval": SchemeEval,
+    "field_data": FieldData,
+    "field_info": FieldInfo,
 }
 
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -13,7 +13,7 @@ from ansys.fluent.core.services.datamodel_tui import (
     DatamodelService as DatamodelService_TUI,
 )
 from ansys.fluent.core.services.events import EventsService
-from ansys.fluent.core.services.field_data import FieldData, FieldDataService, FieldInfo
+from ansys.fluent.core.services.field_data import FieldDataService
 from ansys.fluent.core.services.monitor import MonitorsService
 from ansys.fluent.core.session_shared import (  # noqa: F401
     _CODEGEN_MSG_DATAMODEL,
@@ -170,10 +170,10 @@ class BaseSession:
         self._field_data_service = self.fluent_connection.create_grpc_service(
             FieldDataService, self.error_state
         )
-        self.field_info = FieldInfo(
+        self.field_info = service_creator("field_info").create(
             self._field_data_service, _IsDataValid(self.scheme_eval)
         )
-        self.field_data = FieldData(
+        self.field_data = service_creator("field_data").create(
             self._field_data_service,
             self.field_info,
             _IsDataValid(self.scheme_eval),


### PR DESCRIPTION
Required for PyConsole development (moved the `add_on_*` methods at `DatamodelService` level which will be overwritten on PyConsole side)