### PR TITLE
refactor: rename remote_file_handler to file_transfer_service

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -211,7 +211,7 @@ class DockerLauncher:
                 launcher_args=self.argvals,
                 inside_container=True,
             ),
-            remote_file_handler=self.file_transfer_service,
+            file_transfer_service=self.file_transfer_service,
         )
 
         if self.start_watchdog is None and self.cleanup_on_exit:

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -615,12 +615,12 @@ def launch_remote_fluent(
         launcher_args=launcher_args,
     )
 
-    remote_file_handler = (
+    file_transfer_service = (
         file_transfer_service
         if file_transfer_service
         else PimFileTransferService(pim_instance=fluent_connection._remote_instance)
     )
 
     return session_cls(
-        fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+        fluent_connection=fluent_connection, file_transfer_service=file_transfer_service
     )

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -238,7 +238,7 @@ class SlurmLauncher:
         )
         session = self._new_session.create_from_server_info_file(
             server_info_file_name=self._server_info_file_name,
-            remote_file_handler=None,
+            file_transfer_service=None,
             cleanup_on_exit=self._cleanup_on_exit,
             start_transcript=self._start_transcript,
             inside_container=False,

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -239,7 +239,7 @@ class StandaloneLauncher:
 
             session = self.new_session.create_from_server_info_file(
                 server_info_file_name=server_info_file_name,
-                remote_file_handler=self.file_transfer_service,
+                file_transfer_service=self.file_transfer_service,
                 cleanup_on_exit=self.cleanup_on_exit,
                 start_transcript=self.start_transcript,
                 launcher_args=self.argvals,

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -113,7 +113,7 @@ class DatamodelServiceImpl:
         channel: grpc.Channel,
         metadata: list[tuple[str, str]],
         fluent_error_state,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ) -> None:
         """__init__ method of DatamodelServiceImpl class."""
         intercept_channel = grpc.intercept_channel(
@@ -126,7 +126,7 @@ class DatamodelServiceImpl:
         )
         self._stub = DataModelGrpcModule.DataModelStub(intercept_channel)
         self._metadata = metadata
-        self.remote_file_handler = remote_file_handler
+        self.file_transfer_service = file_transfer_service
 
     def initialize_datamodel(
         self, request: DataModelProtoModule.InitDatamodelRequest
@@ -351,7 +351,7 @@ class DatamodelService(StreamingService):
         channel: grpc.Channel,
         metadata: list[tuple[str, str]],
         fluent_error_state,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ) -> None:
         """__init__ method of DatamodelService class."""
         self._impl = DatamodelServiceImpl(channel, metadata, fluent_error_state)
@@ -361,7 +361,7 @@ class DatamodelService(StreamingService):
         )
         self.event_streaming = None
         self.events = {}
