### PR TITLE
refactor: Make flobject consistent wrt server.

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -865,6 +865,7 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
 
 def _rename(obj: NamedObject, new: str, old: str):
     """Rename a named object.
+
     Parameters
     ----------
     obj: NamedObject

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1332,9 +1332,6 @@ def get_cls(name, info, parent=None, version=None):
             cls.child_object_type = get_cls(
                 "child-object-type", object_type, cls, version=version
             )
-            cls.child_object_type.rename = lambda self, name: _rename(
-                self._parent, name, self._name
-            )
             cls.child_object_type.get_name = lambda self: self._name
     except Exception:
         print(

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -379,7 +379,7 @@ class Filename(SettingsBase[str], Textual):
     _state_type = str
 
     def file_purpose(self):
-        """Specifies whether this file is used as input or output by Fluent"""
+        """Specifies whether this file is used as input or output by Fluent."""
         return self.get_attr(_InlineConstants.file_purpose)
 
 
@@ -389,7 +389,7 @@ class FilenameList(SettingsBase[StringListType], Textual):
     _state_type = StringListType
 
     def file_purpose(self):
-        """Specifies whether these files are used as input or output by Fluent"""
+        """Specifies whether these files are used as input or output by Fluent."""
         return self.get_attr(_InlineConstants.file_purpose)
 
 
@@ -871,7 +871,6 @@ class ListObject(SettingsBase[ListStateType], Generic[ChildTypeT]):
     -------
     get_size()
        Get the size of the list.
-
     """
 
     # New objects could get inserted by other operations, so we cannot assume

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1309,9 +1309,6 @@ def get_cls(name, info, parent=None, version=None):
             cls.child_object_type = get_cls(
                 "child-object-type", object_type, cls, version=version
             )
-            cls.child_object_type.rename = lambda self, name: self._parent.rename(
-                new=name, old=self._name
-            )
             cls.child_object_type.get_name = lambda self: self._name
     except Exception:
         print(

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -138,7 +138,7 @@ def test_parametric_workflow():
     )
     study2 = solver_session.parametric_studies[study2_name]
     assert len(study2.design_points) == 2
-    solver_session.parametric_studies.rename("New Study", study2_name)
+    solver_session.parametric_studies[study2_name].rename("New Study")
     assert "New Study" in solver_session.parametric_studies
     del solver_session.parametric_studies[study1_name]
     assert len(solver_session.parametric_studies) == 1

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -707,6 +707,10 @@ def test_accessor_methods_on_settings_object(load_static_mixer_settings_only):
 
     assert solver.results.graphics.mesh.get_object_names() == ["mesh_new"]
 
+    if solver.get_fluent_version() >= "24.2.0":
+        solver.results.graphics.mesh.rename(new="mesh-242", old="mesh_new")
+        assert solver.results.graphics.mesh.get_object_names() == ["mesh-242"]
+
 
 @pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object_types(load_static_mixer_settings_only):

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -703,13 +703,12 @@ def test_accessor_methods_on_settings_object(load_static_mixer_settings_only):
 
     assert solver.results.graphics.mesh.get_object_names() == ["mesh-1"]
 
-    solver.results.graphics.mesh.rename("mesh_new", "mesh-1")
-
+    solver.results.graphics.mesh["mesh-1"].rename("mesh_new")
     assert solver.results.graphics.mesh.get_object_names() == ["mesh_new"]
 
     if solver.get_fluent_version() >= "24.2.0":
-        solver.results.graphics.mesh.rename(new="mesh-242", old="mesh_new")
-        assert solver.results.graphics.mesh.get_object_names() == ["mesh-242"]
+        solver.results.graphics.mesh.rename(new="mesh_242", old="mesh_new")
+        assert solver.results.graphics.mesh.get_object_names() == ["mesh_242"]
 
 
 @pytest.mark.fluent_version("latest")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -701,6 +701,12 @@ def test_accessor_methods_on_settings_object(load_static_mixer_settings_only):
     else:
         assert not mesh.name.is_read_only()
 
+    assert solver.results.graphics.mesh.get_object_names() == ["mesh-1"]
+
+    solver.results.graphics.mesh.rename("mesh_new", "mesh-1")
+
+    assert solver.results.graphics.mesh.get_object_names() == ["mesh_new"]
+
 
 @pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object_types(load_static_mixer_settings_only):

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -455,11 +455,9 @@ def test_named_object():
     r.n_1["n1"] = {}
     r.n_1["n2"] = {}
     assert r.n_1.get_object_names() == ["n1", "n2"]
-    r.n_1.rename("n3", "n1")
-    assert r.n_1.get_object_names() == ["n3", "n2"]
     r.n_1.create("n4")
-    assert r.n_1.get_object_names() == ["n3", "n2", "n4"]
-    del r.n_1["n3"]
+    assert r.n_1.get_object_names() == ["n1", "n2", "n4"]
+    del r.n_1["n1"]
     assert r.n_1.get_object_names() == ["n2", "n4"]
     r.n_1["n1"] = {"rl_1": [1.2, 3.4], "sl_1": ["foo", "bar"]}
     assert r.n_1["n1"]() == {"rl_1": [1.2, 3.4], "sl_1": ["foo", "bar"]}
@@ -471,11 +469,7 @@ def test_named_object():
 def test_list_object():
     r = flobject.get_root(Proxy())
     assert r.l_1.get_size() == 0
-    r.l_1.resize(3)
-    assert r.l_1.get_size() == 3
-    r.l_1.resize(2)
-    assert r.l_1.get_size() == 2
-    assert r.l_1() == [
+    r.l_1 = [
         {"il_1": None, "bl_1": None},
         {"il_1": None, "bl_1": None},
     ]


### PR DESCRIPTION
Please note:
Along with this there should be a couple of minor style fixes in the server side to have the 2 files completely in sync.

There has been some changes in the rename method to support backwards compatibility. 
Tests have been added to check the earlier and latest behavior of 'rename' method. Server-side flobject.py will be updated accordingly.