### PR TITLE
refactor: Remove wait_on_refresh

### DIFF
--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -294,7 +294,6 @@ class BaseTask:
             return ArgumentWrapper(self, attr)
         except Exception as ex:
             logger.debug(str(ex))
-        # self._command_source._wait_on_refresh()
         return self._task_objects.get(attr, None)
 
     def __setattr__(self, attr, value):
@@ -911,7 +910,6 @@ class WorkflowWrapper:
         )  # or self._task_with_cmd_matching_help_string(attr)
         if obj:
             return obj
-        # self._wait_on_refresh()
         return self._task_objects.get(attr, None)
 
     def __dir__(self):
@@ -924,21 +922,6 @@ class WorkflowWrapper:
     def __call__(self):
         """Delegate calls to the underlying workflow."""
         return self._workflow()
-
-    # def _wait_on_refresh(self, time_unit=0.1, skip_check=False):
-    #     if not skip_check:
-    #         t0 = time()
-    #     if skip_check or threading.get_ident() == self._main_thread_ident:
-    #         refresh_count = self._refresh_count
-    #         orig_refresh_count = refresh_count
-    #         sleep(20 * time_unit)
-    #         while self._refreshing or self._refresh_count > refresh_count:
-    #             refresh_count = self._refresh_count
-    #             sleep(time_unit)
-    #         if self._refresh_count > orig_refresh_count:
-    #             self._wait_on_refresh(time_unit=time_unit, skip_check=True)
-    #     if not skip_check:
-    #         logger.debug("_wait_on_refresh time taken {time() - t0}")
 
     def _workflow_state(self):
         return self._workflow()

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from time import sleep
 from typing import Any, Iterator, List, Optional, Tuple
 import warnings
 
@@ -966,7 +965,6 @@ class WorkflowWrapper:
             def refresh_after_sleep(_):
                 while self._refreshing:
                     logger.debug("Already _refreshing, ...")
-                    sleep(0.1)
                 self._refreshing = True
                 logger.debug("Call _refresh_task_accessors")
                 _refresh_task_accessors(self)

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from time import sleep, time
+from time import sleep
 from typing import Any, Iterator, List, Optional, Tuple
 import warnings
 
@@ -294,7 +294,7 @@ class BaseTask:
             return ArgumentWrapper(self, attr)
         except Exception as ex:
             logger.debug(str(ex))
-        self._command_source._wait_on_refresh()
+        # self._command_source._wait_on_refresh()
         return self._task_objects.get(attr, None)
 
     def __setattr__(self, attr, value):
@@ -911,7 +911,7 @@ class WorkflowWrapper:
         )  # or self._task_with_cmd_matching_help_string(attr)
         if obj:
             return obj
-        self._wait_on_refresh()
+        # self._wait_on_refresh()
         return self._task_objects.get(attr, None)
 
     def __dir__(self):
@@ -925,20 +925,20 @@ class WorkflowWrapper:
         """Delegate calls to the underlying workflow."""
         return self._workflow()
 
-    def _wait_on_refresh(self, time_unit=0.1, skip_check=False):
-        if not skip_check:
-            t0 = time()
-        if skip_check or threading.get_ident() == self._main_thread_ident:
-            refresh_count = self._refresh_count
-            orig_refresh_count = refresh_count
-            sleep(20 * time_unit)
-            while self._refreshing or self._refresh_count > refresh_count:
-                refresh_count = self._refresh_count
-                sleep(time_unit)
-            if self._refresh_count > orig_refresh_count:
-                self._wait_on_refresh(time_unit=time_unit, skip_check=True)
-        if not skip_check:
-            logger.debug("_wait_on_refresh time taken {time() - t0}")
+    # def _wait_on_refresh(self, time_unit=0.1, skip_check=False):
+    #     if not skip_check:
+    #         t0 = time()
+    #     if skip_check or threading.get_ident() == self._main_thread_ident:
+    #         refresh_count = self._refresh_count
+    #         orig_refresh_count = refresh_count
+    #         sleep(20 * time_unit)
+    #         while self._refreshing or self._refresh_count > refresh_count:
+    #             refresh_count = self._refresh_count
+    #             sleep(time_unit)
+    #         if self._refresh_count > orig_refresh_count:
+    #             self._wait_on_refresh(time_unit=time_unit, skip_check=True)
+    #     if not skip_check:
+    #         logger.debug("_wait_on_refresh time taken {time() - t0}")
 
     def _workflow_state(self):
         return self._workflow()


### PR DESCRIPTION
Just commenting out the "_wait_on_refresh" method from the workflow.py code and running all the related tests suggest that it is running fine. So, we can get rid of this method with some level of confidence. What are your view?

Got rid of all instances of sleep.

cc @seanpearsonuk , @mkundu1 