### PR TITLE
refactor: Remove RemoteFileHandler wrapper

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -15,7 +15,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _process_invalid_args,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
-from ansys.fluent.core.utils.file_transfer_service import RemoteFileHandler
+from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
@@ -51,6 +51,7 @@ class DockerLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
+        remote_file_handler: Optional[Any] = PimFileTransferService(),
     ):
         """Launch Fluent session in container mode.
 
@@ -136,6 +137,8 @@ class DockerLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
+        remote_file_handler : optional
+            File transfer service. Uploads/downloads files to/from the server.
 
         Returns
         -------
@@ -168,6 +171,7 @@ class DockerLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.new_session = self.mode.value[0]
+        self.remote_file_handler = remote_file_handler
 
     def __call__(self):
         if self.mode == FluentMode.SOLVER_ICING:
@@ -205,7 +209,7 @@ class DockerLauncher:
                 launcher_args=self.argvals,
                 inside_container=True,
             ),
-            remote_file_handler=RemoteFileHandler(),
+            remote_file_handler=self.remote_file_handler,
         )
 
         if self.start_watchdog is None and self.cleanup_on_exit:

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -137,7 +137,7 @@ class DockerLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
-        remote_file_handler : optional
+        file_transfer_service : optional
             File transfer service. Uploads/downloads files to/from the server.
 
         Returns

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -51,7 +51,7 @@ class DockerLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
-        remote_file_handler: Optional[Any] = PimFileTransferService(),
+        file_transfer_service: Optional[Any] = None,
     ):
         """Launch Fluent session in container mode.
 
@@ -171,7 +171,9 @@ class DockerLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.new_session = self.mode.value[0]
-        self.remote_file_handler = remote_file_handler
+        self.file_transfer_service = (
+            file_transfer_service if file_transfer_service else PimFileTransferService()
+        )
 
     def __call__(self):
         if self.mode == FluentMode.SOLVER_ICING:
@@ -209,7 +211,7 @@ class DockerLauncher:
                 launcher_args=self.argvals,
                 inside_container=True,
             ),
-            remote_file_handler=self.remote_file_handler,
+            remote_file_handler=self.file_transfer_service,
         )
 
         if self.start_watchdog is None and self.cleanup_on_exit:

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -30,7 +30,6 @@ from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.session_solver_icing import SolverIcing
-from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
@@ -101,7 +100,7 @@ def launch_fluent(
     topy: Optional[Union[str, list]] = None,
     start_watchdog: Optional[bool] = None,
     scheduler_options: Optional[dict] = None,
-    remote_file_handler: Optional[Any] = PimFileTransferService(),
+    file_transfer_service: Optional[Any] = None,
     **kwargs,
 ) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SlurmFuture, dict]:
     """Launch Fluent locally in server mode or connect to a running Fluent server
@@ -206,7 +205,7 @@ def launch_fluent(
         "scheduler_account": "<account>"}``. The keys ``scheduler_headnode``,
         ``scheduler_queue`` and ``scheduler_account`` are optional and should be
         specified in a similar manner to Fluent's scheduler options.
-    remote_file_handler : optional
+    file_transfer_service : optional
         File transfer service. Uploads/downloads files to/from the server.
 
     Returns
@@ -320,5 +319,4 @@ def connect_to_fluent(
 
     return new_session(
         fluent_connection=fluent_connection,
-        remote_file_handler=PimFileTransferService(),
     )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -30,7 +30,7 @@ from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.session_solver_icing import SolverIcing
-from ansys.fluent.core.utils.file_transfer_service import RemoteFileHandler
+from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
@@ -101,6 +101,7 @@ def launch_fluent(
     topy: Optional[Union[str, list]] = None,
     start_watchdog: Optional[bool] = None,
     scheduler_options: Optional[dict] = None,
+    remote_file_handler: Optional[Any] = PimFileTransferService(),
     **kwargs,
 ) -> Union[Meshing, PureMeshing, Solver, SolverIcing, SlurmFuture, dict]:
     """Launch Fluent locally in server mode or connect to a running Fluent server
@@ -205,6 +206,8 @@ def launch_fluent(
         "scheduler_account": "<account>"}``. The keys ``scheduler_headnode``,
         ``scheduler_queue`` and ``scheduler_account`` are optional and should be
         specified in a similar manner to Fluent's scheduler options.
+    remote_file_handler : optional
+        File transfer service. Uploads/downloads files to/from the server.
 
     Returns
     -------
