### PR TITLE
refactor: Correct attribute access path

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -565,17 +565,22 @@ class Group(SettingsBase[DictStateType]):
 
     def _get_parent_of_active_child_names(self, name):
         parents = ""
+        path_list = []
         for parent in self.get_active_child_names():
             try:
                 if hasattr(getattr(self, parent), str(name)):
+                    path_list.append(f"\n {self.python_path}.{parent}.{str(name)} \n")
                     if len(parents) != 0:
-                        parents += "." + parent
+                        parents += ", " + parent
                     else:
                         parents += parent
             except AttributeError:
                 pass
+        if len(path_list):
+            print(f"\n {str(name)} can be accessed from the following paths: \n")
+            for path in path_list:
+                print(path)
         if len(parents):
-            print(f"\n {name} is a child of {parents} \n")
             return f"\n {name} is a child of {parents} \n"
 
     def __getattribute__(self, name):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -569,7 +569,7 @@ class Group(SettingsBase[DictStateType]):
         for parent in self.get_active_child_names():
             try:
                 if hasattr(getattr(self, parent), str(name)):
-                    path_list.append(f"\n {self.python_path}.{parent}.{str(name)} \n")
+                    path_list.append(f"    {self.python_path}.{parent}.{str(name)}")
                     if len(parents) != 0:
                         parents += ", " + parent
                     else:


### PR DESCRIPTION
If a field x is located at active paths a.b.x and a.b.c.x and the user queries a.x, The paths should be a.b.x and a.b.c.x.

Incorrect path (existing output) - 

![image](https://github.com/ansys/pyfluent/assets/106588300/be9b1d46-0571-4aab-9604-07f2b2fc9c74)

`-------------------------------------`

Corrected path - 

![image](https://github.com/ansys/pyfluent/assets/106588300/0f2c2aa8-6834-439d-b63c-3415b0a109b9)

`-------------------------------------`

![image](https://github.com/ansys/pyfluent/assets/106588300/d6e1d789-937c-4881-8b0e-b88efaca0373)

