### PR TITLE
refactor: Clean up the launcher code.

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -171,16 +171,13 @@ class DockerLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.mode = _get_mode(mode)
-        self.new_session = self.mode.value[1]
+        self.new_session = self.mode.value
 
     def __call__(self):
         if self.mode == FluentMode.SOLVER_ICING:
             self.argvals["fluent_icing"] = True
         args = _build_fluent_launch_args_string(**self.argvals).split()
-        if (
-            self.mode == FluentMode.MESHING_MODE
-            or self.mode == FluentMode.PURE_MESHING_MODE
-        ):
+        if FluentMode.is_meshing(self.mode):
             args.append(" -meshing")
         if self.container_dict is None:
             setattr(self, "container_dict", {})

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
     FluentMode,
-    _get_argvals,
+    _get_mode,
     _process_invalid_args,
-    _process_kwargs,
     launch_remote_fluent,
 )
 
@@ -22,7 +21,6 @@ class PIMLauncher:
 
     def __init__(
         self,
-        argvals: Optional[Any] = None,
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -47,7 +45,6 @@ class PIMLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
-        **kwargs,
     ):
         """Launch Fluent session in `PIM<https://pypim.docs.pyansys.com/version/stable/>` mode.
 
@@ -157,13 +154,12 @@ class PIMLauncher:
         The allocated machines and core counts are queried from the scheduler environment and
         passed to Fluent.
         """
-        _process_kwargs(kwargs)
-        del kwargs
         del start_container
         argvals = locals().copy()
+        del argvals["self"]
         _process_invalid_args(dry_run, "pim", argvals)
-        args = _get_argvals(argvals, mode)
-        argvals.update(args)
+        self.mode = _get_mode(mode)
+        self.new_session = self.mode.value[1]
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():
@@ -196,7 +192,7 @@ class PIMLauncher:
             start_transcript=self.start_transcript,
             product_version=fluent_product_version,
             cleanup_on_exit=self.cleanup_on_exit,
-            meshing_mode=self.meshing_mode,
+            mode=self.mode,
             dimensionality=self.version,
             launcher_args=self.argvals,
         )

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -159,7 +159,7 @@ class PIMLauncher:
         del argvals["self"]
         _process_invalid_args(dry_run, "pim", argvals)
         self.mode = _get_mode(mode)
-        self.new_session = self.mode.value[1]
+        self.new_session = self.mode.value
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -29,7 +29,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _await_fluent_launch,
     _build_journal_argument,
     _generate_launch_string,
-    _get_argvals,
+    _get_mode,
     _get_server_info_file_name,
     _get_subprocess_kwargs_for_fluent,
     _process_invalid_args,
@@ -179,10 +179,11 @@ class SlurmLauncher:
         dry_run = kwargs.get("dry_run")
         mode = kwargs.get("mode")
         argvals = kwargs.copy()
+        del argvals["self"]
         del kwargs
         _process_invalid_args(dry_run, "slurm", argvals)
-        args = _get_argvals(argvals, mode)
-        argvals.update(args)
+        self.mode = _get_mode(mode)
+        self.new_session = self.mode.value[1]
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = -1
         for arg_name, arg_values in argvals.items():