-        self.remote_file_handler = remote_file_handler
+        self.file_transfer_service = file_transfer_service
 
     def get_attribute_value(self, rules: str, path: str, attribute: str) -> _TValue:
         request = DataModelProtoModule.GetAttributeValueRequest(
@@ -1534,7 +1534,7 @@ class PyCommand:
 class _InputFile:
     def _do_before_execute(self, value):
         try:
-            self.service.remote_file_handler.upload(file_name=value)
+            self.service.file_transfer_service.upload(file_name=value)
         except AttributeError:
             pass
 
@@ -1542,7 +1542,7 @@ class _InputFile:
 class _OutputFile:
     def _do_after_execute(self, value):
         try:
-            self.service.remote_file_handler.download(file_name=value)
+            self.service.file_transfer_service.download(file_name=value)
         except AttributeError:
             pass
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -94,26 +94,26 @@ class BaseSession:
     def __init__(
         self,
         fluent_connection: FluentConnection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """BaseSession.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
-            remote_file_handler: Supports file upload and download.
+            file_transfer_service: Supports file upload and download.
         """
         BaseSession.build_from_fluent_connection(
-            self, fluent_connection, remote_file_handler
+            self, fluent_connection, file_transfer_service
         )
 
     def build_from_fluent_connection(
         self,
         fluent_connection: FluentConnection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """Build a BaseSession object from fluent_connection object."""
         self.fluent_connection = fluent_connection
-        self._remote_file_handler = remote_file_handler
+        self._file_transfer_service = file_transfer_service
         self.error_state = self.fluent_connection.error_state
         self.scheme_eval = self.fluent_connection.scheme_eval
         self.rp_vars = RPVars(self.scheme_eval.string_eval)
@@ -138,7 +138,7 @@ class BaseSession:
             fluent_connection._channel,
             fluent_connection._metadata,
             self.error_state,
-            self._remote_file_handler,
+            self._file_transfer_service,
         )
 
         self.datamodel_events = DatamodelEvents(self.datamodel_service_se)
@@ -226,7 +226,7 @@ class BaseSession:
     def create_from_server_info_file(
         cls,
         server_info_file_name: str,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
         **connection_kwargs,
     ):
         """Create a Session instance from server-info file.
@@ -235,7 +235,7 @@ class BaseSession:
         ----------
         server_info_file_name : str
             Path to server-info file written out by Fluent server
-        remote_file_handler : Optional
+        file_transfer_service : Optional
             Support file upload and download.
         **connection_kwargs : dict, optional
             Additional keyword arguments may be specified, and they will be passed to the `FluentConnection`
@@ -253,7 +253,7 @@ class BaseSession:
             fluent_connection=FluentConnection(
                 ip=ip, port=port, password=password, **connection_kwargs
             ),
-            remote_file_handler=remote_file_handler,
+            file_transfer_service=file_transfer_service,
         )
         return session
 

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -19,16 +19,17 @@ class Meshing(PureMeshing):
     def __init__(
         self,
         fluent_connection: FluentConnection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """Meshing session.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
-            remote_file_handler: Supports file upload and download.
+            file_transfer_service: Supports file upload and download.
         """
         super(Meshing, self).__init__(
-            fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+            fluent_connection=fluent_connection,
+            file_transfer_service=file_transfer_service,
         )
         self.switch_to_solver = lambda: self._switch_to_solver()
         self.switched = False
@@ -37,7 +38,7 @@ class Meshing(PureMeshing):
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(
             fluent_connection=self.fluent_connection,
-            remote_file_handler=self._remote_file_handler,
+            file_transfer_service=self._file_transfer_service,
         )
         delattr(self, "switch_to_solver")
         self.switched = True

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -40,16 +40,17 @@ class PureMeshing(BaseSession):
     def __init__(
         self,
         fluent_connection: FluentConnection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """PureMeshing session.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
-            remote_file_handler: Supports file upload and download.
+            file_transfer_service: Supports file upload and download.
         """
         super(PureMeshing, self).__init__(
-            fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+            fluent_connection=fluent_connection,
+            file_transfer_service=file_transfer_service,
         )
         self._base_meshing = BaseMeshing(
             self.execute_tui,

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -77,16 +77,17 @@ class Solver(BaseSession):
     def __init__(
         self,
         fluent_connection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """Solver session.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
-            remote_file_handler: Supports file upload and download.
+            file_transfer_service: Supports file upload and download.
         """
         super(Solver, self).__init__(
-            fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+            fluent_connection=fluent_connection,
+            file_transfer_service=file_transfer_service,
         )
         self._build_from_fluent_connection(fluent_connection)
 
@@ -198,7 +199,7 @@ class Solver(BaseSession):
             self._settings_root = flobject.get_root(
                 flproxy=self._settings_service,
                 version=self._version,
-                remote_file_handler=self._remote_file_handler,
+                file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.fluent_connection.scheme_eval.scheme_eval,
             )
         return self._settings_root

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -19,16 +19,17 @@ class SolverIcing(Solver):
     def __init__(
         self,
         fluent_connection: FluentConnection,
-        remote_file_handler: Optional[Any] = None,
+        file_transfer_service: Optional[Any] = None,
     ):
         """SolverIcing session.
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
-            remote_file_handler: Supports file upload and download.
+            file_transfer_service: Supports file upload and download.
         """
         super(SolverIcing, self).__init__(
-            fluent_connection=fluent_connection, remote_file_handler=remote_file_handler
+            fluent_connection=fluent_connection,
+            file_transfer_service=file_transfer_service,
         )
         self._flserver_root = None
         self._fluent_version = None

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -173,7 +173,7 @@ class Base:
         """__init__ of Base class."""
         self._setattr("_parent", weakref.proxy(parent) if parent is not None else None)
         self._setattr("_flproxy", None)
-        self._setattr("_remote_file_handler", None)
+        self._setattr("_file_transfer_service", None)
         if name is not None:
             self._setattr("_name", name)
 
@@ -181,9 +181,9 @@ class Base:
         """Set flproxy object."""
         self._setattr("_flproxy", flproxy)
 
-    def set_remote_file_handler(self, remote_file_handler):
-        """Set remote_file_handler."""
-        self._setattr("_remote_file_handler", remote_file_handler)
+    def set_file_transfer_service(self, file_transfer_service):
+        """Set file_transfer_service."""
+        self._setattr("_file_transfer_service", file_transfer_service)
 
     @property
     def flproxy(self):
@@ -197,15 +197,15 @@ class Base:
         return self._flproxy
 
     @property
-    def remote_file_handler(self):
+    def file_transfer_service(self):
         """Remote file handler.
 
         Supports file upload and download.
         """
-        if self._remote_file_handler:
-            return self._remote_file_handler
+        if self._file_transfer_service:
+            return self._file_transfer_service
         elif self._parent:
-            return self._parent.remote_file_handler
+            return self._parent.file_transfer_service
 
     _name = None
     fluent_name = None
@@ -707,14 +707,14 @@ class FileName(Base):
 
 class _InputFile(FileName):
     def _do_before_execute(self, value):
-        if self.remote_file_handler:
-            self.remote_file_handler.upload(file_name=value)
+        if self.file_transfer_service:
+            self.file_transfer_service.upload(file_name=value)
 
 
 class _OutputFile(FileName):
     def _do_after_execute(self, value):
-        if self.remote_file_handler:
-            self.remote_file_handler.download(file_name=value)
+        if self.file_transfer_service:
+            self.file_transfer_service.download(file_name=value)
 
 
 class _InOutFile(_InputFile, _OutputFile):
@@ -1824,7 +1824,7 @@ def _gethash(obj_info):
 def get_root(
     flproxy,
     version: str = "",
-    remote_file_handler: Optional[Any] = None,
+    file_transfer_service: Optional[Any] = None,
     scheme_eval=None,
 ) -> Group:
     """Get the root settings object.
@@ -1856,10 +1856,10 @@ def get_root(
         cls, _ = get_cls("", obj_info, version=version)
     root = cls()
     root.set_flproxy(flproxy)
-    root.set_remote_file_handler(remote_file_handler)
+    root.set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     root._setattr("_static_info", obj_info)
-    root._setattr("_remote_file_handler", remote_file_handler)
+    root._setattr("_file_transfer_service", file_transfer_service)
     return root
 
 

--- a/src/ansys/fluent/core/utils/data_transfer.py
+++ b/src/ansys/fluent/core/utils/data_transfer.py
@@ -26,7 +26,7 @@ class MeshWriteError(RuntimeError):
 def _read_case_into(solver, file_type, file_name, full_file_name_container=None):
     network_logger.info(f"Trying to read case: {file_name}")
     try:
-        solver._remote_file_handler.upload(file_name=file_name)
+        solver._file_transfer_service.upload(file_name=file_name)
     except AttributeError:
         pass
     if full_file_name_container:
@@ -152,7 +152,9 @@ def transfer_case(
             else:
                 writer()
             try:
-                source_instance._remote_file_handler.download(file_name=full_file_name)
+                source_instance._file_transfer_service.download(
+                    file_name=full_file_name
+                )
             except AttributeError:
                 pass
             network_logger.info(f"Saved mesh from meshing session: {full_file_name}")

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -141,7 +141,7 @@ def test_file_purpose_on_remote_instance(
 
     solver_session = Solver(
         fluent_connection=solver.fluent_connection,
-        remote_file_handler=file_service,
+        file_transfer_service=file_service,
     )
 
     solver_session.file.read_case(file_name=import_file_name)
@@ -156,7 +156,7 @@ def test_file_purpose_on_remote_instance(
 
     meshing_session = PureMeshing(
         fluent_connection=meshing.fluent_connection,
-        remote_file_handler=file_service,
+        file_transfer_service=file_service,
     )
 
     meshing_session.meshing.File.ReadMesh(FileName=import_file_name)


### PR DESCRIPTION
Renamed `remote_file_handler` to `file_transfer_service`.