### PR TITLE
feat: datamodel_tui refactoring

### DIFF
--- a/src/ansys/fluent/core/services/__init__.py
+++ b/src/ansys/fluent/core/services/__init__.py
@@ -5,6 +5,7 @@ from ansys.fluent.core.services.datamodel_tui import (
     DatamodelService as DatamodelService_TUI,
 )
 from ansys.fluent.core.services.field_data import FieldData, FieldInfo
+from ansys.fluent.core.services.monitor import MonitorsService
 from ansys.fluent.core.services.scheme_eval import SchemeEval
 from ansys.fluent.core.services.settings import SettingsService
 
@@ -15,6 +16,7 @@ _service_cls_by_name = {
     "scheme_eval": SchemeEval,
     "field_data": FieldData,
     "field_info": FieldInfo,
+    "monitors": MonitorsService,
 }
 
 

--- a/src/ansys/fluent/core/services/__init__.py
+++ b/src/ansys/fluent/core/services/__init__.py
@@ -1,12 +1,16 @@
 from ansys.fluent.core.services.datamodel_se import (
     DatamodelService as DatamodelService_SE,
 )
+from ansys.fluent.core.services.datamodel_tui import (
+    DatamodelService as DatamodelService_TUI,
+)
 from ansys.fluent.core.services.field_data import FieldData, FieldInfo
 from ansys.fluent.core.services.scheme_eval import SchemeEval
 from ansys.fluent.core.services.settings import SettingsService
 
 _service_cls_by_name = {
     "datamodel": DatamodelService_SE,
+    "tui": DatamodelService_TUI,
     "settings": SettingsService,
     "scheme_eval": SchemeEval,
     "field_data": FieldData,

--- a/src/ansys/fluent/core/services/api_upgrade.py
+++ b/src/ansys/fluent/core/services/api_upgrade.py
@@ -1,26 +1,15 @@
 import os
 from typing import TypeVar
 
-import grpc
-
-from ansys.fluent.core.services.scheme_eval import SchemeEval, SchemeEvalService
+from ansys.fluent.core.services.scheme_eval import SchemeEval
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 _TApiUpgradeAdvisor = TypeVar("_TApiUpgradeAdvisor", bound="ApiUpgradeAdvisor")
 
 
 class ApiUpgradeAdvisor:
-    def __init__(
-        self,
-        channel: grpc.Channel,
-        metadata: list[tuple[str, str]],
-        fluent_error_state,
-        version: str,
-        mode: str,
-    ) -> None:
-        self._scheme_eval = SchemeEval(
-            SchemeEvalService(channel, metadata, fluent_error_state)
-        ).scheme_eval
+    def __init__(self, scheme_eval: SchemeEval, version: str, mode: str) -> None:
+        self._scheme_eval = scheme_eval.scheme_eval
         self._version = version
         self._mode = mode
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -103,10 +103,7 @@ class Attribute(Enum):
 
 
 class DatamodelServiceImpl:
-    """Wraps the StateEngine-based datamodel gRPC service of Fluent.
-
-    Using the methods from the ``PyMenu`` class is recommended.
-    """
+    """Wraps the StateEngine-based datamodel gRPC service of Fluent."""
 
     def __init__(
         self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
@@ -355,6 +352,8 @@ class EventSubscription:
 
 
 class DatamodelService(StreamingService):
+    """Pure Python wrapper of DatamodelServiceImpl."""
+
     def __init__(
         self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
     ) -> None:

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -17,6 +17,7 @@ from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
     TracingInterceptor,
+    WrapApiCallInterceptor,
 )
 
 Path = list[str]
@@ -38,6 +39,7 @@ class DatamodelServiceImpl:
             ErrorStateInterceptor(self._fluent_error_state),
             TracingInterceptor(),
             BatchInterceptor(),
+            WrapApiCallInterceptor(),
         )
         self._stub = DataModelGrpcModule.DataModelStub(intercept_channel)
         self._metadata = metadata
@@ -137,7 +139,7 @@ class DatamodelService:
     ) -> Any:
         request = DataModelProtoModule.GetAttributeValueRequest()
         request.path = path