@@ -316,5 +319,6 @@ def connect_to_fluent(
         watchdog.launch(os.getpid(), port, password, ip)
 
     return new_session(
-        fluent_connection=fluent_connection, remote_file_handler=RemoteFileHandler()
+        fluent_connection=fluent_connection,
+        remote_file_handler=PimFileTransferService(),
     )

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -22,10 +22,6 @@ from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.session_solver_icing import SolverIcing
-from ansys.fluent.core.utils.file_transfer_service import (
-    PimFileTransferService,
-    RemoteFileHandler,
-)
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.utils.networking import find_remoting_ip
 import ansys.platform.instancemanagement as pypim
@@ -555,6 +551,7 @@ def launch_remote_fluent(
     mode: FluentMode = FluentMode.SOLVER,
     dimensionality: Optional[str] = None,
     launcher_args: Optional[Dict[str, Any]] = None,
+    remote_file_handler: Optional[Any] = None,
 ) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
     """Launch Fluent remotely using `PyPIM <https://pypim.docs.pyansys.com>`.
 
@@ -585,6 +582,8 @@ def launch_remote_fluent(
     dimensionality : str, optional
         Geometric dimensionality of the Fluent simulation. The default is ``None``,
         in which case ``"3d"`` is used. Options are ``"3d"`` and ``"2d"``.
+    remote_file_handler : optional
+        File transfer service. Uploads/downloads files to/from the server.
 
     Returns
     -------
@@ -615,12 +614,11 @@ def launch_remote_fluent(
         launcher_args=launcher_args,
     )
 
-    remote_file_handler = RemoteFileHandler(
-        transfer_service=PimFileTransferService(
+    return session_cls(
+        fluent_connection=fluent_connection,
+        remote_file_handler=remote_file_handler(
             pim_instance=fluent_connection._remote_instance
         )
-    )
-
-    return session_cls(
-        fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+        if pypim.is_configured()
+        else remote_file_handler(),
     )

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -22,6 +22,7 @@ from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.session_solver_icing import SolverIcing
+from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.utils.networking import find_remoting_ip
 import ansys.platform.instancemanagement as pypim
@@ -615,9 +616,9 @@ def launch_remote_fluent(
     )
 
     remote_file_handler = (
-        file_transfer_service(pim_instance=fluent_connection._remote_instance)
-        if pypim.is_configured()
-        else file_transfer_service()
+        file_transfer_service
+        if file_transfer_service
+        else PimFileTransferService(pim_instance=fluent_connection._remote_instance)
     )
 
     return session_cls(

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -551,7 +551,7 @@ def launch_remote_fluent(
     mode: FluentMode = FluentMode.SOLVER,
     dimensionality: Optional[str] = None,
     launcher_args: Optional[Dict[str, Any]] = None,
-    remote_file_handler: Optional[Any] = None,
+    file_transfer_service: Optional[Any] = None,
 ) -> Union[Meshing, PureMeshing, Solver, SolverIcing]:
     """Launch Fluent remotely using `PyPIM <https://pypim.docs.pyansys.com>`.
 
@@ -582,7 +582,7 @@ def launch_remote_fluent(
     dimensionality : str, optional
         Geometric dimensionality of the Fluent simulation. The default is ``None``,
         in which case ``"3d"`` is used. Options are ``"3d"`` and ``"2d"``.
-    remote_file_handler : optional
+    file_transfer_service : optional
         File transfer service. Uploads/downloads files to/from the server.
 
     Returns
@@ -614,11 +614,12 @@ def launch_remote_fluent(
         launcher_args=launcher_args,
     )
 
-    return session_cls(
-        fluent_connection=fluent_connection,
-        remote_file_handler=remote_file_handler(
-            pim_instance=fluent_connection._remote_instance
-        )
+    remote_file_handler = (
+        file_transfer_service(pim_instance=fluent_connection._remote_instance)
         if pypim.is_configured()
-        else remote_file_handler(),
+        else file_transfer_service()
+    )
+
+    return session_cls(
+        fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
     )

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -9,6 +9,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _process_invalid_args,
     launch_remote_fluent,
 )
+from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
@@ -44,6 +45,7 @@ class PIMLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
+        remote_file_handler: Optional[Any] = PimFileTransferService(),
     ):
         """Launch Fluent session in `PIM<https://pypim.docs.pyansys.com/version/stable/>` mode.
 
@@ -129,6 +131,8 @@ class PIMLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
+        remote_file_handler : optional
+            File transfer service. Uploads/downloads files to/from the server.
 
         Returns
         -------
@@ -173,6 +177,7 @@ class PIMLauncher:
                 "'start_watchdog' argument for 'launch_fluent' is currently not supported "
                 "when starting a remote Fluent PyPIM client."
             )
+        self.remote_file_handler = remote_file_handler
 
     def __call__(self):
         logger.info(
@@ -191,4 +196,5 @@ class PIMLauncher:
             mode=self.mode,
             dimensionality=self.version,
             launcher_args=self.argvals,
+            remote_file_handler=self.remote_file_handler,
         )

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -45,7 +45,7 @@ class PIMLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
-        remote_file_handler: Optional[Any] = PimFileTransferService(),
+        file_transfer_service: Optional[Any] = None,
     ):
         """Launch Fluent session in `PIM<https://pypim.docs.pyansys.com/version/stable/>` mode.
 
@@ -131,7 +131,7 @@ class PIMLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
-        remote_file_handler : optional
+        file_transfer_service : optional
             File transfer service. Uploads/downloads files to/from the server.
 
         Returns
@@ -177,7 +177,9 @@ class PIMLauncher:
                 "'start_watchdog' argument for 'launch_fluent' is currently not supported "
                 "when starting a remote Fluent PyPIM client."
             )
