### PR TITLE
feat: Backward compatibility for settings API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ build-doc-source:
 	@sudo rm -rf doc/source/api/meshing/tui
 	@sudo rm -rf doc/source/api/solver/datamodel
 	@sudo rm -rf doc/source/api/solver/tui
-	#@sudo rm -rf doc/source/api/solver/_autosummary/settings
+	@sudo rm -rf doc/source/api/solver/_autosummary/settings
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_doc.txt
 	@xvfb-run make -C doc html

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ build-doc-source:
 	@sudo rm -rf doc/source/api/meshing/tui
 	@sudo rm -rf doc/source/api/solver/datamodel
 	@sudo rm -rf doc/source/api/solver/tui
-	@sudo rm -rf doc/source/api/solver/_autosummary/settings
+	#@sudo rm -rf doc/source/api/solver/_autosummary/settings
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples
 	@pip install -r requirements/requirements_doc.txt
 	@xvfb-run make -C doc html

--- a/doc/settings_rstgen.py
+++ b/doc/settings_rstgen.py
@@ -58,7 +58,7 @@ def _generate_table_for_rst(r, data_dict={}):
 def _populate_parents_list(cls):
     if hasattr(cls, "child_names"):
         for child in cls.child_names:
-            child_cls = getattr(cls, child)
+            child_cls = cls._child_classes[child]
             child_file = child_cls.__module__.split(".")[-1]
             if not parents_dict.get(child_file):
                 parents_dict[child_file] = []
@@ -67,7 +67,7 @@ def _populate_parents_list(cls):
 
     if hasattr(cls, "command_names"):
         for child in cls.command_names:
-            child_cls = getattr(cls, child)
+            child_cls = cls._child_classes[child]
             child_file = child_cls.__module__.split(".")[-1]
             if not parents_dict.get(child_file):
                 parents_dict[child_file] = []
@@ -76,7 +76,7 @@ def _populate_parents_list(cls):
 
     if hasattr(cls, "argument_names"):
         for child in cls.argument_names:
-            child_cls = getattr(cls, child)
+            child_cls = cls._child_classes[child]
             child_file = child_cls.__module__.split(".")[-1]
             if not parents_dict.get(child_file):
                 parents_dict[child_file] = []
@@ -93,15 +93,15 @@ def _populate_parents_list(cls):
 
     if hasattr(cls, "child_names"):
         for child in cls.child_names:
-            _populate_parents_list(getattr(cls, child))
+            _populate_parents_list(cls._child_classes[child])
 
     if hasattr(cls, "command_names"):
         for child in cls.command_names:
-            _populate_parents_list(getattr(cls, child))
+            _populate_parents_list(cls._child_classes[child])
 
     if hasattr(cls, "argument_names"):
         for child in cls.argument_names:
-            _populate_parents_list(getattr(cls, child))
+            _populate_parents_list(cls._child_classes[child])
 
     if hasattr(cls, "child_object_type"):
         _populate_parents_list(getattr(cls, "child_object_type"))
@@ -132,7 +132,7 @@ def _populate_rst_from_settings(rst_dir, cls, version):
             data_dict = {}
             data_dict["Attribute"] = "Summary"
             for child in cls.child_names:
-                child_cls = getattr(cls, child)
+                child_cls = cls._child_classes[child]
                 ref_string = f":ref:`{child} <{child_cls.__module__.split('.')[-1]}>`"
                 data_dict[ref_string] = child_cls.__doc__.strip("\n").split("\n")[0]
             _generate_table_for_rst(r, data_dict)
@@ -142,7 +142,7 @@ def _populate_rst_from_settings(rst_dir, cls, version):
             data_dict = {}
             data_dict["Method"] = "Summary"
             for child in cls.command_names:
-                child_cls = getattr(cls, child)
+                child_cls = cls._child_classes[child]
                 ref_string = f":ref:`{child} <{child_cls.__module__.split('.')[-1]}>`"
                 data_dict[ref_string] = child_cls.__doc__.strip("\n").split("\n")[0]
             _generate_table_for_rst(r, data_dict)
@@ -152,7 +152,7 @@ def _populate_rst_from_settings(rst_dir, cls, version):
             data_dict = {}
             data_dict["Argument"] = "Summary"
             for child in cls.argument_names:
-                child_cls = getattr(cls, child)
+                child_cls = cls._child_classes[child]
                 ref_string = f":ref:`{child} <{child_cls.__module__.split('.')[-1]}>`"
                 data_dict[ref_string] = child_cls.__doc__.strip("\n").split("\n")[0]
             _generate_table_for_rst(r, data_dict)
@@ -181,15 +181,15 @@ def _populate_rst_from_settings(rst_dir, cls, version):
         rst_list.append(rstpath)
         if has_children:
             for child in cls.child_names:
-                _populate_rst_from_settings(rst_dir, getattr(cls, child), version)
+                _populate_rst_from_settings(rst_dir, cls._child_classes[child], version)
 
         if has_commands:
             for child in cls.command_names:
