### PR TITLE
feat: units percent and ohms and handling nested quantities

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -595,7 +595,14 @@ class SettingsBase(Base, Generic[StateT]):
     def set_state(self, state: Optional[StateT] = None, **kwargs):
         """Set the state of the object."""
         with self.while_setting_state():
-            return self.flproxy.set_var(self.path, self.to_scheme_keys(kwargs or state))
+            if isinstance(state, (tuple, ansys_units.Quantity)) and hasattr(
+                self, "value"
+            ):
+                self.value.set_state(state, **kwargs)
+            else:
+                return self.flproxy.set_var(
+                    self.path, self.to_scheme_keys(kwargs or state)
+                )
 
     @staticmethod
     def _print_state_helper(state, out, indent=0, indent_factor=2):

--- a/src/ansys/fluent/core/solver/flunits.py
+++ b/src/ansys/fluent/core/solver/flunits.py
@@ -15,16 +15,22 @@ from ansys.units.quantity import get_si_value
 import re
 from pprint import pprint
 
-fl_unit_subs = {'deg': 'radian', 'rad':'radian'}
+fl_unit_re_subs = {'deg': 'radian', 'rad':'radian'}
+fl_unit_subs = {'%':''}
+
 def replace_units(match):
-    return fl_unit_subs[match.group(0)]
+    return fl_unit_re_subs[match.group(0)]
 
 def substitute_fl_units_with_py_units(fl_units_dict):
     subs = {}
     for k, v in fl_units_dict.items():
-        new_val = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in fl_unit_subs), replace_units, v)
+        new_val = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in fl_unit_re_subs), replace_units, v)
         if new_val != v:
             subs[k] = new_val
+        else:
+            new_val = fl_unit_subs.get(v, None)
+            if new_val is not None:
+                subs[k] = new_val
     print("Substitutions:")
     for k, v in subs.items():
         print(f"'{fl_units_dict[k]}' -> '{v}' for '{k}'")
@@ -57,6 +63,12 @@ def make_python_fl_unit_table(scheme_unit_table):
 Output from most recent run to generate the table below:
 
 >>> pprint(make_python_fl_unit_table(fl_scheme_unit_table))
