### PR TITLE
feat: state with units

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -581,10 +581,13 @@ class SettingsBase(Base, Generic[StateT]):
     def _add_units_to_state(self, state):
         if isinstance(state, collections.abc.Mapping):
             for k, v in state.items():
+                child = None
                 if isinstance(self, collections.abc.Mapping):
-                    child = self[k]
-                else:
-                    child = getattr(self, k, None)
+                    try:
+                        child = self[k]
+                    except KeyError:
+                        pass
+                child = child or getattr(self, k, None)
                 if child is None:
                     raise RuntimeError("Unexpected None child getting units for state")
                 elif isinstance(child, RealNumerical):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -415,11 +415,10 @@ class RealNumerical(Numerical):
             quantity = self.as_quantity()
             if quantity is not None:
                 return (quantity.value, quantity.units.name)
-        units = self.units()
-        if units is not None:
-            value = self.get_state()
-            if isinstance(value, (float, int)):
-                return (value, units)
+        # n.b. different impl to previous. Especially for
+        # nested state, user will want to get maximal information,
+        # so unconditionally just return all we have here
+        return (self.get_state(), self.units())
 
     def units(self) -> Optional[str]:
         """Get the physical units of the object as a string."""

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -651,7 +651,7 @@ class Boolean(SettingsBase[bool], Property):
 class RealList(SettingsBase[RealListType], RealNumerical):
     """A ``RealList`` object representing a real list setting."""
 
-    base_set_state = SettingsBase[RealType].set_state
+    base_set_state = SettingsBase[RealListType].set_state
     set_state = RealNumerical.set_state
 
     _state_type = RealListType

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -395,19 +395,20 @@ class RealNumerical(Numerical):
             the units specified for the quantity are not supported.
         """
         try:
-            if ansys_units and isinstance(state, (ansys_units.Quantity, tuple)):
+
+            def get_units():
                 units = self.units()
                 if units is None:
                     raise UnhandledQuantity(self.path, state)
+                return units
+
+            if ansys_units and isinstance(state, (ansys_units.Quantity, tuple)):
                 state = (
                     ansys_units.Quantity(*state) if isinstance(state, tuple) else state
                 )
-                state = state.to(units).value
+                state = state.to(get_units()).value
             elif isinstance(state, tuple):
-                units = self.units()
-                if units is None:
-                    raise UnhandledQuantity(self.path, state)
-                if state[1] == units:
+                if state[1] == get_units():
                     state = state[0]
                 else:
                     raise UnhandledQuantity(self.path, state)

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -343,8 +343,8 @@ class Numerical(Property):
 
 
 class RealNumerical(Numerical):
-    """A ``RealNumerical`` object representing a real value setting,
-    including single real values and containers of real values, such as lists.
+    """A ``RealNumerical`` object representing a real value setting, including single
+    real values and containers of real values, such as lists.
 
     Methods
     -------

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from inspect import Parameter
+
 """Module for accessing and modifying hierarchy of Fluent settings.
 
 The only useful method is '`get_root``, which returns the root object for
@@ -1811,3 +1813,18 @@ def _get_child_path(cls, path, identifier, list_of_children):
                 list_of_children.append(path_to_append)
         _list_children(cls._child_classes[name], identifier, path, list_of_children)
         path.pop()
+
+
+def update_state(obj, state):
+    if isinstance(state, collections.abc.Mapping):
+        for k, v in state.items():
+            if isinstance(obj, collections.abc.Mapping):
+                child = obj[k]
+            else:
+                child = getattr(obj, k, None)
+            if isinstance(child, RealNumerical):
+                state[k] = child.state_with_units()
+            elif child is None:
+                print("unexpected None child")
+            elif not isinstance(child, Parameter):
+                update_state(child, state[k])