-        request.attribute = attribute
+        request.attribute = DataModelProtoModule.Attribute.Value(attribute.upper())
         if include_unavailable:
             request.args["include_unavailable"] = 1
         response = self._impl.get_attribute_value(request)
@@ -207,8 +209,11 @@ class PyMenu:
         List[str]
             Names of child menus.
         """
+        attribute = DataModelProtoModule.Attribute.Name(
+            DataModelProtoModule.Attribute.CHILD_NAMES
+        ).lower()
         return self._service.get_attribute_value(
-            self._path, DataModelProtoModule.Attribute.CHILD_NAMES, include_unavailable
+            self._path, attribute, include_unavailable
         )
 
     def execute(self, *args, **kwargs) -> Any:
@@ -246,8 +251,11 @@ class PyMenu:
         -------
         str
         """
+        attribute = DataModelProtoModule.Attribute.Name(
+            DataModelProtoModule.Attribute.HELP_STRING
+        ).lower()
         return self._service.get_attribute_value(
-            self._path, DataModelProtoModule.Attribute.HELP_STRING, include_unavailable
+            self._path, attribute, include_unavailable
         )
 
     def get_static_info(self) -> dict[str, Any]:

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -129,10 +129,15 @@ class DatamodelService:
     """Pure Python wrapper of DatamodelServiceImpl."""
 
     def __init__(
-        self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
+        self,
+        channel: grpc.Channel,
+        metadata: list[tuple[str, str]],
+        fluent_error_state,
+        scheme_eval,
     ) -> None:
         """__init__ method of DatamodelService class."""
         self._impl = DatamodelServiceImpl(channel, metadata, fluent_error_state)
