### PR TITLE
fix: Failing test for 24.2 is fixed.

### DIFF
--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -24,6 +24,7 @@ from ansys.fluent.core.solver.flobject import (
     Group,
     NamedObject,
     SettingsBase,
+    StateT,
     StateType,
 )
 import ansys.fluent.core.solver.function.reduction as reduction_old
@@ -243,8 +244,16 @@ class Solver(BaseSession):
         fut: Future = asynchronous(pyfluent.launch_fluent)(**launcher_args)
         fut.add_done_callback(functools.partial(Solver._sync_from_future, self))
 
-    def __call__(self):
+    def get_state(self) -> StateT:
+        """Get the state of the object."""
         return self._root.get_state()
+
+    def set_state(self, state: Optional[StateT] = None, **kwargs):
+        """Set the state of the object."""
+        self._root.set_state(state, **kwargs)
+
+    def __call__(self):
+        return self.get_state()
 
     def _populate_settings_api_root(self):
         if not self._settings_api_root:

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -854,7 +854,6 @@ def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     assert energy_parent == "\n energy is a child of models \n"
 
 
-@pytest.mark.skip("Failing in the latest image (#2463)")
 @pytest.mark.fluent_version(">=24.2")
 def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -433,6 +433,7 @@ def test_solver_methods(new_solver_session):
         assert api_keys.issubset(set(dir(solver)))
 
 
+@pytest.mark.fluent_version(">=23.2")
 def test_get_set_state_on_solver(new_solver_session):
     solver = new_solver_session
     state = solver.get_state()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -431,3 +431,10 @@ def test_solver_methods(new_solver_session):
             "parallel",
         }
         assert api_keys.issubset(set(dir(solver)))
+
+
+def test_get_set_state_on_solver(new_solver_session):
+    solver = new_solver_session
+    state = solver.get_state()
+    assert state
+    solver.set_state(state)


### PR DESCRIPTION
Expose get_state() and set_state() at solver level.
Activate failing test with new fluent image.