-        self.remote_file_handler = remote_file_handler
+        self.file_transfer_service = (
+            file_transfer_service if file_transfer_service else PimFileTransferService()
+        )
 
     def __call__(self):
         logger.info(
@@ -196,5 +198,5 @@ class PIMLauncher:
             mode=self.mode,
             dimensionality=self.version,
             launcher_args=self.argvals,
-            remote_file_handler=self.remote_file_handler,
+            file_transfer_service=self.file_transfer_service,
         )

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -57,7 +57,7 @@ class StandaloneLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
-        remote_file_handler: Optional[Any] = PimFileTransferService(),
+        file_transfer_service: Optional[Any] = None,
     ):
         """Launch Fluent session in standalone mode.
 
@@ -143,7 +143,7 @@ class StandaloneLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
-        remote_file_handler : optional
+        file_transfer_service : optional
             File transfer service. Uploads/downloads files to/from the server.
 
         Returns
@@ -177,7 +177,9 @@ class StandaloneLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.new_session = self.mode.value[0]
-        self.remote_file_handler = remote_file_handler
+        self.file_transfer_service = (
+            file_transfer_service if file_transfer_service else PimFileTransferService()
+        )
 
     def __call__(self):
         if self.lightweight_mode is None:
@@ -240,7 +242,7 @@ class StandaloneLauncher:
 
             session = self.new_session.create_from_server_info_file(
                 server_info_file_name=server_info_file_name,
-                remote_file_handler=self.remote_file_handler,
+                remote_file_handler=self.file_transfer_service,
                 cleanup_on_exit=self.cleanup_on_exit,
                 start_transcript=self.start_transcript,
                 launcher_args=self.argvals,

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -21,7 +21,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _raise_exception_g_gu_in_windows_os,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
-from ansys.fluent.core.utils.file_transfer_service import RemoteFileHandler
+from ansys.fluent.core.utils.file_transfer_service import PimFileTransferService
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
@@ -57,6 +57,7 @@ class StandaloneLauncher:
         topy: Optional[Union[str, list]] = None,
         start_watchdog: Optional[bool] = None,
         scheduler_options: Optional[dict] = None,
+        remote_file_handler: Optional[Any] = PimFileTransferService(),
     ):
         """Launch Fluent session in standalone mode.
 
@@ -142,6 +143,8 @@ class StandaloneLauncher:
             which means an independent watchdog process is run to ensure
             that any local GUI-less Fluent sessions started by PyFluent are properly closed (or killed if frozen)
             when the current Python process ends.
+        remote_file_handler : optional
+            File transfer service. Uploads/downloads files to/from the server.
 
         Returns
         -------
@@ -174,6 +177,7 @@ class StandaloneLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.new_session = self.mode.value[0]
+        self.remote_file_handler = remote_file_handler
 
     def __call__(self):
         if self.lightweight_mode is None:
@@ -236,7 +240,7 @@ class StandaloneLauncher:
 
             session = self.new_session.create_from_server_info_file(
                 server_info_file_name=server_info_file_name,
-                remote_file_handler=RemoteFileHandler(),
+                remote_file_handler=self.remote_file_handler,
                 cleanup_on_exit=self.cleanup_on_exit,
                 start_transcript=self.start_transcript,
                 launcher_args=self.argvals,

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -288,9 +288,9 @@ class BaseSession:
         remote_file_name : str, optional
             remote file name, by default None
         """
-        return PimFileTransferService(self.fluent_connection._remote_instance).upload(
-            file_name, remote_file_name
-        )
+        return PimFileTransferService(
+            self.fluent_connection._remote_instance
+        ).upload_file(file_name, remote_file_name)
 
     def download(self, file_name: str, local_file_name: Optional[str] = "."):
         """Download a file from the server supported by `PyPIM<https://pypim.docs.pyansys.com/version/stable/>`.
@@ -302,9 +302,9 @@ class BaseSession:
         local_file_name : str, optional
             local file path, by default current directory
         """
-        return PimFileTransferService(self.fluent_connection._remote_instance).download(
-            file_name, local_file_name
-        )
+        return PimFileTransferService(
+            self.fluent_connection._remote_instance
+        ).download_file(file_name, local_file_name)
 
     def __dir__(self):
         returned_list = sorted(set(list(self.__dict__.keys()) + dir(type(self))))


### PR DESCRIPTION
1. Removed `RemoteFileHandler` wrapper.
2. Added `file_transfer_service` parameter to `launch_fluent`, `launch_remote_fluent` and Standalone, Container, PIM launchers.
3. Moved `TransferRecorderService` to `test_launcher_remote.py`.