+Substitutions:
+'deg' -> 'radian' for 'angle'
+'rad s^-1' -> 'radian s^-1' for 'angular-velocity'
+'deg' -> 'radian' for 'crank-angle'
+'%' -> '' for 'percentage'
+'N m rad^-1' -> 'N m radian^-1' for 'spring-constant-angular'
 Not SI:
 {'concentration': 'kmol m^-3',
  'elec-charge': 'A h',
@@ -75,7 +87,6 @@ Unhandled:
  'mole-transfer-rate': 'kgmol m^-3 s^-1',
  'particles-conc': '1.e15-particles/kg',
  'particles-rate': '1.e15 m^-3 s^-1',
- 'percentage': '%',
  'site-density': 'kgmol m^-2',
  'soot-limiting-nuclei-rate': '1e+15-particles/m3-s',
  'soot-oxidation-constant': 'kg m kgmol^-1 K^-0.5 s^-1',
@@ -140,6 +151,7 @@ _fl_unit_table = {
     "moment-of-inertia": "kg m^2",
     "nucleation-rate": "m^-3 s^-1",
     "number-density": "m^-3",
+    "percentage": "",
     "power": "W",
     "power-per-time": "W s^-1",
     "pressure": "Pa",

--- a/src/ansys/fluent/core/solver/flunits.py
+++ b/src/ansys/fluent/core/solver/flunits.py
@@ -15,8 +15,13 @@ from ansys.units.quantity import get_si_value
 import re
 from pprint import pprint
 
-fl_unit_re_subs = {'deg': 'radian', 'rad':'radian'}
-fl_unit_subs = {'%':''}
+fl_unit_re_subs = {
+    'deg': 'radian',
+    'rad': 'radian',
+    'Ohm': 'ohm'
+}
+
+fl_unit_subs = {'%': ''}
 
 def replace_units(match):
     return fl_unit_re_subs[match.group(0)]
@@ -66,7 +71,11 @@ Output from most recent run to generate the table below:
 Substitutions:
 'deg' -> 'radian' for 'angle'
 'rad s^-1' -> 'radian s^-1' for 'angular-velocity'
+'Ohm m^3' -> 'ohm m^3' for 'contact-resistance-vol'
 'deg' -> 'radian' for 'crank-angle'
+'Ohm m^2' -> 'ohm m^2' for 'elec-contact-resistance'
+'Ohm m' -> 'ohm m' for 'elec-resistivity'
+'Ohm' -> 'ohm' for 'elec-resistance'
 '%' -> '' for 'percentage'
 'N m rad^-1' -> 'N m radian^-1' for 'spring-constant-angular'
 Not SI:
@@ -75,11 +84,7 @@ Not SI:
  'molec-wt': 'kg kmol^-1',
  'soot-sitespecies-concentration': 'kmol m^-3'}
 Unhandled:
-{'contact-resistance-vol': 'Ohm m^3',
- 'crank-angular-velocity': 'rev min^-1',
- 'elec-contact-resistance': 'Ohm m^2',
- 'elec-resistance': 'Ohm',
- 'elec-resistivity': 'Ohm m',
+{'crank-angular-velocity': 'rev min^-1',
  'energy-density': 'J/m2',
  'mole-con-henry-const': 'Pa m^3 kgmol^-1',
  'mole-specific-energy': 'J kgmol^-1',
@@ -108,6 +113,7 @@ _fl_unit_table = {
     "area-inverse": "m^-2",
     "collision-rate": "m^-3 s^-1",
     "contact-resistance": "m^2 K W^-1",
+    "contact-resistance-vol": "ohm m^3",
     "crank-angle": "radian",
     "current": "A",
     "current-density": "A m^-2",
@@ -121,8 +127,11 @@ _fl_unit_table = {
     "depth": "m",
     "elec-charge-density": "A s m^-3",
     "elec-conductivity": "S m^-1",
+    "elec-contact-resistance": "ohm m^2",
     "elec-field": "V m^-1",
     "elec-permittivity": "farad m^-1",
+    "elec-resistance": "ohm",
+    "elec-resistivity": "ohm m",
     "energy": "J",
     "force": "N",
     "force*time-per-volume": "N s m^-3",

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1047,7 +1047,7 @@ def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
         },
         "name": "hot-inlet",
         "turbulence": {
-            "turbulent_intensity": (0.05, None),
+            "turbulent_intensity": (0.05, ""),
             "turbulent_specification": "Intensity and Viscosity Ratio",
             "turbulent_viscosity_ratio": (10, None),
         },

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -10,11 +10,7 @@ from util.solver_workflow import new_solver_session_no_transcript  # noqa: F401
 
 from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.solver import flobject
-from ansys.fluent.core.solver.flobject import (
-    InactiveObjectError,
-    UnhandledQuantity,
-    find_children,
-)
+from ansys.fluent.core.solver.flobject import InactiveObjectError, find_children
 import ansys.units
 
 
@@ -973,45 +969,31 @@ def _check_vector_units(obj, units):
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
-
     assert isinstance(solver._root.state_with_units(), dict)
-
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
-
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
-
     hydraulic_diameter = turbulence.hydraulic_diameter
     hydraulic_diameter.set_state("1 [in]")
     assert hydraulic_diameter() == "1 [in]"
     assert hydraulic_diameter.as_quantity() == None
     assert hydraulic_diameter.state_with_units() == ("1 [in]", "m")
     assert hydraulic_diameter.units() == "m"
-
     turbulent_intensity = turbulence.turbulent_intensity
     turbulent_intensity.set_state(0.2)
     assert turbulent_intensity() == 0.2
-
-    # turbulent_intensity has a units-quantity attribute, 'percentage', but it
-    # is unsupported. So, 'percentage' cannot be converted to a Quantity.
-    assert turbulent_intensity.as_quantity() == None
-
-    # likewise, cannot set turbulent_intensity via a Quantity
-    with pytest.raises(UnhandledQuantity):
-        turbulent_intensity.set_state(ansys.units.Quantity(0.1, ""))
-
+    assert turbulent_intensity.as_quantity() == ansys.units.Quantity(0.2, "")
+    turbulent_intensity.set_state(ansys.units.Quantity(0.1, ""))
+    assert turbulent_intensity.state_with_units() == (0.1, "")
     hydraulic_diameter.set_state(1)
     assert hydraulic_diameter.as_quantity() == ansys.units.Quantity(1, "m")
     assert hydraulic_diameter.state_with_units() == (1.0, "m")
     assert hydraulic_diameter.units() == "m"
-
     hydraulic_diameter.set_state(ansys.units.Quantity(1, "in"))
     assert hydraulic_diameter.as_quantity() == ansys.units.Quantity(0.0254, "m")
     assert hydraulic_diameter.state_with_units() == (0.0254, "m")
     assert hydraulic_diameter.units() == "m"
     assert hydraulic_diameter() == 0.0254
-
-    # clip_factor has no units-quantity attribute because it is dimensionless
     clip_factor = solver.setup.models.viscous.options.production_limiter.clip_factor
     clip_factor.set_state(1.2)
     assert clip_factor() == 1.2
@@ -1040,37 +1022,28 @@ def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     ansys_units = flobject.ansys_units
     flobject.ansys_units = None
-
     assert isinstance(solver._root.state_with_units(), dict)
-
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
-
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
-
     hydraulic_diameter = turbulence.hydraulic_diameter
     hydraulic_diameter.set_state("1 [in]")
     assert hydraulic_diameter() == "1 [in]"
     assert hydraulic_diameter.as_quantity() == None
     assert hydraulic_diameter.state_with_units() == ("1 [in]", "m")
     assert hydraulic_diameter.units() == "m"
-
     turbulent_intensity = turbulence.turbulent_intensity
     turbulent_intensity.set_state(0.2)
     assert turbulent_intensity() == 0.2
-
-    # turbulent_intensity has a units-quantity attribute, 'percentage', but it
-    # is unsupported. So, 'percentage' cannot be converted to a Quantity.
     assert turbulent_intensity.as_quantity() == None
-
+    turbulent_intensity.set_state((0.1, ""))
+    assert turbulent_intensity.state_with_units == (0.1, "")
     hydraulic_diameter.set_state(1)
     assert hydraulic_diameter.as_quantity() == None
     assert hydraulic_diameter.state_with_units() == (1.0, "m")
     assert hydraulic_diameter.units() == "m"
     hydraulic_diameter.set_state((2.0, "m"))
     assert hydraulic_diameter.state_with_units() == (2.0, "m")
-
-    # clip_factor has no units-quantity attribute because it is dimensionless
     clip_factor = solver.setup.models.viscous.options.production_limiter.clip_factor
     clip_factor.set_state(1.2)
     assert clip_factor() == 1.2

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -999,6 +999,16 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     ) / ansys.units.Quantity(3.0, ansys.units.UnitRegistry().s)
     hot_inlet.momentum.velocity.value = velocity
     assert hot_inlet.momentum.velocity.value.as_quantity() == velocity
+    velocity = (1.0, "m s^-1")
+    hot_inlet.momentum.velocity = velocity
+    assert hot_inlet.momentum.velocity.value.state_with_units() == velocity
+    velocity = ansys.units.Quantity(12.0, "m s^-1")
+    hot_inlet.momentum.velocity = velocity
+    assert hot_inlet.momentum.velocity.value.as_quantity() == velocity
+    assert hot_inlet.momentum.velocity.state_with_units() == {
+        "option": "value",
+        "value": (12.0, "m s^-1"),
+    }
     clip_factor = solver.setup.models.viscous.options.production_limiter.clip_factor
     clip_factor.set_state(1.2)
     assert clip_factor() == 1.2
@@ -1020,54 +1030,6 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
         ].initial_state.orientation.first_axis.axis_to.vector,
         "",
     )
-
-
-@pytest.mark.fluent_version(">=24.1")
-def test_ansys_units_integration_no_pyansys_units(load_mixing_elbow_mesh):
-    solver = load_mixing_elbow_mesh
-    ansys_units = flobject.ansys_units
-    flobject.ansys_units = None
-    assert isinstance(solver._root.state_with_units(), dict)
-    hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
-    turbulence = hot_inlet.turbulence
-    turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"
-    hydraulic_diameter = turbulence.hydraulic_diameter
-    hydraulic_diameter.set_state("1 [in]")
-    assert hydraulic_diameter() == "1 [in]"
-    assert hydraulic_diameter.as_quantity() == None
-    assert hydraulic_diameter.state_with_units() == ("1 [in]", "m")
-    assert hydraulic_diameter.units() == "m"
-    turbulent_intensity = turbulence.turbulent_intensity
-    turbulent_intensity.set_state(0.2)
-    assert turbulent_intensity() == 0.2
-    assert turbulent_intensity.as_quantity() == None
-    turbulent_intensity.set_state((0.1, ""))
-    assert turbulent_intensity.state_with_units == (0.1, "")
-    hydraulic_diameter.set_state(1)
-    assert hydraulic_diameter.as_quantity() == None
-    assert hydraulic_diameter.state_with_units() == (1.0, "m")
-    assert hydraulic_diameter.units() == "m"
-    hydraulic_diameter.set_state((2.0, "m"))
-    assert hydraulic_diameter.state_with_units() == (2.0, "m")
-    clip_factor = solver.setup.models.viscous.options.production_limiter.clip_factor
-    clip_factor.set_state(1.2)
-    assert clip_factor() == 1.2
-    assert clip_factor.as_quantity() == None
-    assert clip_factor.state_with_units() == (1.2, "")
-    assert clip_factor.units() == ""
-
-    _check_vector_units(
-        solver.setup.general.operating_conditions.reference_pressure_location, "m"
-    )
-
-    _check_vector_units(
-        solver.setup.reference_frames[
-            "global"
-        ].initial_state.orientation.first_axis.axis_to.vector,
-        "",
-    )
-
-    flobject.ansys_units = ansys_units
 
 
 @pytest.mark.fluent_version(">=24.2")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -994,6 +994,11 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     assert hydraulic_diameter.state_with_units() == (0.0254, "m")
     assert hydraulic_diameter.units() == "m"
     assert hydraulic_diameter() == 0.0254
+    velocity = ansys.units.Quantity(
+        12.0, ansys.units.UnitRegistry().ft
+    ) / ansys.units.Quantity(3.0, ansys.units.UnitRegistry().s)
+    hot_inlet.momentum.velocity.value = velocity
+    assert hot_inlet.momentum.velocity.value.as_quantity() == velocity
     clip_factor = solver.setup.models.viscous.options.production_limiter.clip_factor
     clip_factor.set_state(1.2)
     assert clip_factor() == 1.2


### PR DESCRIPTION
- Extend units coverage by massaging the Fluent table a bit more.
- Fix an issue for setting quantities at `x` where `x.value` is a `Real`*. WARNING: this is a hack.