### PR TITLE
build: Separate 24.2 nightly tests.

### DIFF
--- a/.github/workflows/nightly-test-run-develop-branch.yml
+++ b/.github/workflows/nightly-test-run-develop-branch.yml
@@ -1,8 +1,8 @@
 name: Nightly Test Run Develop
 
 on:
-  schedule:  # UTC at 0400
-    - cron:  '0 4 * * *'
+  schedule:  # UTC at 0300
+    - cron:  '0 3 * * *'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/nightly-test-run-develop-branch.yml
+++ b/.github/workflows/nightly-test-run-develop-branch.yml
@@ -1,0 +1,80 @@
+name: Nightly Test Run Develop
+
+on:
+  schedule:  # UTC at 0400
+    - cron:  '0 4 * * *'
+  workflow_dispatch:
+
+env:
+  ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+  PYFLUENT_TIMEOUT_FORCE_EXIT: 30
+  PYFLUENT_LAUNCH_CONTAINER: 1
+  PYFLUENT_LOGGING: 'DEBUG'
+  PYFLUENT_WATCHDOG_DEBUG: 'OFF'
+  PYFLUENT_HIDE_LOG_SECRETS: 1
+
+jobs:
+  test:
+    name: Unit Testing
+    runs-on: [self-hosted, pyfluent]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_*.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Add version information
+        run: make version-info
+
+      - name: Install pyfluent
+        run: make install
+
+      - name: Retrieve PyFluent version
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)"
+        id: version
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ansys-bot
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull 24.2 Fluent docker image
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v24.2.0
+
+      - name: Run 24.2 API codegen
+        run: make api-codegen
+        env:
+          FLUENT_IMAGE_TAG: v24.2.0
+
+      - name: Print 24.2 Fluent version info
+        run: |
+          cat src/ansys/fluent/core/fluent_version_242.py
+          python -c "from ansys.fluent.core.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
+      - name: Install again after codegen
+        run: |
+          rm -rf dist
+          make install > /dev/null
+
+      - name: 24.2 Unit Testing
+        run: make unittest-all-242
+        env:
+          FLUENT_IMAGE_TAG: v24.2.0
+

--- a/.github/workflows/nightly-test-run.yml
+++ b/.github/workflows/nightly-test-run.yml
@@ -113,31 +113,6 @@ jobs:
           cat src/ansys/fluent/core/fluent_version_241.py
           python -c "from ansys.fluent.core.solver.settings_241 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
-      - name: Pull 24.2 Fluent docker image
-        run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: v24.2.0
-
-      - name: Run 24.2 API codegen
-        run: make api-codegen
-        env:
-          FLUENT_IMAGE_TAG: v24.2.0
-
-      - name: Print 24.2 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/fluent_version_242.py
-          python -c "from ansys.fluent.core.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
-      - name: Install again after codegen
-        run: |
-          rm -rf dist
-          make install > /dev/null
-
-      - name: 24.2 Unit Testing
-        run: make unittest-all-242
-        env:
-          FLUENT_IMAGE_TAG: v24.2.0
-
       - name: 24.1 Unit Testing
         run: make unittest-all-241
         env:


### PR DESCRIPTION
This separates the nightly test runs for 24.2 from the other versions.

We can catch the connection error in python and re-run that test only???