### PR TITLE
docs: Minor improvement suggested by user

### DIFF
--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -109,7 +109,7 @@ scheduler environments are Univa Grid Engine (UGE), Load Sharing Facility (LSF),
 Portable Batch System (PBS), and Slurm.
 
 This example shows a bash shell script that can be submitted to a Slurm
-scheduler using the ```sbatch``` command:
+scheduler using the ``sbatch`` command:
 
 .. code:: bash
 

--- a/doc/source/user_guide/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/launching_ansys_fluent.rst
@@ -208,6 +208,7 @@ scheduler without using any bash script:
       },
       additional_arguments="-t16 -cnf=m1:8,m2:8",
    )
+   solver = slurm.result()
 
 .. vale off
 


### PR DESCRIPTION
The detail about `slurm.result()` was only available in a [separate page](https://fluent.docs.pyansys.com/version/stable/api/general/launcher/slurm.html#module-ansys.fluent.core.launcher.slurm_launcher)