### PR TITLE
feat:                   units follow-up with testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ shutil.copy2(_README_FILE, _DOCS_FILE)
 install_requires = [
     "ansys-api-fluent>=0.3.22",
     "ansys-platform-instancemanagement~=1.0",
-    "ansys-units>=0.2.0",
+    "ansys-units>=0.3.0",
     "grpcio>=1.30.0",
     "grpcio-health-checking>=1.30.0",
     "numpy<2,>=1.21.5",

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -500,41 +500,32 @@ class Real(SettingsBase[RealType], Numerical):
             error = "Code not configured to support units."
         if not error:
             quantity = self.get_attr("units-quantity")
-            if not quantity:
-                error = f"{self.path} does not contain quantity information."
-            else:
-                try:
-                    return ansys_units.Quantity(
-                        value=self.get_state(),
-                        units=get_si_unit_for_fluent_quantity(quantity),
-                    )
-                except (TypeError, ValueError) as e:
-                    error = e
+            try:
+                return ansys_units.Quantity(
+                    value=self.get_state(),
+                    units=get_si_unit_for_fluent_quantity(quantity),
+                )
+            except (TypeError, ValueError) as e:
+                error = e
         warnings.warn(f"Unable to construct 'Quantity'. {error}")
 
-    def set_state(self, state: Optional[StateT] = None, **kwargs): # noqa W9006
+    def set_state(self, state: Optional[StateT] = None, **kwargs):
         """Set the state of the object.
 
         Raises
         ------
         UnhandledQuantity
-            If the quantity objet cannot be handled for the given path. This can
-            happen if the quantity attribute is not present in this parameter, or
-            if the quantity attribute specifies an unsupported quantity, or if
-            the units soecified for the quantity are not supported.
+            If the quantity object cannot be handled for the given path. This can
+            happen if the quantity attribute specifies an unsupported quantity, or if
+            the units specified for the quantity are not supported.
         """
         if ansys_units and isinstance(state, ansys_units.Quantity):
             try:
                 quantity = self.get_attr("units-quantity")
-                if not quantity:
-                    raise ValueError(
-                        f"{self.path} does not contain quantity information."
-                    )
                 unit = get_si_unit_for_fluent_quantity(quantity)
                 state = state.to(unit).value
             except Exception as ex:
                 raise UnhandledQuantity(self.path, state) from ex
-
         return super().set_state(state=state, **kwargs)
 
     _state_type = RealType

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Module for accessing and modifying hierarchy of Fluent settings.
 
 The only useful method is '`get_root``, which returns the root object for
@@ -15,7 +17,6 @@ Example
 >>> r.setup.models.energy.enabled = True
 >>> r.boundary_conditions.velocity_inlet['inlet'].vmag.constant = 20
 """
-from __future__ import annotations
 
 import collections
 from contextlib import contextmanager, nullcontext
@@ -35,7 +36,7 @@ import weakref
 try:
     import ansys.units as ansys_units
 
-    from .flunits import get_si_unit_for_fluent_quantity
+    from .flunits import UnhandledQuantity, get_si_unit_for_fluent_quantity
 except ImportError:
     get_unit_for_fl_quantity_attr = None
     ansys_units = None
@@ -492,7 +493,7 @@ class Real(SettingsBase[RealType], Numerical):
     expression values.
     """
 
-    def get_state_as_quantity(self) -> Optional[ansys_units.Quantity]:
+    def as_quantity(self) -> Optional[ansys_units.Quantity]:
         """Get the state of the object as a Quantity."""
         error = None
         if not ansys_units:
@@ -511,22 +512,29 @@ class Real(SettingsBase[RealType], Numerical):
                     error = e
         warnings.warn(f"Unable to construct 'Quantity'. {error}")
 
-    def set_state(self, state: Optional[StateT] = None, **kwargs):
+    def set_state(self, state: Optional[StateT] = None, **kwargs): # noqa W9006
         """Set the state of the object.
 
         Raises
         ------
-        TypeError
-            If the quantity attribute is not a string instance.
-        ValueError
-            If the quantity attribute is not present in this parameter.
+        UnhandledQuantity
+            If the quantity objet cannot be handled for the given path. This can
+            happen if the quantity attribute is not present in this parameter, or
+            if the quantity attribute specifies an unsupported quantity, or if
+            the units soecified for the quantity are not supported.
         """
         if ansys_units and isinstance(state, ansys_units.Quantity):
-            quantity = self.get_attr("units-quantity")
-            if not quantity:
-                raise ValueError(f"{self.path} does not contain quantity information.")
-            unit = get_si_unit_for_fluent_quantity(quantity)
-            state = state.to(unit).value
+            try:
+                quantity = self.get_attr("units-quantity")
+                if not quantity:
+                    raise ValueError(
+                        f"{self.path} does not contain quantity information."
+                    )
+                unit = get_si_unit_for_fluent_quantity(quantity)
+                state = state.to(unit).value
+            except Exception as ex:
+                raise UnhandledQuantity(self.path, state) from ex
+
         return super().set_state(state=state, **kwargs)
 
     _state_type = RealType
@@ -823,6 +831,8 @@ class Group(SettingsBase[DictStateType]):
             allowed = attr.allowed_values()
             if allowed and value not in allowed:
                 raise allowed_values_error(name, value, allowed) from ex
+            else:
+                raise ex
 
 
 class WildcardPath(Group):

--- a/src/ansys/fluent/core/solver/flunits.py
+++ b/src/ansys/fluent/core/solver/flunits.py
@@ -82,6 +82,8 @@ Unhandled:
  'wave-length': 'Angstrom'}
 """
 
+from typing import Optional
+
 _fl_unit_table = {
     "acceleration": "m s^-2",
     "angle": "radian",
@@ -225,16 +227,22 @@ class UnhandledQuantity(RuntimeError):
         )
 
 
-def get_si_unit_for_fluent_quantity(quantity: str, unit_table: dict = None):
+def get_si_unit_for_fluent_quantity(
+    quantity: Optional[str], unit_table: Optional[dict] = None
+):
     """Get the SI unit for the given Fluent quantity.
 
     Raises
     ------
     InvalidQuantityType
