### PR TITLE
fix: settingsgen

### DIFF
--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -455,7 +455,6 @@ def _populate_classes(parent_dir):
             return_type = getattr(cls, "return_type", None)
             if return_type:
                 f.write(f"{istr1}return_type = {return_type}\n")
-                f.write(f'{istr1}"""\n')
                 if stubf:
                     stubf.write(f"{istr1}{return_type} = ...\n")
 

--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -454,7 +454,7 @@ def _populate_classes(parent_dir):
 
             return_type = getattr(cls, "return_type", None)
             if return_type:
-                f.write(f"{istr1}return_type = {return_type}\n")
+                f.write(f'{istr1}return_type = "{return_type}"\n')
                 if stubf:
                     stubf.write(f"{istr1}{return_type} = ...\n")
 


### PR DESCRIPTION
It was not caught in my PR because the codegen was not rerun after the docker image update. The unittests ran with the dynamically generated classes from the new image due to the updated static-info.