+        self._scheme_eval = scheme_eval
 
     def get_attribute_value(
         self, path: str, attribute: str, include_unavailable: bool
@@ -228,9 +233,7 @@ class PyMenu:
             Query result (any Python datatype)
         """
         with ApiUpgradeAdvisor(
-            self._service._impl._channel,
-            self._service._impl._metadata,
-            self._service._impl._fluent_error_state,
+            self._service._scheme_eval,
             self._version,
             self._mode,
         ):

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -24,16 +24,13 @@ Path = list[str]
 logger: logging.Logger = logging.getLogger("pyfluent.tui")
 
 
-class DatamodelService:
-    """Class wrapping the TUI-based datamodel gRPC service of Fluent.
-
-    Using the methods from PyMenu class is recommended.
-    """
+class DatamodelServiceImpl:
+    """Class wrapping the TUI-based datamodel gRPC service of Fluent."""
 
     def __init__(
         self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
     ) -> None:
-        """__init__ method of DatamodelService class."""
+        """__init__ method of DatamodelServiceImpl class."""
         self._channel = channel
         self._fluent_error_state = fluent_error_state
         intercept_channel = grpc.intercept_channel(
@@ -126,6 +123,53 @@ def _convert_gvalue_to_value(gval: Variant) -> Any:
         return val
 
 
+class DatamodelService:
+    """Pure Python wrapper of DatamodelServiceImpl."""
+
+    def __init__(
+        self, channel: grpc.Channel, metadata: list[tuple[str, str]], fluent_error_state
+    ) -> None:
+        """__init__ method of DatamodelService class."""
+        self._impl = DatamodelServiceImpl(channel, metadata, fluent_error_state)
+
+    def get_attribute_value(
+        self, path: str, attribute: str, include_unavailable: bool
+    ) -> Any:
+        request = DataModelProtoModule.GetAttributeValueRequest()
+        request.path = path
+        request.attribute = attribute
+        if include_unavailable:
+            request.args["include_unavailable"] = 1
+        response = self._impl.get_attribute_value(request)
+        return _convert_gvalue_to_value(response.value)
+
+    def execute_command(self, path: str, *args, **kwargs) -> Any:
+        request = DataModelProtoModule.ExecuteCommandRequest()
+        request.path = path
+        if kwargs:
+            for k, v in kwargs.items():
+                _convert_value_to_gvalue(v, request.args.fields[k])
+        else:
+            _convert_value_to_gvalue(args, request.args.fields["tui_args"])
+        return self._impl.execute_command(request)
+
+    def execute_query(self, path: str, *args, **kwargs) -> Any:
+        request = DataModelProtoModule.ExecuteQueryRequest()
+        request.path = path
+        if kwargs:
+            for k, v in kwargs.items():
+                _convert_value_to_gvalue(v, request.args.fields[k])
+        else:
+            _convert_value_to_gvalue(args, request.args.fields["tui_args"])
+        return self._impl.execute_query(request)
+
+    def get_static_info(self, path: str):
+        request = DataModelProtoModule.GetStaticInfoRequest()
+        request.path = path
+        response = self._impl.get_static_info(request)
+        return MessageToDict(response.info, including_default_value_fields=True)
+
+
 class PyMenu:
     """Pythonic wrapper of TUI-based DatamodelService class. Use this class instead of
     directly calling the DatamodelService's method.
@@ -163,32 +207,9 @@ class PyMenu:
         List[str]
             Names of child menus.
         """
-        request = DataModelProtoModule.GetAttributeValueRequest()
-        request.path = self._path
-        request.attribute = DataModelProtoModule.Attribute.CHILD_NAMES
-        if include_unavailable:
-            request.args["include_unavailable"] = 1
-        response = self._service.get_attribute_value(request)
-        return _convert_gvalue_to_value(response.value)
-
-    def _execute_command(
-        self, request: DataModelProtoModule.ExecuteCommandRequest
-    ) -> Any:
-        with ApiUpgradeAdvisor(
-            self._service._channel,
-            self._service._metadata,
-            self._service._fluent_error_state,
-            self._version,
-            self._mode,
-        ):
-            ret = self._service.execute_command(request)
-            return _convert_gvalue_to_value(ret.result)
-
-    def _execute_query(
-        self, request: DataModelProtoModule.ExecuteCommandRequest
-    ) -> Any:
-        ret = self._service.execute_query(request)
-        return _convert_gvalue_to_value(ret.result)
+        return self._service.get_attribute_value(
+            self._path, DataModelProtoModule.Attribute.CHILD_NAMES, include_unavailable
+        )
 
     def execute(self, *args, **kwargs) -> Any:
         """Execute a command or query at a path with positional or keyword arguments.
@@ -199,22 +220,19 @@ class PyMenu:
         Returns
         -------
         Any
-            Query result (any Python datatype) or Future object
-            wrapping TUI output of a command.
+            Query result (any Python datatype)
         """
-        request = DataModelProtoModule.ExecuteCommandRequest()
-        request.path = self._path
-        if kwargs:
-            for k, v in kwargs.items():
-                _convert_value_to_gvalue(v, request.args.fields[k])
-        else:
-            _convert_value_to_gvalue(args, request.args.fields["tui_args"])
-        if self._path.startswith("/query/"):
-            return self._execute_query(request)
-        else:
-            request_str = " ".join(str(request).split())
-            logger.debug(f"TUI Command: {request_str}")
-            return self._execute_command(request)
+        with ApiUpgradeAdvisor(
+            self._service._impl._channel,
+            self._service._impl._metadata,
+            self._service._impl._fluent_error_state,
+            self._version,
+            self._mode,
+        ):
+            if self._path.startswith("/query/"):
+                return self._service.execute_query(self._path, *args, **kwargs)
+            else:
+                return self._service.execute_command(self._path, *args, **kwargs)
 
     def get_doc_string(self, include_unavailable: bool = False) -> str:
         """Get docstring for a menu.
@@ -228,13 +246,9 @@ class PyMenu:
         -------
         str
         """
-        request = DataModelProtoModule.GetAttributeValueRequest()
-        request.path = self._path
-        request.attribute = DataModelProtoModule.Attribute.HELP_STRING
-        if include_unavailable:
-            request.args["include_unavailable"] = 1
-        response = self._service.get_attribute_value(request)
-        return _convert_gvalue_to_value(response.value)
+        return self._service.get_attribute_value(
+            self._path, DataModelProtoModule.Attribute.HELP_STRING, include_unavailable
+        )
 
     def get_static_info(self) -> dict[str, Any]:
         """Get static info at menu level.
@@ -245,10 +259,7 @@ class PyMenu:
             static info
         """
         try:
-            request = DataModelProtoModule.GetStaticInfoRequest()
-            request.path = self._path
-            response = self._service.get_static_info(request)
-            return MessageToDict(response.info, including_default_value_fields=True)
+            return self._service.get_static_info(self._path)
         except RuntimeError:
             return _get_static_info_at_level(self)
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -9,9 +9,6 @@ from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.journaling import Journal
 from ansys.fluent.core.services import service_creator
 from ansys.fluent.core.services.batch_ops import BatchOpsService
-from ansys.fluent.core.services.datamodel_tui import (
-    DatamodelService as DatamodelService_TUI,
-)
 from ansys.fluent.core.services.events import EventsService
 from ansys.fluent.core.services.field_data import FieldDataService
 from ansys.fluent.core.services.monitor import MonitorsService
@@ -130,8 +127,8 @@ class BaseSession:
         if fluent_connection.start_transcript:
             self.transcript.start()
 
-        self.datamodel_service_tui = self.fluent_connection.create_grpc_service(
-            DatamodelService_TUI, self.error_state
+        self.datamodel_service_tui = service_creator("tui").create(
+            fluent_connection._channel, fluent_connection._metadata, self.error_state
         )
 
         self.datamodel_service_se = service_creator("datamodel").create(

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -11,7 +11,6 @@ from ansys.fluent.core.services import service_creator
 from ansys.fluent.core.services.batch_ops import BatchOpsService
 from ansys.fluent.core.services.events import EventsService
 from ansys.fluent.core.services.field_data import FieldDataService
-from ansys.fluent.core.services.monitor import MonitorsService
 from ansys.fluent.core.session_shared import (  # noqa: F401
     _CODEGEN_MSG_DATAMODEL,
     _CODEGEN_MSG_TUI,
@@ -151,8 +150,8 @@ class BaseSession:
             self.events_service, self.error_state, self.fluent_connection._id
         )
 
-        self._monitors_service = self.fluent_connection.create_grpc_service(
-            MonitorsService, self.error_state
+        self._monitors_service = service_creator("monitors").create(
+            fluent_connection._channel, fluent_connection._metadata, self.error_state
         )
         self.monitors_manager = MonitorsManager(
             self.fluent_connection._id, self._monitors_service

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -128,7 +128,10 @@ class BaseSession:
             self.transcript.start()
 
         self.datamodel_service_tui = service_creator("tui").create(
-            fluent_connection._channel, fluent_connection._metadata, self.error_state
+            fluent_connection._channel,
+            fluent_connection._metadata,
+            self.error_state,
+            self.scheme_eval,
         )
 
         self.datamodel_service_se = service_creator("datamodel").create(

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -14,13 +14,13 @@ from ansys.fluent.core.services.reduction import Reduction, ReductionService
 from ansys.fluent.core.services.svar import SVARData, SVARInfo, SVARService
 from ansys.fluent.core.session import _CODEGEN_MSG_TUI, BaseSession, _get_preferences
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL
+from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.solver.flobject import (
     Group,
     NamedObject,
     SettingsBase,
     StateType,
 )
-from ansys.fluent.core.solver.flobject import get_root as settings_get_root
 import ansys.fluent.core.solver.function.reduction as reduction_old
 from ansys.fluent.core.systemcoupling import SystemCoupling
 from ansys.fluent.core.utils.execution import asynchronous
@@ -163,7 +163,7 @@ class Solver(BaseSession):
     def _root(self):
         """Root settings object."""
         if self._settings_root is None:
-            self._settings_root = settings_get_root(
+            self._settings_root = flobject.get_root(
                 flproxy=self._settings_service, version=self.version
             )
         return self._settings_root


### PR DESCRIPTION
1. datamodel_tui refactoring for pyconsole work (extract a pure python service class to overwrite from pyconsole)
2. A small change so that flobject.get_root can be overwritten in pyconsole (to avoid the hash comparison for pyconsole as that will always fail as it compares the local static-info and static-info over grpc)
3. Refactoring required for monitor service implementation in PyConsole.