### PR TITLE
fix: Fix a settingsgen issue

### DIFF
--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -363,7 +363,8 @@ def _populate_classes(parent_dir):
                     stubf.write(f"{istr1}child_names = ...\n")
 
                 for child in child_names:
-                    child_class_strings.append(f"{child}={child}_cls")
+                    child_cls = cls._child_classes[child]
+                    child_class_strings.append(f"{child}={child_cls.__name__}_cls")
                     if stubf:
                         stubf.write(f"{istr1}{child} = ...\n")
 
@@ -380,7 +381,8 @@ def _populate_classes(parent_dir):
 
                 commands_info = _get_commands_info(commands_hash)
                 for command in command_names:
-                    child_class_strings.append(f"{command}={command}_cls")
+                    command_cls = cls._child_classes[command]
+                    child_class_strings.append(f"{command}={command_cls.__name__}_cls")
                     # function annotation for commands
                     if stubf:
                         command_info = commands_info[command]
@@ -402,7 +404,8 @@ def _populate_classes(parent_dir):
 
                 queries_info = _get_commands_info(queries_hash)
                 for query in query_names:
-                    child_class_strings.append(f"{query}={query}_cls")
+                    query_cls = cls._child_classes[query]
+                    child_class_strings.append(f"{query}={query_cls.__name__}_cls")
                     # function annotation for queries
                     if stubf:
                         query_info = queries_info[query]


### PR DESCRIPTION
Fixes an issue from the following code with the latest Fluent. The code is used in PyConsole implementation.
```
>>> import ansys.fluent.core.solver.settings_242
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\__init__.py", line 9, in <module>
    from .root import root
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\root.py", line 20, in <module>
    from .setup import setup as setup_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\setup.py", line 18, in <module>
    from .models_1 import models as models_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\models_1.py", line 28, in <module>
    from .battery import battery as battery_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\battery.py", line 30, in <module>
    from .tool_kits import tool_kits as tool_kits_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\tool_kits.py", line 19, in <module>
    from .rom_tool_kit import rom_tool_kit as rom_tool_kit_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\rom_tool_kit.py", line 17, in <module>
    from .rom_data_creator_tool import rom_data_creator_tool as rom_data_creator_tool_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\rom_data_creator_tool.py", line 18, in <module>
    from .transient_setup import transient_setup as transient_setup_cls
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\transient_setup.py", line 26, in <module>
    class transient_setup(Group):
  File "D:\ANSYSDev\PyFluentDev\pyfluent\src\ansys\fluent\core\solver\settings_242\transient_setup.py", line 46, in transient_setup
    file_name=file_name_cls,
NameError: name 'file_name_cls' is not defined. Did you mean: 'file_name_1_cls'?
```