### PR TITLE
feat: Throw standard Python error on beartype violation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     "docker>=6.1.3",
     "psutil>=5.9.5",
     "requests>=2.31.0",
-    "beartype>=0.16.4",
+    "beartype>=0.17",
 ]
 
 extras_require = {

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 from typing import Any, Dict, Optional, Union
 
-from beartype import beartype
+from beartype import BeartypeConf, beartype
 
 from ansys.fluent.core.exceptions import DisallowedValuesError, InvalidArgument
 from ansys.fluent.core.fluent_connection import FluentConnection, PortNotProvided
@@ -418,7 +418,7 @@ def _confirm_watchdog_start(start_watchdog, cleanup_on_exit, fluent_connection):
     return start_watchdog
 
 
-@beartype
+@beartype(conf=BeartypeConf(violation_type=TypeError))
 def _build_journal_argument(
     topy: Union[None, bool, str], journal_file_names: Union[None, str, list[str]]
 ) -> str:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import platform
 
-from beartype.roar import BeartypeCallHintParamViolation
 import pytest
 from util.fixture_fluent import download_input_file
 
@@ -316,7 +315,7 @@ def test_fluent_launchers():
             ' -i "a.jou" -i "b.jou" -topy="c.py"',
             pytest.wont_raise(),
         ),
-        (None, 5, None, pytest.raises(BeartypeCallHintParamViolation)),
+        (None, 5, None, pytest.raises(TypeError)),
         (True, None, None, pytest.raises(InvalidArgument)),
     ],
 )


### PR DESCRIPTION
This feature is now supported in beartype version 0.17.