### PR TITLE
feat: workflow updates.

### DIFF
--- a/src/ansys/fluent/core/meshing/meshing_workflow.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow.py
@@ -38,6 +38,7 @@ class MeshingWorkflow(WorkflowWrapper):
         self._is_ftm = False
         self._part_management = part_management
         self._pm_file_management = pm_file_management
+        self._task_names_map = {}
 
     def watertight(self, dynamic_interface: bool) -> None:
         """Initialize a watertight workflow.
@@ -89,3 +90,25 @@ class MeshingWorkflow(WorkflowWrapper):
         """
         if self._is_ftm:
             return self._pm_file_management
+
+    def __getattr__(self, item):
+        if not self._task_names_map:
+            for task in self.TaskObject().keys():
+                python_task_name = (
+                    str(task)
+                    .lower()
+                    .replace(" ", "_")
+                    .replace("_the", "")
+                    .replace("(", "")
+                    .replace(")", "")
+                )
+                self._task_names_map[python_task_name] = task
+
+        for python_name, task_name in self._task_names_map.items():
+            if item == python_name:
+                return self.task(task_name)
+
+        return AttributeError(
+            f"'{item}' is not a valid attribute name."
+            f"\nAllowed attributes are: {list(self._task_names_map.keys())}."
+        )


### PR DESCRIPTION
Here we have made an attempt to remove the string aspects in workflow objects.

Now, meshing.workflow.import_geometry is equivalent to meshing.workflow.task("Import Geometry").

If the user mistypes an attribute, he gets a suggestion of the allowed atrributes in form of python names.