-                _populate_rst_from_settings(rst_dir, getattr(cls, child), version)
+                _populate_rst_from_settings(rst_dir, cls._child_classes[child], version)
 
         if has_arguments:
             for child in cls.argument_names:
-                _populate_rst_from_settings(rst_dir, getattr(cls, child), version)
+                _populate_rst_from_settings(rst_dir, cls._child_classes[child], version)
 
         if has_named_object:
             _populate_rst_from_settings(
@@ -213,7 +213,7 @@ if __name__ == "__main__":
     if not os.path.exists(rst_dir):
         os.makedirs(rst_dir)
 
-    image_tag = os.getenv("FLUENT_IMAGE_TAG", "v23.2.0")
+    image_tag = os.getenv("FLUENT_IMAGE_TAG", "v24.1.0")
     version = get_version_for_file_name(image_tag.lstrip("v"))
     settings = importlib.import_module(f"ansys.fluent.core.solver.settings_{version}")
     _populate_parents_list(settings.root)

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -198,6 +198,7 @@ class Solver(BaseSession):
                 flproxy=self._settings_service,
                 version=self._version,
                 remote_file_handler=self._remote_file_handler,
+                scheme_eval=self.fluent_connection.scheme_eval.scheme_eval,
             )
         return self._settings_root
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -800,12 +800,11 @@ class Group(SettingsBase[DictStateType]):
         try:
             return super().__getattribute__(name)
         except AttributeError as ex:
-            if name not in ["remote_file_handler"]:
-                self._get_parent_of_active_child_names(name)
-                error_msg = allowed_name_error_message(
-                    "Settings objects", name, super().__getattribute__("child_names")
-                )
-                ex.args = (error_msg,)
+            self._get_parent_of_active_child_names(name)
+            error_msg = allowed_name_error_message(
+                "Settings objects", name, super().__getattribute__("child_names")
+            )
+            ex.args = (error_msg,)
             raise
 
     def __setattr__(self, name: str, value):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -985,8 +985,8 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
                 self._create_child_object(name)
 
     def __delitem__(self, name: str):
-        # TODO: there is an issue in wrapping the following line with a context manager
-        self.flproxy.delete(self.path, name)
+        with self.while_deleting():
+            self.flproxy.delete(self.path, name)
         if name in self._objects:
             del self._objects[name]
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -985,8 +985,8 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
                 self._create_child_object(name)
 
     def __delitem__(self, name: str):
-        while self.while_deleting():
-            self.flproxy.delete(self.path, name)
+        # TODO: there is an issue in wrapping the following line with a context manager
+        self.flproxy.delete(self.path, name)
         if name in self._objects:
             del self._objects[name]
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -946,6 +946,14 @@ def test_strings_with_allowed_values(load_static_mixer_settings_only):
     ]
 
 
+@pytest.mark.fluent_version(">=24.2")
+def test_parent_class_attributes(load_static_mixer_settings_only):
+    solver = load_static_mixer_settings_only
+    assert solver.setup.models.energy.enabled
+    with pytest.raises(AttributeError):
+        solver.setup.models.energy.__class__.enabled
+
+
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -142,6 +142,7 @@ def test_api_upgrade(new_solver_session, capsys):
     "<solver_session>.file.read_case" in capsys.readouterr().out
 
 
+@pytest.mark.skip(reason="Skipping till docker image is updated")
 @pytest.mark.fluent_version(">=24.2")
 def test_deprecated_settings(new_solver_session):
     solver = new_solver_session

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
@@ -205,4 +207,6 @@ def test_deprecated_settings(new_solver_session):
     with pytest.warns(DeprecatedSettingWarning):
         solver.results.gr.contour["c1"].field = "pressure"
 
-    del solver.results.gr.contour["c1"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        del solver.results.gr.contour["c1"]

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -204,3 +204,5 @@ def test_deprecated_settings(new_solver_session):
 
     with pytest.warns(DeprecatedSettingWarning):
         solver.results.gr.contour["c1"].field = "pressure"
+
+    del solver.results.gr.contour["c1"]

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
@@ -207,6 +205,5 @@ def test_deprecated_settings(new_solver_session):
     with pytest.warns(DeprecatedSettingWarning):
         solver.results.gr.contour["c1"].field = "pressure"
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with pytest.warns(DeprecatedSettingWarning):
         del solver.results.gr.contour["c1"]


### PR DESCRIPTION
This PR adds the backward compatbility support in PyFluent settings API using the `child-aliases`/`command-aliases`/`query-aliases` attributes in settings API.

A tree of alias-objects mimicking the original object tree is constructed on-access basis during runtime. For an object hierarchy `A -> B -> C`, If `A1` is an alias of `A`, `A1.B` and `A1.C` are also aliases and the backward compatibility message for set_state is shown at all levels. The `_Alias` base class prints the backward compatibility message on various journaling points using the scheme_eval function which is passed through the `get_root()` function.

Please see the Fluent side PR for more details on flobject.py change.

I'm also incorporating changes from #2428 which simplifies some code requiring access to original settings object classes.