--- a/src/ansys/fluent/core/solver/flunits.py
+++ b/src/ansys/fluent/core/solver/flunits.py
@@ -237,11 +237,9 @@ def get_si_unit_for_fluent_quantity(
     ------
     InvalidQuantityType
         If ``quantity`` is not a string instance, unless it is None.
-    UnitsNotDefinedForQuantity
-        If ``quantity`` is undefined for PyFluent.
     """
-    # The settings API should return None only if the
-    # parameter is dict
+    # The settings API should return None for the units-quantity
+    # attribute only for dimensionless variables
     if quantity is None:
         return ""
     try:
@@ -253,4 +251,7 @@ def get_si_unit_for_fluent_quantity(
     try:
         return (unit_table or _fl_unit_table)[quantity]
     except KeyError:
-        raise UnitsNotDefinedForQuantity(quantity)
+        # if it's not configured, None signifies that
+        # we don't know the units. no need to raise
+        # as this is pretty normal
+        pass

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -979,6 +979,22 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
 
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
+
+    assert hot_inlet.state_with_units() == {
+        "momentum": {
+            "initial_gauge_pressure": {"option": "value", "value": (0, "Pa")},
+            "reference_frame": "Absolute",
+            "velocity": {"option": "value", "value": (0, "m s^-1")},
+            "velocity_specification_method": "Magnitude, Normal to Boundary",
+        },
+        "name": "hot-inlet",
+        "turbulence": {
+            "turbulent_intensity": (0.05, None),
+            "turbulent_specification": "Intensity and Viscosity Ratio",
+            "turbulent_viscosity_ratio": (10, None),
+        },
+    }
+
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
 
@@ -1043,6 +1059,22 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     flobject.ansys_units = None
 
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
+
+    assert hot_inlet.state_with_units() == {
+        "momentum": {
+            "initial_gauge_pressure": {"option": "value", "value": (0, "Pa")},
+            "reference_frame": "Absolute",
+            "velocity": {"option": "value", "value": (0, "m s^-1")},
+            "velocity_specification_method": "Magnitude, Normal to Boundary",
+        },
+        "name": "hot-inlet",
+        "turbulence": {
+            "turbulent_intensity": (0.05, None),
+            "turbulent_specification": "Intensity and Viscosity Ratio",
+            "turbulent_viscosity_ratio": (10, None),
+        },
+    }
+
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -971,7 +971,7 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     hydraulic_diameter.set_state("1 [in]")
     assert hydraulic_diameter() == "1 [in]"
     assert hydraulic_diameter.as_quantity() == None
-    assert hydraulic_diameter.state_with_units() == None
+    assert hydraulic_diameter.state_with_units() == ("1 [in]", "m")
     assert hydraulic_diameter.units() == "m"
 
     turbulent_intensity = turbulence.turbulent_intensity
@@ -1048,7 +1048,7 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     hydraulic_diameter.set_state("1 [in]")
     assert hydraulic_diameter() == "1 [in]"
     assert hydraulic_diameter.as_quantity() == None
-    assert hydraulic_diameter.state_with_units() == None
+    assert hydraulic_diameter.state_with_units() == ("1 [in]", "m")
     assert hydraulic_diameter.units() == "m"
 
     turbulent_intensity = turbulence.turbulent_intensity
@@ -1073,5 +1073,25 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     assert clip_factor.as_quantity() == None
     assert clip_factor.state_with_units() == (1.2, "")
     assert clip_factor.units() == ""
+
+    def check_vector_units(obj, units):
+        assert obj.units() == units
+        state_with_units = obj.state_with_units()
+        state = obj.get_state()
+        assert len(state_with_units) == 2
+        assert len(state) == len(state_with_units[0])
+        assert all(x == y for x, y in zip(state, state_with_units[0]))
+        assert units == state_with_units[1]
+
+    check_vector_units(
+        solver.setup.general.operating_conditions.reference_pressure_location, "m"
+    )
+
+    check_vector_units(
+        solver.setup.reference_frames[
+            "global"
+        ].initial_state.orientation.first_axis.axis_to.vector,
+        "",
+    )
 
     flobject.ansys_units = ansys_units

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -959,6 +959,21 @@ def test_parent_class_attributes(load_static_mixer_settings_only):
         solver.setup.models.energy.__class__.enabled
 
 
+def _check_vector_units(obj, units):
+    assert obj.units() == units
+    state_with_units = obj.state_with_units()
+    state = obj.get_state()
+    assert len(state_with_units) == 2
+    assert len(state) == len(state_with_units[0])
+    assert all(x == y for x, y in zip(state, state_with_units[0]))
+    assert units == state_with_units[1]
+    # TODO
+    # Needs update in ansys.units: comparison operator converts each
+    # object to float, but Quantity supports lists and arrays.
+    # if flobject.ansys_units:
+    #     assert obj.as_quantity() == ansys.units.Quantity(obj.get_state(), units)
+
+
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
@@ -1009,24 +1024,11 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     assert clip_factor.state_with_units() == (1.8, "")
     assert clip_factor.units() == ""
 
-    def check_vector_units(obj, units):
-        assert obj.units() == units
-        state_with_units = obj.state_with_units()
-        state = obj.get_state()
-        assert len(state_with_units) == 2
-        assert len(state) == len(state_with_units[0])
-        assert all(x == y for x, y in zip(state, state_with_units[0]))
-        assert units == state_with_units[1]
-        # TODO
-        # Needs update in ansys.units: comparison operator converts each
-        # object to float, but Quantity supports lists and arrays.
-        # assert obj.as_quantity() == ansys.units.Quantity(obj.get_state(), units)
-
-    check_vector_units(
+    _check_vector_units(
         solver.setup.general.operating_conditions.reference_pressure_location, "m"
     )
 
-    check_vector_units(
+    _check_vector_units(
         solver.setup.reference_frames[
             "global"
         ].initial_state.orientation.first_axis.axis_to.vector,
@@ -1074,20 +1076,11 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     assert clip_factor.state_with_units() == (1.2, "")
     assert clip_factor.units() == ""
 
-    def check_vector_units(obj, units):
-        assert obj.units() == units
-        state_with_units = obj.state_with_units()
-        state = obj.get_state()
-        assert len(state_with_units) == 2
-        assert len(state) == len(state_with_units[0])
-        assert all(x == y for x, y in zip(state, state_with_units[0]))
-        assert units == state_with_units[1]
-
-    check_vector_units(
+    _check_vector_units(
         solver.setup.general.operating_conditions.reference_pressure_location, "m"
     )
 
-    check_vector_units(
+    _check_vector_units(
         solver.setup.reference_frames[
             "global"
         ].initial_state.orientation.first_axis.axis_to.vector,

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -995,6 +995,8 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
         },
     }
 
+    assert isinstance(solver._root.state_with_units(), dict)
+
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
 
@@ -1074,6 +1076,8 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
             "turbulent_viscosity_ratio": (10, None),
         },
     }
+
+    assert isinstance(solver._root.state_with_units(), dict)
 
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -978,24 +978,9 @@ def _check_vector_units(obj, units):
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
 
-    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
-
-    assert hot_inlet.state_with_units() == {
-        "momentum": {
-            "initial_gauge_pressure": {"option": "value", "value": (0, "Pa")},
-            "reference_frame": "Absolute",
-            "velocity": {"option": "value", "value": (0, "m s^-1")},
-            "velocity_specification_method": "Magnitude, Normal to Boundary",
-        },
-        "name": "hot-inlet",
-        "turbulence": {
-            "turbulent_intensity": (0.05, None),
-            "turbulent_specification": "Intensity and Viscosity Ratio",
-            "turbulent_viscosity_ratio": (10, None),
-        },
-    }
-
     assert isinstance(solver._root.state_with_units(), dict)
+
+    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
 
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
@@ -1060,24 +1045,9 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     ansys_units = flobject.ansys_units
     flobject.ansys_units = None
 
-    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
-
-    assert hot_inlet.state_with_units() == {
-        "momentum": {
-            "initial_gauge_pressure": {"option": "value", "value": (0, "Pa")},
-            "reference_frame": "Absolute",
-            "velocity": {"option": "value", "value": (0, "m s^-1")},
-            "velocity_specification_method": "Magnitude, Normal to Boundary",
-        },
-        "name": "hot-inlet",
-        "turbulence": {
-            "turbulent_intensity": (0.05, None),
-            "turbulent_specification": "Intensity and Viscosity Ratio",
-            "turbulent_viscosity_ratio": (10, None),
-        },
-    }
-
     assert isinstance(solver._root.state_with_units(), dict)
+
+    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
 
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
@@ -1124,3 +1094,25 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     )
 
     flobject.ansys_units = ansys_units
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
+    solver = load_mixing_elbow_mesh
+
+    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
+
+    assert hot_inlet.state_with_units() == {
+        "momentum": {
+            "initial_gauge_pressure": {"option": "value", "value": (0, "Pa")},
+            "reference_frame": "Absolute",
+            "velocity": {"option": "value", "value": (0, "m s^-1")},
+            "velocity_specification_method": "Magnitude, Normal to Boundary",
+        },
+        "name": "hot-inlet",
+        "turbulence": {
+            "turbulent_intensity": (0.05, None),
+            "turbulent_specification": "Intensity and Viscosity Ratio",
+            "turbulent_viscosity_ratio": (10, None),
+        },
+    }


### PR DESCRIPTION
- **Add `RealList` to units support**.
- Generalize the implementations for `Real` and `RealList` in a shared mixin base class.
- Change the behaviour of method `real_with_units`. Previously it returned None if the units were undefined or if the value were not `float` (or `int`). That would be particularly unsatisfactory for nested state, so we construct the tuple unconditionally now.
- Added test steps for the `RealList`.
- ansys.units update is required, as commented in test code.
- added code and test for **nested** state with units. **This means a lot more changes since the approvals!**