### PR TITLE
style: Add --target-version=py39 to black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ repos:
   rev: 23.11.0
   hooks:
   - id: black
+    args: [
+      --target-version=py39
+    ]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0

--- a/src/ansys/fluent/core/streaming_services/datamodel_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_streaming.py
@@ -21,7 +21,7 @@ class DatamodelStream(StreamingService):
         rules,
         no_commands_diff_state,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """Processes datamodel events."""
         data_model_request = datamodel_se_pb2.DataModelRequest(*args, **kwargs)


### PR DESCRIPTION
This will catch any Python >3.9 code during pre-commit.