### PR TITLE
fix: issues in workflow and case reader

### DIFF
--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -634,11 +634,9 @@ def _get_case_file_name_from_flprj(flprj_file):
     # If the project file name begins with a digit then the node to find will be prepended
     # with "_". Rather than making any assumptions that this is a hard rule, or what
     # the scope of the rule is, simply retry with the name prepended:
-    find_folder = lambda retry=False: root.find(("_" if retry else "") + folder_name)
-    return (
-        (find_folder() or find_folder(retry=True))
-        .find("Input")
-        .find("Case")
-        .find("Target")
-        .get("value")
+    folder_obj = (
+        root.find(folder_name)
+        if len(root.find(folder_name)) > 0
+        else root.find("_" + folder_name)
     )
+    return folder_obj.find("Input").find("Case").find("Target").get("value")

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -403,7 +403,11 @@ class ArgumentsWrapper(PyCallableStateObject):
         task : BaseTask
             The task holding these arguments.
         """
-        self._task = task
+        self.__dict__.update(
+            dict(
+                _task=task,
+            )
+        )
 
     def set_state(self, args: dict) -> None:
         """Overwrite arguments.
@@ -440,6 +444,12 @@ class ArgumentsWrapper(PyCallableStateObject):
 
     def __getattr__(self, attr):
         return getattr(self._task._command_arguments, attr)
+
+    def __setattr__(self, key, value):
+        try:
+            getattr(self, key).set_state(value)
+        except AttributeError:
+            warnings.warn(f"No attribute named '{key}' in '{self._task.name()}'.")
 
     def __setitem__(self, key, value):
         self._task._command_arguments.__setitem__(key, value)
@@ -540,7 +550,7 @@ class CommandTask(BaseTask):
         cmd = self._command()
         if task_arg_state:
             cmd.set_state(task_arg_state)
-        return ReadOnlyObject(self._cmd_sub_items_read_only(cmd, cmd()))
+        return self._cmd_sub_items_read_only(cmd, cmd())
 
     def _cmd_sub_items_read_only(self, cmd, cmd_state):
         for key, value in cmd_state.items():
@@ -548,7 +558,7 @@ class CommandTask(BaseTask):
                 setattr(
                     cmd, key, self._cmd_sub_items_read_only(getattr(cmd, key), value)
                 )
-            setattr(cmd, key, ReadOnlyObject(getattr(cmd, key)))
+            setattr(cmd, key, getattr(cmd, key))
         return cmd
 
     def _command(self):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -449,7 +449,9 @@ class ArgumentsWrapper(PyCallableStateObject):
         try:
             getattr(self, key).set_state(value)
         except AttributeError:
-            warnings.warn(f"No attribute named '{key}' in '{self._task.name()}'.")
+            raise AttributeError(
+                f"No attribute named '{key}' in '{self._task.name()}'."
+            )
 
     def __setitem__(self, key, value):
         self._task._command_arguments.__setitem__(key, value)

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -255,10 +255,9 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
     assert not import_geom.arguments.FileName()
     import_geom.arguments.FileName = "xyz.txt"
     assert import_geom.arguments.FileName() == "xyz.txt"
-    with pytest.warns(
-        UserWarning, match="No attribute named 'File' in 'Import Geometry'."
-    ):
+    with pytest.raises(AttributeError) as msg:
         import_geom.arguments.File = "sample.txt"
+    assert msg.value.args[0] == "No attribute named 'File' in 'Import Geometry'."
     assert not import_geom.arguments.CadImportOptions.OneZonePer.is_read_only()
 
     assert import_geom.arguments.CadImportOptions.OneZonePer() == "body"

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -234,10 +234,41 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
     w.InitializeWorkflow(WorkflowType="Watertight Geometry")
     import_geom = w.task("Import Geometry")
     assert import_geom.arguments.LengthUnit.default_value() == "mm"
-    assert import_geom.arguments.MeshUnit.is_read_only()
+    assert import_geom.arguments.LengthUnit.allowed_values() == [
+        "m",
+        "cm",
+        "mm",
+        "in",
+        "ft",
+        "um",
+        "nm",
+    ]
+    assert import_geom.arguments.LengthUnit() == "mm"
+    import_geom.arguments.LengthUnit.set_state("cm")
+    assert import_geom.arguments.LengthUnit.get_state() == "cm"
+    import_geom.arguments.LengthUnit = "in"
+    assert import_geom.arguments.LengthUnit() == "in"
+
+    assert not import_geom.arguments.MeshUnit.is_read_only()
     assert import_geom.arguments.LengthUnit.is_active()
-    assert import_geom.arguments.FileName.is_read_only()
-    assert import_geom.arguments.CadImportOptions.OneZonePer.is_read_only()
+    assert not import_geom.arguments.FileName.is_read_only()
+    assert not import_geom.arguments.FileName()
+    import_geom.arguments.FileName = "xyz.txt"
+    assert import_geom.arguments.FileName() == "xyz.txt"
+    with pytest.warns(
+        UserWarning, match="No attribute named 'File' in 'Import Geometry'."
+    ):
+        import_geom.arguments.File = "sample.txt"
+    assert not import_geom.arguments.CadImportOptions.OneZonePer.is_read_only()
+
+    assert import_geom.arguments.CadImportOptions.OneZonePer.allowed_values() == [
+        "body",
+        "face",
+        "object",
+    ]
+    assert import_geom.arguments.CadImportOptions.OneZonePer() == "body"
+    import_geom.arguments.CadImportOptions.OneZonePer.set_state("face")
+    assert import_geom.arguments.CadImportOptions.OneZonePer() == "face"
 
     volume_mesh_gen = w.task("Generate the Volume Mesh")
     assert (

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -224,7 +224,7 @@ def test_attribute_query_list_types(new_mesh_session):
     assert ["CAD", "Mesh"] == igt.arguments.FileFormat.getAttribValue("allowedValues")
 
 
-@pytest.mark.fluent_version(">=23.1")
+@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_accessors_for_argument_sub_items(new_mesh_session):
     session_new = new_mesh_session

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -261,11 +261,6 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
         import_geom.arguments.File = "sample.txt"
     assert not import_geom.arguments.CadImportOptions.OneZonePer.is_read_only()
 
-    assert import_geom.arguments.CadImportOptions.OneZonePer.allowed_values() == [
-        "body",
-        "face",
-        "object",
-    ]
     assert import_geom.arguments.CadImportOptions.OneZonePer() == "body"
     import_geom.arguments.CadImportOptions.OneZonePer.set_state("face")
     assert import_geom.arguments.CadImportOptions.OneZonePer() == "face"
@@ -311,6 +306,7 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
     )
 
 
+@pytest.mark.skip("Wait for later implementation.")
 @pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_read_only_behaviour_of_command_arguments(new_mesh_session):


### PR DESCRIPTION
This PR fixes a warning that can be seen in case reader while reading project files. Alongside, this also makes the meshing taskobject arguments non read-only. So, we can set it's values. It also has tests for the same.