### PR TITLE
refactor: Fluent GPU Solver is only supported for 3D.

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -227,9 +227,8 @@ def launch_fluent(
     The allocated machines and core counts are queried from the scheduler environment and
     passed to Fluent.
     """
-    if gpu:
-        if version != "3d":
-            raise GPUSolverSupportError()
+    if version != "3d" and gpu:
+        raise GPUSolverSupportError()
     _process_kwargs(kwargs)
     del kwargs
     fluent_launch_mode = _get_fluent_launch_mode(

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -227,8 +227,8 @@ def launch_fluent(
     The allocated machines and core counts are queried from the scheduler environment and
     passed to Fluent.
     """
-    if version and gpu:
-        if version != "3d" and gpu:
+    if gpu:
+        if version != "3d":
             raise GPUSolverSupportError()
     _process_kwargs(kwargs)
     del kwargs

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -13,6 +13,7 @@ from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.launcher.container_launcher import DockerLauncher
 from ansys.fluent.core.launcher.launcher_utils import (
     FluentMode,
+    GPUSolverSupportError,
     _confirm_watchdog_start,
     _get_fluent_launch_mode,
     _get_mode,
@@ -226,6 +227,9 @@ def launch_fluent(
     The allocated machines and core counts are queried from the scheduler environment and
     passed to Fluent.
     """
+    if version and gpu:
+        if version != "3d" and gpu:
+            raise GPUSolverSupportError()
     _process_kwargs(kwargs)
     del kwargs
     fluent_launch_mode = _get_fluent_launch_mode(

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -42,6 +42,13 @@ class InvalidPassword(ValueError):
         super().__init__("Provide correct 'password'.")
 
 
+class GPUSolverSupportError(ValueError):
+    """Provides the error when an unsupported Fluent version is specified."""
+
+    def __init__(self):
+        super().__init__("Fluent GPU Solver is only supported for 3D.")
+
+
 class IpPortNotProvided(ValueError):
     """Provides the error when ip and port are not specified."""
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -165,15 +165,11 @@ def test_gpu_launch_arg(helpers, monkeypatch):
     # (which is available in the error message) is generated correctly.
     helpers.mock_awp_vars()
     monkeypatch.setenv("PYFLUENT_LAUNCH_CONTAINER", "0")
-    with pytest.raises(LaunchFluentError) as error:
+    with pytest.raises(GPUSolverSupportError) as error:
         pyfluent.launch_fluent(gpu=True, start_timeout=0)
 
-    assert " -gpu" in str(error.value)
-
-    with pytest.raises(LaunchFluentError) as error:
+    with pytest.raises(GPUSolverSupportError) as error:
         pyfluent.launch_fluent(gpu=[1, 2, 4], start_timeout=0)
-
-    assert " -gpu=1,2,4" in str(error.value)
 
 
 def test_gpu_launch_arg_additional_arg(helpers, monkeypatch):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -12,6 +12,7 @@ from ansys.fluent.core.launcher.launcher import create_launcher
 from ansys.fluent.core.launcher.launcher_utils import (
     DockerContainerLaunchNotSupported,
     FluentMode,
+    GPUSolverSupportError,
     LaunchFluentError,
     UnexpectedKeywordArgument,
     _build_journal_argument,
@@ -20,6 +21,26 @@ from ansys.fluent.core.launcher.launcher_utils import (
 )
 from ansys.fluent.core.utils.fluent_version import AnsysVersionNotFound, FluentVersion
 import ansys.platform.instancemanagement as pypim
+
+
+def test_gpu_version_error():
+    with pytest.raises(GPUSolverSupportError) as msg:
+        pyfluent.launch_fluent(
+            mode="meshing",
+            version="2d",
+            precision="single",
+            processor_count=5,
+            show_gui=True,
+            gpu=True,
+        )
+        pyfluent.setup_for_fluent(
+            mode="meshing",
+            version="2d",
+            precision="single",
+            processor_count=5,
+            show_gui=True,
+            gpu=True,
+        )
 
 
 def test_mode():


### PR DESCRIPTION
Fluent GPU Solver is only supported for 3D. Now we are raising `GPUSolverSupportError` exception if `gpu=True` and version is not "3d".

![image](https://github.com/ansys/pyfluent/assets/106588300/7730d4cb-8b5d-447c-9d9a-d16ef1d14066)

`------------------------------------------`

![image](https://github.com/ansys/pyfluent/assets/106588300/2716b2d4-04b7-4daf-875b-9f96560c4a26)