### PR TITLE
docs: Document additional slurm options

### DIFF
--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -209,6 +209,8 @@ scheduler without using any bash script:
       additional_arguments="-t16 -cnf=m1:8,m2:8",
    )
 
+.. vale off
+
 The keys ``scheduler_headnode``, ``scheduler_queue`` and ``scheduler_account`` are
 optional and should be specified in a similar manner to Fluent's scheduler options.
 Here, the :func:`launch_fluent <ansys.fluent.core.launcher.launcher.launch_fluent>`
@@ -216,6 +218,8 @@ method returns a :class:`SlurmFuture <ansys.fluent.core.launcher.slurm_launcher.
 instance from which the PyFluent session can be extracted. For a detailed usage, see the
 documentation of the :mod:`slurm_launcher <ansys.fluent.core.launcher.slurm_launcher>`
 module.
+
+.. vale on
 
 The ``scheduler_options`` parameter doesn't support the automatic scheduler allocation,
 the ``-t`` and ``-cnf`` arguments must be passed to the

--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -109,7 +109,7 @@ scheduler environments are Univa Grid Engine (UGE), Load Sharing Facility (LSF),
 Portable Batch System (PBS), and Slurm.
 
 This example shows a bash shell script that can be submitted to a Slurm
-scheduler using the ```sbatch``` command:  
+scheduler using the ```sbatch``` command:
 
 .. code:: bash
 
@@ -192,3 +192,32 @@ For distributed parallel processing, you usually pass both parameters:
       mode="solver",
       additional_arguments="-t16 -cnf=m1:8,m2:8",
    )
+
+The :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>` method
+also supports the ``scheduler_options`` parameter to submit the Fluent job to a Slurm
+scheduler without using any bash script:
+
+.. code:: python
+
+   slurm = pyfluent.launch_fluent(
+      scheduler_options={
+         "scheduler": "slurm",
+         "scheduler_headnode": "<headnode>",
+         "scheduler_queue": "<queue>",
+         "scheduler_account": "<account>"
+      },
+      additional_arguments="-t16 -cnf=m1:8,m2:8",
+   )
+
+The keys ``scheduler_headnode``, ``scheduler_queue`` and ``scheduler_account`` are
+optional and should be specified in a similar manner to Fluent's scheduler options.
+Here, the :func:`launch_fluent <ansys.fluent.core.launcher.launcher.launch_fluent>`
+method returns a :class:`SlurmFuture <ansys.fluent.core.launcher.slurm_launcher.SlurmFuture>`
+instance from which the PyFluent session can be extracted. For a detailed usage, see the
+documentation of the :mod:`slurm_launcher <ansys.fluent.core.launcher.slurm_launcher>`
+module.
+
+The ``scheduler_options`` parameter doesn't support the automatic scheduler allocation,
+the ``-t`` and ``-cnf`` arguments must be passed to the
+:func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>` method
+using the ``additional_arguments`` parameter for distributed parallel processing.

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -192,6 +192,13 @@ def launch_fluent(
     scheduler_options : dict, optional
         Dictionary containing scheduler options. Default is None.
 
+        Currently only the Slurm scheduler is supported. The ``scheduler_options``
+        dictionary must be of the form ``{"scheduler": "slurm",
+        "scheduler_headnode": "<headnode>", "scheduler_queue": "<queue>",
+        "scheduler_account": "<account>"}``. The keys ``scheduler_headnode``,
+        ``scheduler_queue`` and ``scheduler_account`` are optional and should be
+        specified in a similar manner to Fluent's scheduler options.
+
     Returns
     -------
     :obj:`~typing.Union` [:class:`Meshing<ansys.fluent.core.session_meshing.Meshing>`, \

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -2,8 +2,9 @@
 
 Examples
 --------
->>> # The keys scheduler_headnode, scheduler_queue and scheduler_account are optional
->>> # and should be specified in a similar manner to Fluent's scheduler options.
+Note that the keys ``scheduler_headnode``, ``scheduler_queue`` and ``scheduler_account``
+are optional and should be specified in a similar manner to Fluent's scheduler options.
+
 >>> slurm = pyfluent.launch_fluent(
 ...   scheduler_options={
 ...     "scheduler": "slurm",

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -2,13 +2,22 @@
 
 Examples
 --------
->>> # The keys scheduler_headnode, scheduler_queue and scheduler_account are optional and should be specified in a similar manner to Fluent's scheduler options.
->>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm", "scheduler_headnode": "<headnode>", "scheduler_queue": "<queue>", "scheduler_account": "<account>"})
+>>> # The keys scheduler_headnode, scheduler_queue and scheduler_account are optional
+>>> # and should be specified in a similar manner to Fluent's scheduler options.
+>>> slurm = pyfluent.launch_fluent(
+...   scheduler_options={
+...     "scheduler": "slurm",
+...     "scheduler_headnode": "<headnode>",
+...     "scheduler_queue": "<queue>",
+...     "scheduler_account": "<account>"
+...   },
+...   additional_arguments="-t16 -cnf=m1:8,m2:8",
+... )
 >>> type(slurm)
 <class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
 >>> slurm.pending(), slurm.running(), slurm.done() # before Fluent is launched
 (True, False, False)
->>>  slurm.pending(), slurm.running(), slurm.done() # after Fluent is launched
+>>> slurm.pending(), slurm.running(), slurm.done() # after Fluent is launched
 (False, True, False)
 >>> session = slurm.result()
 >>> type(session)

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -2,7 +2,8 @@
 
 Examples
 --------
->>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm"})
+>>> # The keys scheduler_headnode, scheduler_queue and scheduler_account are optional and should be specified in a similar manner to Fluent's scheduler options.
+>>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm", "scheduler_headnode": "<headnode>", "scheduler_queue": "<queue>", "scheduler_account": "<account>"})
 >>> type(slurm)
 <class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
 >>> slurm.pending(), slurm.running(), slurm.done() # before Fluent is launched


### PR DESCRIPTION
`scheduler_options` argument of `launch_fluent`:
![image](https://github.com/ansys/pyfluent/assets/94432368/7e034759-36b9-43aa-812d-ad2ce1a3c533)

`Launch or connect to Fluent` section of User guide:
![image](https://github.com/ansys/pyfluent/assets/94432368/36ca8acc-554d-44ad-97e0-d43d59b24a08)