@@ -202,7 +203,7 @@ class SlurmLauncher:
         self._argvals.update(self._argvals["scheduler_options"])
         launch_cmd = _generate_launch_string(
             self._argvals,
-            self._meshing_mode,
+            self.mode,
             self._show_gui,
             self._additional_arguments,
             self._server_info_file_name,

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -179,11 +179,10 @@ class SlurmLauncher:
         dry_run = kwargs.get("dry_run")
         mode = kwargs.get("mode")
         argvals = kwargs.copy()
-        del argvals["self"]
         del kwargs
         _process_invalid_args(dry_run, "slurm", argvals)
         self.mode = _get_mode(mode)
-        self.new_session = self.mode.value[1]
+        self._new_session = self.mode.value
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = -1
         for arg_name, arg_values in argvals.items():

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -172,7 +172,7 @@ class StandaloneLauncher:
         del argvals["self"]
         _process_invalid_args(dry_run, "standalone", argvals)
         self.mode = _get_mode(mode)
-        self.new_session = self.mode.value[1]
+        self.new_session = self.mode.value
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -13,13 +13,12 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _build_journal_argument,
     _confirm_watchdog_start,
     _generate_launch_string,
-    _get_argvals,
+    _get_mode,
     _get_server_info,
     _get_server_info_file_name,
     _get_subprocess_kwargs_for_fluent,
     _is_windows,
     _process_invalid_args,
-    _process_kwargs,
     _raise_exception_g_gu_in_windows_os,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
@@ -35,7 +34,6 @@ class StandaloneLauncher:
 
     def __init__(
         self,
-        argvals: Optional[Any] = None,
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -60,7 +58,6 @@ class StandaloneLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
-        **kwargs,
     ):
         """Launch Fluent session in standalone mode.
 
@@ -170,13 +167,12 @@ class StandaloneLauncher:
         The allocated machines and core counts are queried from the scheduler environment and
         passed to Fluent.
         """
-        _process_kwargs(kwargs)
-        del kwargs
         del start_container
         argvals = locals().copy()
+        del argvals["self"]
         _process_invalid_args(dry_run, "standalone", argvals)
-        args = _get_argvals(argvals, mode)
-        argvals.update(args)
+        self.mode = _get_mode(mode)
+        self.new_session = self.mode.value[1]
         if argvals["start_timeout"] is None:
             argvals["start_timeout"] = 60
         for arg_name, arg_values in argvals.items():
@@ -198,7 +194,7 @@ class StandaloneLauncher:
         server_info_file_name = _get_server_info_file_name()
         launch_string = _generate_launch_string(
             self.argvals,
-            self.meshing_mode,
+            self.mode,
             self.show_gui,
             self.additional_arguments,
             server_info_file_name,
@@ -258,7 +254,10 @@ class StandaloneLauncher:
                 ip, port, password = _get_server_info(server_info_file_name)
                 watchdog.launch(os.getpid(), port, password, ip)
             if self.case_file_name:
-                if self.meshing_mode:
+                if (
+                    self.mode == FluentMode.MESHING_MODE
+                    or self.mode == FluentMode.PURE_MESHING_MODE
+                ):
                     session.tui.file.read_case(self.case_file_name)
                 elif self.lightweight_mode:
                     session.read_case_lightweight(self.case_file_name)
@@ -268,7 +267,10 @@ class StandaloneLauncher:
                         file_name=self.case_file_name,
                     )
             if self.case_data_file_name:
-                if not self.meshing_mode:
+                if not (
+                    self.mode == FluentMode.MESHING_MODE
+                    or self.mode == FluentMode.PURE_MESHING_MODE
+                ):
                     session.file.read(
                         file_type="case-data",
                         file_name=self.case_data_file_name,

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -16,6 +16,8 @@ class Meshing(PureMeshing):
     in this mode.
     """
 
+    _internal_name = "meshing"
+
     def __init__(
         self,
         fluent_connection: FluentConnection,

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -26,6 +26,8 @@ class PureMeshing(BaseSession):
     in this mode.
     """
 
+    _internal_name = "pure-meshing"
+
     rules = [
         "workflow",
         "meshing",

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -84,7 +84,6 @@ class Solver(BaseSession):
             fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
         )
         self._build_from_fluent_connection(fluent_connection)
-        self._settings_api_root = None
 
     def _build_from_fluent_connection(self, fluent_connection):
         self._tui_service = self.datamodel_service_tui
@@ -107,6 +106,7 @@ class Solver(BaseSession):
             self.reduction = Reduction(self._reduction_service)
         else:
             self.reduction = reduction_old
+        self._settings_api_root = None
 
     def build_from_fluent_connection(self, fluent_connection):
         """Build a solver session object from fluent_connection object."""

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -69,6 +69,8 @@ class Solver(BaseSession):
     commanding, and solver settings objects are all exposed here.
     """
 
+    _internal_name = "solver"
+
     def __init__(
         self,
         fluent_connection,

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -16,6 +16,8 @@ class SolverIcing(Solver):
     datamodel objects calls.
     """
 
+    _internal_name = "solver-icing"
+
     def __init__(
         self,
         fluent_connection: FluentConnection,


### PR DESCRIPTION
This task solves the issue in https://github.com/ansys/pyfluent/issues/2313.
The root cause of the issue was that some redundant arguments were being passed to the launcher (when called internally). So, this PR contains a total clean up of the launcher code that helps debug these issues easily later.

1. FluentMode (enum class) is cleaned up. The local variable "meshing_mode" has been completely removed as it was confusing with earlier launch mode named same.
2. All "meshing_mode" checks are replaced with mode (enum class)
3. "_get_session_info" and "_get_argvals" are removed and in place a simple "_get_mode" only returns the mode in enum form.
4. For icing, the additional argument value has been put in.

