### PR TITLE
style: Add a precommit hook for conventional commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,10 @@ repos:
           "--score", "n",
           "--rcfile=pylintrc",
         ]
+
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v3.1.0
+  hooks:
+    - id: conventional-pre-commit
+      stages: [commit-msg]
+      args: []


### PR DESCRIPTION
https://github.com/compilerla/conventional-pre-commit

To install the pre-commit hook locally: `pre-commit install --hook-type commit-msg`

Note that, this will validate the commit message of each local commit.