### PR TITLE
fix: Fix an issue in command creation inside singleton

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1479,7 +1479,7 @@ class PyCommand:
                 self.command,
                 self.path.copy(),
                 id,
-                static_info,
+                static_info["args"],
             )
         except RuntimeError:
             logger.warning(
@@ -1576,7 +1576,7 @@ class PyCommandArguments(PyStateContainer):
             logger.info("__del__ %s: %s" % (type(exc).__name__, exc))
 
     def __getattr__(self, attr: str) -> Optional[PyCommandArgumentsSubItem]:
-        for arg in self.static_info["args"]:
+        for arg in self.static_info:
             if arg["name"] == attr:
                 mode = DataModelType.get_mode(arg["type"])
                 py_class = mode.value[1]

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -467,6 +467,7 @@ def test_named_object_specific_methods(new_mesh_session):
     assert not meshing.workflow.TaskObject.get_object_names()
 
 
+@pytest.mark.fluent_version(">=24.1")
 def test_command_creation_inside_singleton(new_mesh_session):
     meshing = new_mesh_session
     read_mesh = meshing.meshing.File.ReadMesh.create_instance()

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -465,3 +465,9 @@ def test_named_object_specific_methods(new_mesh_session):
     meshing.workflow.delete_all_child_objects("TaskObject")
 
     assert not meshing.workflow.TaskObject.get_object_names()
+
+
+def test_command_creation_inside_singleton(new_mesh_session):
+    meshing = new_mesh_session
+    read_mesh = meshing.meshing.File.ReadMesh.create_instance()
+    assert read_mesh.FileName is not None


### PR DESCRIPTION
The class variable `_full_static_info` at `PyCommand` stores static info for all datamodels, starting from root.
The instance variable `_static_info` at `PyCommand` stores the static-info at command level.
The instance variable `static_info` at `PyCommandArguments` stores the static-info at command arguments level.