-        If ``quantity`` is not a string instance.
+        If ``quantity`` is not a string instance, unless it is None.
     UnitsNotDefinedForQuantity
         If ``quantity`` is undefined for PyFluent.
     """
+    # The settings API should return None only if the
+    # parameter is dict
+    if quantity is None:
+        return ""
     try:
         if quantity.startswith("'"):
             quantity = quantity[1:]

--- a/src/ansys/fluent/core/solver/flunits.py
+++ b/src/ansys/fluent/core/solver/flunits.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Module for accessing Fluent units labels per quantity type.
 
 Example
@@ -8,30 +10,76 @@ The following code is employed to translate the source data
 into Python data structures:
 
 from ansys.fluent.core.filereader import lispy
+from ansys.units import Unit
 import re
 from pprint import pprint
 
-fl_unit_subs = {'deg': 'radian', 'rad':'radian',}
+fl_unit_subs = {'deg': 'radian', 'rad':'radian'}
 def replace_units(match):
     return fl_unit_subs[match.group(0)]
 
 def substitute_fl_units_with_py_units(fl_units_dict):
     subs = {}
     for k, v in fl_units_dict.items():
-    new_val = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in fl_unit_subs), replace_units, v)
-    if new_val != v:
-        subs[k] = new_val
+        new_val = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in fl_unit_subs), replace_units, v)
+        if new_val != v:
+            subs[k] = new_val
     print("Substitutions:")
     for k, v in subs.items():
         print(f"'{fl_units_dict[k]}' -> '{v}' for '{k}'")
-        print("\n")
-        fl_units_dict.update(subs)
+    fl_units_dict.update(subs)
+    return fl_units_dict
+
+def remove_unhandled_units(fl_units_dict):
+    unhandled = {}
+    for k, v in fl_units_dict.items():
+        try:
+            Unit(v)
+        except Exception:
+            unhandled[k] = v
+    print("Unhandled:")
+    pprint(unhandled)
+    [fl_units_dict.pop(key) for key in unhandled]
     return fl_units_dict
 
 def make_python_fl_unit_table(scheme_unit_table):
     as_list = lispy.parse(scheme_unit_table)[1][1]
     as_dict = { x[0]:x[1][3].split('"')[1] for x in as_list }
-    return substitute_fl_units_with_py_units(as_dict)
+    return remove_unhandled_units(substitute_fl_units_with_py_units(as_dict))
+
+Output from most recent run to generate the table below:
+
+>>> pprint(make_python_fl_unit_table(fl_scheme_unit_table))
+
+Substitutions:
+'deg' -> 'radian' for 'angle'
+'rad s^-1' -> 'radian s^-1' for 'angular-velocity'
+'deg' -> 'radian' for 'crank-angle'
+'N m rad^-1' -> 'N m radian^-1' for 'spring-constant-angular'
+
+Unhandled:
+{'contact-resistance-vol': 'Ohm m^3',
+ 'crank-angular-velocity': 'rev min^-1',
+ 'elec-contact-resistance': 'Ohm m^2',
+ 'elec-resistance': 'Ohm',
+ 'elec-resistivity': 'Ohm m',
+ 'energy-density': 'J/m2',
+ 'mole-con-henry-const': 'Pa m^3 kgmol^-1',
+ 'mole-specific-energy': 'J kgmol^-1',
+ 'mole-specific-entropy': 'J kgmol^-1 K^-1',
+ 'mole-transfer-rate': 'kgmol m^-3 s^-1',
+ 'particles-conc': '1.e15-particles/kg',
+ 'particles-rate': '1.e15 m^-3 s^-1',
+ 'percentage': '%',
+ 'site-density': 'kgmol m^-2',
+ 'soot-limiting-nuclei-rate': '1e+15-particles/m3-s',
+ 'soot-oxidation-constant': 'kg m kgmol^-1 K^-0.5 s^-1',
+ 'soot-pre-exponential-constant': '1.e15 kg^-1 s^-1',
+ 'soot-surface-growth-scale-factor': 'kg m kgmol^-1 s^-1',
+ 'surface-mole-transfer-rate': 'kgmol m^-2 s^-1',
+ 'univ-gas-constant': 'J K^-1 kgmol^-1',
+ 'viscosity-consistency-index': 'kg s^n-2 m^-1',
+ 'wave-length': 'Angstrom'}
 """
 
 _fl_unit_table = {
@@ -43,9 +91,7 @@ _fl_unit_table = {
     "collision-rate": "m^-3 s^-1",
     "concentration": "kmol m^-3",
     "contact-resistance": "m^2 K W^-1",
-    "contact-resistance-vol": "Ohm m^3",
     "crank-angle": "radian",
-    "crank-angular-velocity": "rev min^-1",
     "current": "A",
     "current-density": "A m^-2",
     "current-vol-density": "A m^-3",
@@ -59,13 +105,9 @@ _fl_unit_table = {
     "elec-charge": "A h",
     "elec-charge-density": "A s m^-3",
     "elec-conductivity": "S m^-1",
-    "elec-contact-resistance": "Ohm m^2",
     "elec-field": "V m^-1",
     "elec-permittivity": "farad m^-1",
-    "elec-resistance": "Ohm",
-    "elec-resistivity": "Ohm m",
     "energy": "J",
-    "energy-density": "J/m2",
     "force": "N",
     "force*time-per-volume": "N s m^-3",
     "force-per-area": "N m^-2",
@@ -89,18 +131,11 @@ _fl_unit_table = {
     "mass-flow-per-time": "kg s^-2",
     "mass-flux": "kg m^-2 s^-1",
     "mass-transfer-rate": "kg m^-3 s^-1",
-    "mole-con-henry-const": "Pa m^3 kgmol^-1",
-    "mole-specific-energy": "J kgmol^-1",
-    "mole-specific-entropy": "J kgmol^-1 K^-1",
-    "mole-transfer-rate": "kgmol m^-3 s^-1",
     "molec-wt": "kg kmol^-1",
     "moment": "N m",
     "moment-of-inertia": "kg m^2",
     "nucleation-rate": "m^-3 s^-1",
     "number-density": "m^-3",
-    "particles-conc": "1.e15-particles/kg",
-    "particles-rate": "1.e15 m^-3 s^-1",
-    "percentage": "%",
     "power": "W",
     "power-per-time": "W s^-1",
     "pressure": "Pa",
@@ -109,14 +144,9 @@ _fl_unit_table = {
     "pressure-time-deriv-sqr": "Pa^2 s^-2",
     "pressure-time-derivative": "Pa s^-1",
     "resistance": "m^-1",
-    "site-density": "kgmol m^-2",
     "soot-formation-constant-unit": "kg N^-1 m^-1 s^-1",
-    "soot-limiting-nuclei-rate": "1e+15-particles/m3-s",
     "soot-linear-termination": "m^3 s^-1",
-    "soot-oxidation-constant": "kg m kgmol^-1 K^-0.5 s^-1",
-    "soot-pre-exponential-constant": "1.e15 kg^-1 s^-1",
     "soot-sitespecies-concentration": "kmol m^-3",
-    "soot-surface-growth-scale-factor": "kg m kgmol^-1 s^-1",
     "source-elliptic-relaxation-function": "kg m^-3 s^-2",
     "source-energy": "W m^-3",
     "source-kinetic-energy": "kg m^-1 s^-3",
@@ -133,7 +163,6 @@ _fl_unit_table = {
     "spring-constant-angular": "N m radian^-1",
     "stefan-boltzmann-constant": "W m^-2 K^-4",
     "surface-density": "kg m^-2",
-    "surface-mole-transfer-rate": "kgmol m^-2 s^-1",
     "surface-tension": "N m^-1",
     "surface-tension-gradient": "N m^-1 K^-1",
     "temperature": "K",
@@ -154,18 +183,46 @@ _fl_unit_table = {
     "turbulent-energy-diss-rate-gradient": "m s^-3",
     "turbulent-kinetic-energy": "m^2 s^-2",
     "turbulent-kinetic-energy-gradient": "m s^-2",
-    "univ-gas-constant": "J K^-1 kgmol^-1",
     "velocity": "m s^-1",
     "viscosity": "kg m^-1 s^-1",
-    "viscosity-consistency-index": "kg s^n-2 m^-1",
     "voltage": "V",
     "volume": "m^3",
     "volume-flow-rate": "m^3 s^-1",
     "volume-flow-rate-per-depth": "m^3 s^-1 m^-1",
     "volume-inverse": "m^-3",
-    "wave-length": "Angstrom",
     "youngs-modulus": "N m^-2",
 }
+
+
+class InvalidQuantityType(TypeError):
+    def __init__(
+        self,
+        quantity,
+    ) -> None:
+        super().__init__(
+            f"The specified quantity, '{quantity}' is not a string ({type(quantity)})."
+        )
+
+
+class UnitsNotDefinedForQuantity(ValueError):
+    def __init__(
+        self,
+        quantity: str,
+    ) -> None:
+        super().__init__(
+            f"The units for the specified quantity, '{quantity}' are not defined in PyFluent."
+        )
+
+
+class UnhandledQuantity(RuntimeError):
+    def __init__(
+        self,
+        path: str,
+        quantity: Quantity,
+    ) -> None:
+        super().__init__(
+            f"Could not handle the quantity, '{quantity}' for the path, {path}."
+        )
 
 
 def get_si_unit_for_fluent_quantity(quantity: str, unit_table: dict = None):
@@ -173,15 +230,18 @@ def get_si_unit_for_fluent_quantity(quantity: str, unit_table: dict = None):
 
     Raises
     ------
-    TypeError
+    InvalidQuantityType
         If ``quantity`` is not a string instance.
+    UnitsNotDefinedForQuantity
+        If ``quantity`` is undefined for PyFluent.
     """
     try:
         if quantity.startswith("'"):
             quantity = quantity[1:]
     except AttributeError:
         # not a string
-        raise TypeError(
-            "Invalid quantity argument type in get_si_unit_for_fluent_quantity."
-        )
-    return (unit_table or _fl_unit_table)[quantity]
+        raise InvalidQuantityType(quantity)
+    try:
+        return (unit_table or _fl_unit_table)[quantity]
+    except KeyError:
+        raise UnitsNotDefinedForQuantity(quantity)

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -996,15 +996,17 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
 
     assert hot_inlet.turbulence.hydraulic_diameter() == 0.0254
 
-    # clip factor has no units-quantity attribute. We should not
-    # assume it to be dimensionless, or???
+    # clip_factor has no units-quantity attribute, because it is dimensionless
     solver.setup.models.viscous.options.production_limiter.clip_factor.set_state(1.2)
     assert solver.setup.models.viscous.options.production_limiter.clip_factor() == 1.2
-    with pytest.raises(UnhandledQuantity):
-        solver.setup.models.viscous.options.production_limiter.clip_factor.set_state(
-            ansys.units.Quantity(1.8, "")
-        )
     assert (
         solver.setup.models.viscous.options.production_limiter.clip_factor.as_quantity()
-        is None
+        == ansys.units.Quantity(1.2, "")
+    )
+    solver.setup.models.viscous.options.production_limiter.clip_factor.set_state(
+        ansys.units.Quantity(1.8, "")
+    )
+    assert (
+        solver.setup.models.viscous.options.production_limiter.clip_factor.as_quantity()
+        == ansys.units.Quantity(1.8, "")
     )


### PR DESCRIPTION
- **Follow-up on initial units integration into PyFluent.**
- upgrade ansys-units dependency
- enable a temporarily disabled test step due to this upgrade
- extend the testing
- fix an flobject assignment issue where exceptions were inadvertently hidden
- treat None value for units-quantity to indicate dimensionless
- implement exception handling
- rename `get_state_as_quantity()` (too long) as `as_quantity()`
- make the generation of the table data stricter