### PR TITLE
feat: Launcher argument for Fluent exposure and graphics driver

### DIFF
--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -186,7 +186,7 @@ processors and activate the Fluent user interface:
 
 .. code:: python
 
-   session=pyfluent.launch_fluent(precision="double", processor_count=2, exposure="gui")
+   session=pyfluent.launch_fluent(precision="double", processor_count=2, ui="gui")
 
 
 For additional launch examples, see :ref:`ref_user_guide_launch`. For

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -186,7 +186,7 @@ processors and activate the Fluent user interface:
 
 .. code:: python
 
-   session=pyfluent.launch_fluent(precision="double", processor_count=2, show_gui=True)
+   session=pyfluent.launch_fluent(precision="double", processor_count=2, exposure="gui")
 
 
 For additional launch examples, see :ref:`ref_user_guide_launch`. For

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -51,7 +51,7 @@ method:
 
 To locate the latest Fluent installation, PyFluent automatically uses the ``AWP_ROOT<ver>``
 environment variable, where ``<ver>`` is the three-digit format for the release.
-For example, ``AWP_ROOT232`` is the environment variable for the 2023 R2 release. 
+For example, ``AWP_ROOT232`` is the environment variable for the 2023 R2 release.
 
 On a Windows system, this environment variable is configured when a release is installed.
 
@@ -73,12 +73,12 @@ setting, and iterates the solver:
   solver.tui.solve.initialize.initialize_flow()
   solver.tui.solve.dual_time_iterate(2, 3)
 
-If you want to interact with the Fluent GUI (graphical user interface), pass ``show_gui=True``
+If you want to interact with the Fluent GUI (graphical user interface), pass ``exposure="gui"``
 to the :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>` method:
 
 .. code:: python
 
-  session = pyfluent.launch_fluent(precision="double", processor_count=2, show_gui=True, mode="solver")
+  session = pyfluent.launch_fluent(precision="double", processor_count=2, exposure="gui", mode="solver")
 
 If you want to look at PyFluent's debug logging, use the following command:
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -73,12 +73,12 @@ setting, and iterates the solver:
   solver.tui.solve.initialize.initialize_flow()
   solver.tui.solve.dual_time_iterate(2, 3)
 
-If you want to interact with the Fluent GUI (graphical user interface), pass ``exposure="gui"``
+If you want to interact with the Fluent GUI (graphical user interface), pass ``ui="gui"``
 to the :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>` method:
 
 .. code:: python
 
-  session = pyfluent.launch_fluent(precision="double", processor_count=2, exposure="gui", mode="solver")
+  session = pyfluent.launch_fluent(precision="double", processor_count=2, ui="gui", mode="solver")
 
 If you want to look at PyFluent's debug logging, use the following command:
 

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -22,8 +22,9 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
 )
 from ansys.fluent.core.launcher.launcher_utils import (  # noqa: F401
     FluentExposure,
-    FluentGraphicsDriver,
+    FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentWindowsGraphicsDriver,
 )
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -21,9 +21,9 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
     launch_fluent,
 )
 from ansys.fluent.core.launcher.launcher_utils import (  # noqa: F401
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
 )
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -20,13 +20,18 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
     connect_to_fluent,
     launch_fluent,
 )
-from ansys.fluent.core.launcher.launcher_utils import FluentMode  # noqa: F401
+from ansys.fluent.core.launcher.launcher_utils import (  # noqa: F401
+    FluentExposure,
+    FluentGraphicsDriver,
+    FluentMode,
+)
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils import fldoc
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.search import search  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
+from ansys.fluent.core.warnings import PyFluentDeprecationWarning  # noqa: F401
 
 _VERSION_INFO = None
 """Global variable indicating the version of the PyFluent package - Empty by default"""

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -64,7 +64,7 @@ class DockerLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         ui : FluentUI
-            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
+            Fluent user interface mode. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -10,6 +10,8 @@ from ansys.fluent.core.launcher.fluent_container import (
     start_fluent_container,
 )
 from ansys.fluent.core.launcher.launcher_utils import (
+    FluentExposure,
+    FluentGraphicsDriver,
     FluentMode,
     _build_fluent_launch_args_string,
     _process_invalid_args,
@@ -28,6 +30,8 @@ class DockerLauncher:
     def __init__(
         self,
         mode: FluentMode,
+        exposure: FluentExposure,
+        graphics_driver: FluentGraphicsDriver,
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -41,7 +45,6 @@ class DockerLauncher:
         dry_run: bool = False,
         cleanup_on_exit: bool = True,
         start_transcript: bool = True,
-        show_gui: Optional[bool] = None,
         case_file_name: Optional[str] = None,
         case_data_file_name: Optional[str] = None,
         lightweight_mode: Optional[bool] = None,
@@ -107,11 +110,6 @@ class DockerLauncher:
             default is ``True``. You can stop and start the streaming of the
             Fluent transcript subsequently via the method calls, ``transcript.start()``
             and ``transcript.stop()`` on the session object.
-        show_gui : bool, optional
-            Whether to display the Fluent GUI. The default is ``None``, which does not
-            cause the GUI to be shown. If a value of ``False`` is
-            not explicitly provided, the GUI will also be shown if
-            the environment variable ``PYFLUENT_SHOW_SERVER_GUI`` is set to 1.
         case_file_name : str, optional
             If provided, the case file at ``case_file_name`` is read into the Fluent session.
         case_data_file_name : str, optional

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -64,15 +64,14 @@ class DockerLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         exposure : FluentExposure
-            Sets the exposure of Fluent. The possible values are the values of the
-            ``FluentExposure`` enum.
+            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
-            Sets the graphics driver of Fluent. The possible values are the values of
-            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
-            the ``FluentLinuxGraphicsDriver`` enum in Linux.
+            Graphics driver of Fluent. Options are the values of the
+            ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
+            ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Select an installed version of ANSYS. The string must be in a format like
-            ``"23.2.0"`` (for 2023 R2) matching the documented version format in the
+            Installed version of Ansys. The string must be in a format like
+            ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.
         version : str, optional

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -10,9 +10,9 @@ from ansys.fluent.core.launcher.fluent_container import (
     start_fluent_container,
 )
 from ansys.fluent.core.launcher.launcher_utils import (
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
     _build_fluent_launch_args_string,
     _process_invalid_args,
@@ -31,7 +31,7 @@ class DockerLauncher:
     def __init__(
         self,
         mode: FluentMode,
-        exposure: FluentExposure,
+        ui: FluentUI,
         graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
@@ -63,8 +63,8 @@ class DockerLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
-        exposure : FluentExposure
-            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
+        ui : FluentUI
+            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -70,7 +70,7 @@ class DockerLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Installed version of Ansys. The string must be in a format like
+            Version of Ansys Fluent to launch. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -11,8 +11,9 @@ from ansys.fluent.core.launcher.fluent_container import (
 )
 from ansys.fluent.core.launcher.launcher_utils import (
     FluentExposure,
-    FluentGraphicsDriver,
+    FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentWindowsGraphicsDriver,
     _build_fluent_launch_args_string,
     _process_invalid_args,
 )
@@ -31,7 +32,7 @@ class DockerLauncher:
         self,
         mode: FluentMode,
         exposure: FluentExposure,
-        graphics_driver: FluentGraphicsDriver,
+        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -62,6 +63,13 @@ class DockerLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
+        exposure : FluentExposure
+            Sets the exposure of Fluent. The possible values are the values of the
+            ``FluentExposure`` enum.
+        graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
+            Sets the graphics driver of Fluent. The possible values are the values of
+            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
+            the ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
             Select an installed version of ANSYS. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2) matching the documented version format in the

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -22,6 +22,7 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _get_mode,
     _get_running_session_mode,
     _get_server_info,
+    _is_windows,
     _process_invalid_args,
     _process_kwargs,
 )
@@ -94,7 +95,7 @@ def launch_fluent(
     dry_run: bool = False,
     cleanup_on_exit: bool = True,
     start_transcript: bool = True,
-    exposure: Union[FluentExposure, str] = FluentExposure.HIDDEN_GUI,
+    exposure: Union[FluentExposure, str, None] = None,
     graphics_driver: Union[FluentGraphicsDriver, str] = FluentGraphicsDriver.AUTO,
     show_gui: Optional[bool] = None,
     case_file_name: Optional[str] = None,
@@ -247,6 +248,10 @@ def launch_fluent(
     if show_gui or os.getenv("PYFLUENT_SHOW_SERVER_GUI") == 1:
         exposure = FluentExposure.GUI
     del show_gui
+    if exposure is None:
+        # Not using NO_GUI in windows as it opens a new cmd or
+        # shows Fluent output in the current cmd if start is not used
+        exposure = FluentExposure.HIDDEN_GUI if _is_windows() else FluentExposure.NO_GUI
     if isinstance(exposure, str):
         exposure = FluentExposure(exposure)
     if isinstance(graphics_driver, str):

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -173,7 +173,8 @@ def launch_fluent(
         ``FluentExposure`` enum or any of ``"no_gui_or_graphics"``, ``"no_gui"``,
         ``"hidden_gui"``, ``"no_graphics"`` or ``"gui"``. The default is
         ``FluentExposure.HIDDEN_GUI`` in Windows and ``FluentExposure.NO_GUI`` in
-        Linux.
+        Linux. ``"no_gui_or_graphics"`` and ``"no_gui"`` exposure are supported in
+        Windows only for Fluent version 2024 R1 or later.
     graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver or str, optional
         Sets the graphics driver of Fluent. In Windows, the possible values are either
         the values of the ``FluentWindowsGraphicsDriver`` enum or any of ``"null"``,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -258,7 +258,7 @@ def launch_fluent(
         raise GPUSolverSupportError()
     _process_kwargs(kwargs)
     del kwargs
-    if show_gui:
+    if show_gui is not None:
         warnings.warn(
             "show_gui is deprecated, use exposure instead", PyFluentDeprecationWarning
         )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -120,8 +120,8 @@ def launch_fluent(
     Parameters
     ----------
     product_version : str, optional
-        Select an installed version of ANSYS. The string must be in a format like
-        ``"23.2.0"`` (for 2023 R2) matching the documented version format in the
+        Installed version of ANSYS. The string must be in a format like
+        ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
         FluentVersion class. The default is ``None``, in which case the newest installed
         version is used.
     version : str, optional
@@ -169,20 +169,20 @@ def launch_fluent(
         Fluent transcript subsequently via the method calls, ``transcript.start()``
         and ``transcript.stop()`` on the session object.
     exposure : FluentExposure or str, optional
-        Sets the exposure of Fluent. The possible values are either the values of the
-        ``FluentExposure`` enum or any of ``"no_gui_or_graphics"``, ``"no_gui"``,
-        ``"hidden_gui"``, ``"no_graphics"`` or ``"gui"``. The default is
-        ``FluentExposure.HIDDEN_GUI`` in Windows and ``FluentExposure.NO_GUI`` in
-        Linux. ``"no_gui_or_graphics"`` and ``"no_gui"`` exposure are supported in
-        Windows only for Fluent version 2024 R1 or later.
+        Exposure of Fluent. Options are either the values of the ``FluentExposure`` enum
+        or any of ``"no_gui_or_graphics"``, ``"no_gui"``, ``"hidden_gui"``,
+        ``"no_graphics"`` or ``"gui"``. The default is ``FluentExposure.HIDDEN_GUI`` in
+        Windows and ``FluentExposure.NO_GUI`` in Linux. ``"no_gui_or_graphics"`` and
+        ``"no_gui"`` exposure are supported in Windows only for Fluent version 2024 R1
+        or later.
     graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver or str, optional
-        Sets the graphics driver of Fluent. In Windows, the possible values are either
-        the values of the ``FluentWindowsGraphicsDriver`` enum or any of ``"null"``,
-        ``"msw"``, ``"dx11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. In Linux, the
-        possible values are either the values of the ``FluentLinuxGraphicsDriver`` enum
-        or any of ``"null"``, ``"x11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. The
-        default is ``FluentWindowsGraphicsDriver.AUTO`` in Windows and
-        ``FluentLinuxGraphicsDriver.AUTO`` in Linux.
+        Graphics driver of Fluent. In Windows, options are either the values of the
+        ``FluentWindowsGraphicsDriver`` enum or any of ``"null"``, ``"msw"``,
+        ``"dx11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. In Linux, options are
+        either the values of the ``FluentLinuxGraphicsDriver`` enum or any of
+       ``"null"``, ``"x11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. The default is
+       ``FluentWindowsGraphicsDriver.AUTO`` in Windows and
+       ``FluentLinuxGraphicsDriver.AUTO`` in Linux.
     show_gui : bool, optional
         Whether to display the Fluent GUI. The default is ``None``, which does not
         cause the GUI to be shown. If a value of ``False`` is
@@ -261,7 +261,8 @@ def launch_fluent(
     del kwargs
     if show_gui is not None:
         warnings.warn(
-            "show_gui is deprecated, use exposure instead", PyFluentDeprecationWarning
+            "'show_gui' is deprecated, use 'exposure' instead",
+            PyFluentDeprecationWarning,
         )
     if show_gui or os.getenv("PYFLUENT_SHOW_SERVER_GUI") == 1:
         exposure = FluentExposure.GUI

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -172,7 +172,7 @@ def launch_fluent(
         Sets the exposure of Fluent. The possible values are either the values of the
         ``FluentExposure`` enum or any of ``"no_gui_or_graphics"``, ``"no_gui"``,
         ``"hidden_gui"``, ``"no_graphics"`` or ``"gui"``. The default is
-        ``FluentExposure.HIDDEN_GUI`` in Windows or ``FluentExposure.NO_GUI`` in
+        ``FluentExposure.HIDDEN_GUI`` in Windows and ``FluentExposure.NO_GUI`` in
         Linux.
     graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver or str, optional
         Sets the graphics driver of Fluent. In Windows, the possible values are either
@@ -180,7 +180,7 @@ def launch_fluent(
         ``"msw"``, ``"dx11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. In Linux, the
         possible values are either the values of the ``FluentLinuxGraphicsDriver`` enum
         or any of ``"null"``, ``"x11"``, ``"opengl2"``, ``"opengl"`` or ``"auto"``. The
-        default is ``FluentWindowsGraphicsDriver.AUTO`` in Windows or
+        default is ``FluentWindowsGraphicsDriver.AUTO`` in Windows and
         ``FluentLinuxGraphicsDriver.AUTO`` in Linux.
     show_gui : bool, optional
         Whether to display the Fluent GUI. The default is ``None``, which does not
@@ -267,7 +267,7 @@ def launch_fluent(
     del show_gui
     if exposure is None:
         # Not using NO_GUI in windows as it opens a new cmd or
-        # shows Fluent output in the current cmd if start is not used
+        # shows Fluent output in the current cmd if start <launch_string> is not used
         exposure = FluentExposure.HIDDEN_GUI if _is_windows() else FluentExposure.NO_GUI
     if isinstance(exposure, str):
         exposure = FluentExposure(exposure)

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -169,12 +169,12 @@ def launch_fluent(
         Fluent transcript subsequently via the method calls, ``transcript.start()``
         and ``transcript.stop()`` on the session object.
     ui : FluentUI or str, optional
-        UI option of Fluent. Options are either the values of the ``FluentUI`` enum
-        or any of ``"no_gui_or_graphics"``, ``"no_gui"``, ``"hidden_gui"``,
+        Fluent user interface mode. Options are either the values of the ``FluentUI``
+        enum or any of ``"no_gui_or_graphics"``, ``"no_gui"``, ``"hidden_gui"``,
         ``"no_graphics"`` or ``"gui"``. The default is ``FluentUI.HIDDEN_GUI`` in
         Windows and ``FluentUI.NO_GUI`` in Linux. ``"no_gui_or_graphics"`` and
-        ``"no_gui"`` ui options are supported in Windows only for Fluent version 2024 R1
-        or later.
+        ``"no_gui"`` user interface modes are supported in Windows starting from Fluent
+        version 2024 R1.
     graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver or str, optional
         Graphics driver of Fluent. In Windows, options are either the values of the
         ``FluentWindowsGraphicsDriver`` enum or any of ``"null"``, ``"msw"``,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -13,9 +13,9 @@ from ansys.fluent.core.exceptions import DisallowedValuesError
 from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.launcher.container_launcher import DockerLauncher
 from ansys.fluent.core.launcher.launcher_utils import (
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
     GPUSolverSupportError,
     _confirm_watchdog_start,
@@ -96,7 +96,7 @@ def launch_fluent(
     dry_run: bool = False,
     cleanup_on_exit: bool = True,
     start_transcript: bool = True,
-    exposure: Union[FluentExposure, str, None] = None,
+    ui: Union[FluentUI, str, None] = None,
     graphics_driver: Union[
         FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
     ] = None,
@@ -168,12 +168,12 @@ def launch_fluent(
         default is ``True``. You can stop and start the streaming of the
         Fluent transcript subsequently via the method calls, ``transcript.start()``
         and ``transcript.stop()`` on the session object.
-    exposure : FluentExposure or str, optional
-        Exposure of Fluent. Options are either the values of the ``FluentExposure`` enum
+    ui : FluentUI or str, optional
+        UI option of Fluent. Options are either the values of the ``FluentUI`` enum
         or any of ``"no_gui_or_graphics"``, ``"no_gui"``, ``"hidden_gui"``,
-        ``"no_graphics"`` or ``"gui"``. The default is ``FluentExposure.HIDDEN_GUI`` in
-        Windows and ``FluentExposure.NO_GUI`` in Linux. ``"no_gui_or_graphics"`` and
-        ``"no_gui"`` exposure are supported in Windows only for Fluent version 2024 R1
+        ``"no_graphics"`` or ``"gui"``. The default is ``FluentUI.HIDDEN_GUI`` in
+        Windows and ``FluentUI.NO_GUI`` in Linux. ``"no_gui_or_graphics"`` and
+        ``"no_gui"`` ui options are supported in Windows only for Fluent version 2024 R1
         or later.
     graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver or str, optional
         Graphics driver of Fluent. In Windows, options are either the values of the
@@ -261,18 +261,18 @@ def launch_fluent(
     del kwargs
     if show_gui is not None:
         warnings.warn(
-            "'show_gui' is deprecated, use 'exposure' instead",
+            "'show_gui' is deprecated, use 'ui' instead",
             PyFluentDeprecationWarning,
         )
     if show_gui or os.getenv("PYFLUENT_SHOW_SERVER_GUI") == 1:
-        exposure = FluentExposure.GUI
+        ui = FluentUI.GUI
     del show_gui
-    if exposure is None:
+    if ui is None:
         # Not using NO_GUI in windows as it opens a new cmd or
         # shows Fluent output in the current cmd if start <launch_string> is not used
-        exposure = FluentExposure.HIDDEN_GUI if _is_windows() else FluentExposure.NO_GUI
-    if isinstance(exposure, str):
-        exposure = FluentExposure(exposure)
+        ui = FluentUI.HIDDEN_GUI if _is_windows() else FluentUI.NO_GUI
+    if isinstance(ui, str):
+        ui = FluentUI(ui)
     if graphics_driver is None:
         graphics_driver = "auto"
     graphics_driver = str(graphics_driver)

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -120,7 +120,7 @@ def launch_fluent(
     Parameters
     ----------
     product_version : str, optional
-        Installed version of ANSYS. The string must be in a format like
+        Version of Ansys Fluent to launch. The string must be in a format like
         ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
         FluentVersion class. The default is ``None``, in which case the newest installed
         version is used.

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -390,7 +390,7 @@ def _get_mode(mode: Optional[Union[FluentMode, str, None]] = None):
 def _raise_non_gui_exception_in_windows(
     ui: FluentUI, product_version: FluentVersion
 ) -> None:
-    """Exposure lower than ``FluentUI.HIDDEN_GUI`` is not supported in Windows in
+    """UI option lower than ``FluentUI.HIDDEN_GUI`` is not supported in Windows in
     Fluent versions lower than 2024 R1."""
     if (
         _is_windows()

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -1,6 +1,7 @@
 """Provides a module for launching utilities."""
 
 from enum import Enum
+from functools import total_ordering
 import json
 import logging
 import os
@@ -179,6 +180,7 @@ class FluentMode(Enum):
         return mode in [FluentMode.MESHING_MODE, FluentMode.PURE_MESHING_MODE]
 
 
+@total_ordering
 class FluentEnum(Enum):
     @classmethod
     def _missing_(cls, value: str):
@@ -188,12 +190,25 @@ class FluentEnum(Enum):
                 return member
         return None
 
+    def __lt__(self, other):
+        if not isinstance(other, type(self)):
+            raise RuntimeError(
+                f"Cannot compare between {type(self).__name__} and {type(other).__name__}"
+            )
+        if self == other:
+            return False
+        for member in type(self):
+            if self == member:
+                return True
+            if other == member:
+                return False
+
 
 class FluentExposure(FluentEnum):
     NO_GUI_OR_GRAPHICS = "g"
-    NO_GRAPHICS = "gr"
     NO_GUI = "gu"
     HIDDEN_GUI = "hidden"
+    NO_GRAPHICS = "gr"
     GUI = ""
 
 

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -192,8 +192,8 @@ class FluentEnum(Enum):
             if str(member) == value:
                 return member
         raise ValueError(
-            f"The specified value '{value}' is not supported."
-            f""" Supported values are: '{", '".join(str(member) for member in cls)}'."""
+            f"The specified value '{value}' is a supported value of {cls.__name__}."
+            f""" The supported values are: '{", '".join(str(member) for member in cls)}'."""
         )
 
     def __str__(self):
@@ -216,10 +216,10 @@ class FluentEnum(Enum):
 class FluentExposure(FluentEnum):
     """Supported UI or graphics exposure of Fluent."""
 
-    NO_GUI_OR_GRAPHICS = ("-g",)
-    NO_GRAPHICS = ("-gr",)
-    NO_GUI = ("-gu",)
-    HIDDEN_GUI = ("-hidden",)
+    NO_GUI_OR_GRAPHICS = ("g",)
+    NO_GRAPHICS = ("gr",)
+    NO_GUI = ("gu",)
+    HIDDEN_GUI = ("hidden",)
     GUI = ("",)
 
 

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -95,16 +95,18 @@ def check_docker_support():
 def _get_standalone_launch_fluent_version(
     product_version: Union[FluentVersion, str, None]
 ) -> Optional[FluentVersion]:
-    """Determine the Fluent version during launch_fluent in standalone mode. The version
-    is searched in the following order.
+    """Determine the Fluent version during the execution of the ``launch_fluent()``
+    method in standalone mode.
 
-    1. ``product_version`` parameter passed with ``launch_fluent``.
-    2. The latest ANSYS version from ``AWP_ROOTnnn``` environment variables.
+    The search for the version is performed in this order.
+
+    1. The ``product_version`` parameter passed with the ``launch_fluent()`` method.
+    2. The latest Ansys version from ``AWP_ROOTnnn``` environment variables.
 
     Returns
     -------
     FluentVersion, optional
-        Fluent version or None
+        Fluent version or ``None``
     """
 
     # (DEV) if "PYFLUENT_FLUENT_ROOT" environment variable is defined, we cannot
@@ -122,7 +124,9 @@ def _get_standalone_launch_fluent_version(
 
 
 def get_fluent_exe_path(**launch_argvals) -> Path:
-    """Get Fluent executable path. The path is searched in the following order.
+    """Get the path for the Fluent executable file.
+
+    The search for the path is performed in this order:
 
     1. ``product_version`` parameter passed with ``launch_fluent``.
     2. The latest ANSYS version from ``AWP_ROOTnnn``` environment variables.
@@ -211,7 +215,7 @@ class FluentMode(Enum):
 
 @total_ordering
 class FluentEnum(Enum):
-    """Base class for Fluent-related enums.
+    """Provides the base class for Fluent-related enums.
 
     Accepts lowercase member names as values and supports comparison operators.
     """
@@ -244,7 +248,7 @@ class FluentEnum(Enum):
 
 
 class FluentExposure(FluentEnum):
-    """Supported UI or graphics exposure of Fluent."""
+    """Provides supported UI or graphics exposure of Fluent."""
 
     NO_GUI_OR_GRAPHICS = ("g",)
     NO_GRAPHICS = ("gr",)
@@ -254,7 +258,7 @@ class FluentExposure(FluentEnum):
 
 
 class FluentWindowsGraphicsDriver(FluentEnum):
-    """Supported graphics driver of Fluent in Windows."""
+    """Provides supported graphics driver of Fluent in Windows."""
 
     NULL = ("null",)
     MSW = ("msw",)
@@ -265,7 +269,7 @@ class FluentWindowsGraphicsDriver(FluentEnum):
 
 
 class FluentLinuxGraphicsDriver(FluentEnum):
-    """Supported graphics driver of Fluent in Linux."""
+    """Provides supported graphics driver of Fluent in Linux."""
 
     NULL = ("null",)
     X11 = ("x11",)
@@ -386,7 +390,8 @@ def _get_mode(mode: Optional[Union[FluentMode, str, None]] = None):
 def _raise_non_gui_exception_in_windows(
     exposure: FluentExposure, product_version: FluentVersion
 ) -> None:
-    """Exposure < hidden_gui is not supported in Windows in Fluent version < 24.1."""
+    """Exposure lower than ``FluentExposure.HIDDEN_GUI`` is not supported in Windows in
+    Fluent versions lower than 2024 R1."""
     if (
         _is_windows()
         and exposure < FluentExposure.HIDDEN_GUI

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -248,7 +248,7 @@ class FluentEnum(Enum):
 
 
 class FluentUI(FluentEnum):
-    """Provides supported UI options of Fluent."""
+    """Provides supported user interface mode of Fluent."""
 
     NO_GUI_OR_GRAPHICS = ("g",)
     NO_GRAPHICS = ("gr",)
@@ -390,8 +390,8 @@ def _get_mode(mode: Optional[Union[FluentMode, str, None]] = None):
 def _raise_non_gui_exception_in_windows(
     ui: FluentUI, product_version: FluentVersion
 ) -> None:
-    """UI option lower than ``FluentUI.HIDDEN_GUI`` is not supported in Windows in
-    Fluent versions lower than 2024 R1."""
+    """Fluent user interface mode lower than ``FluentUI.HIDDEN_GUI`` is not supported in
+    Windows in Fluent versions lower than 2024 R1."""
     if (
         _is_windows()
         and ui < FluentUI.HIDDEN_GUI

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -182,13 +182,22 @@ class FluentMode(Enum):
 
 @total_ordering
 class FluentEnum(Enum):
+    """Base class for Fluent-related enums. Accepts lowercase member names as values
+    and supports comparison operators.
+    """
+
     @classmethod
     def _missing_(cls, value: str):
-        value = value.upper()
         for member in cls:
-            if member.name == value:
+            if str(member) == value:
                 return member
-        return None
+        raise ValueError(
+            f"The specified value '{value}' is not supported."
+            f""" Supported values are: '{", '".join(str(member) for member in cls)}'."""
+        )
+
+    def __str__(self):
+        return self.name.lower()
 
     def __lt__(self, other):
         if not isinstance(other, type(self)):
@@ -205,20 +214,34 @@ class FluentEnum(Enum):
 
 
 class FluentExposure(FluentEnum):
-    NO_GUI_OR_GRAPHICS = "g"
-    NO_GUI = "gu"
-    HIDDEN_GUI = "hidden"
-    NO_GRAPHICS = "gr"
-    GUI = ""
+    """Supported UI or graphics exposure of Fluent."""
+
+    NO_GUI_OR_GRAPHICS = ("-g",)
+    NO_GRAPHICS = ("-gr",)
+    NO_GUI = ("-gu",)
+    HIDDEN_GUI = ("-hidden",)
+    GUI = ("",)
 
 
-class FluentGraphicsDriver(FluentEnum):
-    NULL = "null"
-    MSW = "msw"
-    DX11 = "dx11"
-    OPENGL2 = "opengl2"
-    OPENGL = "opengl"
-    AUTO = ""
+class FluentWindowsGraphicsDriver(FluentEnum):
+    """Supported graphics driver of Fluent in Windows."""
+
+    NULL = ("null",)
+    MSW = ("msw",)
+    DX11 = ("dx11",)
+    OPENGL2 = ("opengl2",)
+    OPENGL = ("opengl",)
+    AUTO = ("",)
+
+
+class FluentLinuxGraphicsDriver(FluentEnum):
+    """Supported graphics driver of Fluent in Linux."""
+
+    NULL = ("null",)
+    X11 = ("x11",)
+    OPENGL2 = ("opengl2",)
+    OPENGL = ("opengl",)
+    AUTO = ("",)
 
 
 def _get_server_info_file_name(use_tmpdir=True):
@@ -311,11 +334,11 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
     elif isinstance(gpu, list):
         launch_args_string += f" -gpu={','.join(map(str, gpu))}"
     exposure = kwargs.get("exposure")
-    if exposure and exposure.value:
-        launch_args_string += f" -{exposure.value}"
+    if exposure and exposure.value[0]:
+        launch_args_string += f" -{exposure.value[0]}"
     graphics_driver = kwargs.get("graphics_driver")
-    if graphics_driver and graphics_driver.value:
-        launch_args_string += f" -driver={graphics_driver.value}"
+    if graphics_driver and graphics_driver.value[0]:
+        launch_args_string += f" -driver={graphics_driver.value[0]}"
     return launch_args_string
 
 

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -182,8 +182,9 @@ class FluentMode(Enum):
 
 @total_ordering
 class FluentEnum(Enum):
-    """Base class for Fluent-related enums. Accepts lowercase member names as values
-    and supports comparison operators.
+    """Base class for Fluent-related enums.
+
+    Accepts lowercase member names as values and supports comparison operators.
     """
 
     @classmethod

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -201,7 +201,7 @@ class FluentEnum(Enum):
 
     def __lt__(self, other):
         if not isinstance(other, type(self)):
-            raise RuntimeError(
+            raise TypeError(
                 f"Cannot compare between {type(self).__name__} and {type(other).__name__}"
             )
         if self == other:
@@ -321,8 +321,8 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
                     json_key = json.dumps(argval)
                 argval = fluent_map[json_key]
             launch_args_string += v["fluent_format"].replace("{}", str(argval))
-    addArgs = kwargs["additional_arguments"]
-    if "-t" not in addArgs and "-cnf=" not in addArgs:
+    addArgs = kwargs.get("additional_arguments")
+    if addArgs and "-t" not in addArgs and "-cnf=" not in addArgs:
         parallel_options = build_parallel_options(
             load_machines(ncores=kwargs["processor_count"])
         )
@@ -338,7 +338,7 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
         launch_args_string += f" -{exposure.value[0]}"
     graphics_driver = kwargs.get("graphics_driver")
     if graphics_driver and graphics_driver.value[0]:
-        launch_args_string += f" -driver={graphics_driver.value[0]}"
+        launch_args_string += f" -driver {graphics_driver.value[0]}"
     return launch_args_string
 
 

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -247,8 +247,8 @@ class FluentEnum(Enum):
                 return False
 
 
-class FluentExposure(FluentEnum):
-    """Provides supported UI or graphics exposure of Fluent."""
+class FluentUI(FluentEnum):
+    """Provides supported UI options of Fluent."""
 
     NO_GUI_OR_GRAPHICS = ("g",)
     NO_GRAPHICS = ("gr",)
@@ -367,9 +367,9 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
         launch_args_string += " -gpu"
     elif isinstance(gpu, list):
         launch_args_string += f" -gpu={','.join(map(str, gpu))}"
-    exposure = kwargs.get("exposure")
-    if exposure and exposure.value[0]:
-        launch_args_string += f" -{exposure.value[0]}"
+    ui = kwargs.get("ui")
+    if ui and ui.value[0]:
+        launch_args_string += f" -{ui.value[0]}"
     graphics_driver = kwargs.get("graphics_driver")
     if graphics_driver and graphics_driver.value[0]:
         launch_args_string += f" -driver {graphics_driver.value[0]}"
@@ -388,17 +388,17 @@ def _get_mode(mode: Optional[Union[FluentMode, str, None]] = None):
 
 
 def _raise_non_gui_exception_in_windows(
-    exposure: FluentExposure, product_version: FluentVersion
+    ui: FluentUI, product_version: FluentVersion
 ) -> None:
-    """Exposure lower than ``FluentExposure.HIDDEN_GUI`` is not supported in Windows in
+    """Exposure lower than ``FluentUI.HIDDEN_GUI`` is not supported in Windows in
     Fluent versions lower than 2024 R1."""
     if (
         _is_windows()
-        and exposure < FluentExposure.HIDDEN_GUI
+        and ui < FluentUI.HIDDEN_GUI
         and product_version < FluentVersion.v241
     ):
         raise InvalidArgument(
-            f"'{exposure}' supported in Windows only for Fluent version 24.1 or later."
+            f"'{ui}' supported in Windows only for Fluent version 24.1 or later."
         )
 
 

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -58,15 +58,14 @@ class PIMLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         exposure : FluentExposure
-            Sets the exposure of Fluent. The possible values are the values of the
-            ``FluentExposure`` enum.
+            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
-            Sets the graphics driver of Fluent. The possible values are the values of
-            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
-            the ``FluentLinuxGraphicsDriver`` enum in Linux.
+            Graphics driver of Fluent. Options are the values of the
+            ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
+            ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Select an installed version of ANSYS. The string must be in a format like
-            ``"23.2.0"`` (for 2023 R2) matching the documented version format in the
+            Installed version of Ansys. The string must be in a format like
+            ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.
         version : str, optional

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -5,9 +5,9 @@ import os
 from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
     _process_invalid_args,
     launch_remote_fluent,
@@ -25,7 +25,7 @@ class PIMLauncher:
     def __init__(
         self,
         mode: FluentMode,
-        exposure: FluentExposure,
+        ui: FluentUI,
         graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
@@ -57,8 +57,8 @@ class PIMLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
-        exposure : FluentExposure
-            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
+        ui : FluentUI
+            Exposure of Fluent. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -64,7 +64,7 @@ class PIMLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Installed version of Ansys. The string must be in a format like
+            Version of Ansys Fluent to launch. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -58,7 +58,7 @@ class PIMLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         ui : FluentUI
-            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
+            Fluent user interface mode. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -5,6 +5,8 @@ import os
 from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
+    FluentExposure,
+    FluentGraphicsDriver,
     FluentMode,
     _process_invalid_args,
     launch_remote_fluent,
@@ -22,6 +24,8 @@ class PIMLauncher:
     def __init__(
         self,
         mode: FluentMode,
+        exposure: FluentExposure,
+        graphics_driver: FluentGraphicsDriver,
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -35,7 +39,6 @@ class PIMLauncher:
         dry_run: bool = False,
         cleanup_on_exit: bool = True,
         start_transcript: bool = True,
-        show_gui: Optional[bool] = None,
         case_file_name: Optional[str] = None,
         case_data_file_name: Optional[str] = None,
         lightweight_mode: Optional[bool] = None,
@@ -101,11 +104,6 @@ class PIMLauncher:
             default is ``True``. You can stop and start the streaming of the
             Fluent transcript subsequently via the method calls, ``transcript.start()``
             and ``transcript.stop()`` on the session object.
-        show_gui : bool, optional
-            Whether to display the Fluent GUI. The default is ``None``, which does not
-            cause the GUI to be shown. If a value of ``False`` is
-            not explicitly provided, the GUI will also be shown if
-            the environment variable ``PYFLUENT_SHOW_SERVER_GUI`` is set to 1.
         case_file_name : str, optional
             If provided, the case file at ``case_file_name`` is read into the Fluent session.
         case_data_file_name : str, optional

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -58,7 +58,7 @@ class PIMLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         ui : FluentUI
-            Exposure of Fluent. Options are the values of the ``FluentUI`` enum.
+            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -6,8 +6,9 @@ from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
     FluentExposure,
-    FluentGraphicsDriver,
+    FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentWindowsGraphicsDriver,
     _process_invalid_args,
     launch_remote_fluent,
 )
@@ -25,7 +26,7 @@ class PIMLauncher:
         self,
         mode: FluentMode,
         exposure: FluentExposure,
-        graphics_driver: FluentGraphicsDriver,
+        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -56,6 +57,13 @@ class PIMLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
+        exposure : FluentExposure
+            Sets the exposure of Fluent. The possible values are the values of the
+            ``FluentExposure`` enum.
+        graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
+            Sets the graphics driver of Fluent. The possible values are the values of
+            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
+            the ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
             Select an installed version of ANSYS. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2) matching the documented version format in the

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -214,7 +214,6 @@ class SlurmLauncher:
         launch_cmd = _generate_launch_string(
             self._argvals,
             self.mode,
-            self._show_gui,
             self._additional_arguments,
             self._server_info_file_name,
         )

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -68,15 +68,14 @@ class StandaloneLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         exposure : FluentExposure
-            Sets the exposure of Fluent. The possible values are the values of the
-            ``FluentExposure`` enum.
+            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
-            Sets the graphics driver of Fluent. The possible values are the values of
-            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
-            the ``FluentLinuxGraphicsDriver`` enum in Linux.
+            Graphics driver of Fluent. Options are the values of the
+            ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
+            ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Select an installed version of ANSYS. The string must be in a format like
-            ``"23.2.0"`` (for 2023 R2) matching the documented version format in the
+            Installed version of Ansys. The string must be in a format like
+            ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.
         version : str, optional

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -7,6 +7,8 @@ import subprocess
 from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
+    FluentExposure,
+    FluentGraphicsDriver,
     FluentMode,
     LaunchFluentError,
     _await_fluent_launch,
@@ -18,7 +20,6 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _get_subprocess_kwargs_for_fluent,
     _is_windows,
     _process_invalid_args,
-    _raise_exception_g_gu_in_windows_os,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
 
@@ -33,6 +34,8 @@ class StandaloneLauncher:
     def __init__(
         self,
         mode: FluentMode,
+        exposure: FluentExposure,
+        graphics_driver: FluentGraphicsDriver,
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -46,7 +49,6 @@ class StandaloneLauncher:
         dry_run: bool = False,
         cleanup_on_exit: bool = True,
         start_transcript: bool = True,
-        show_gui: Optional[bool] = None,
         case_file_name: Optional[str] = None,
         case_data_file_name: Optional[str] = None,
         lightweight_mode: Optional[bool] = None,
@@ -112,11 +114,6 @@ class StandaloneLauncher:
             default is ``True``. You can stop and start the streaming of the
             Fluent transcript subsequently via the method calls, ``transcript.start()``
             and ``transcript.stop()`` on the session object.
-        show_gui : bool, optional
-            Whether to display the Fluent GUI. The default is ``None``, which does not
-            cause the GUI to be shown. If a value of ``False`` is
-            not explicitly provided, the GUI will also be shown if
-            the environment variable ``PYFLUENT_SHOW_SERVER_GUI`` is set to 1.
         case_file_name : str, optional
             If provided, the case file at ``case_file_name`` is read into the Fluent session.
         case_data_file_name : str, optional
@@ -184,9 +181,6 @@ class StandaloneLauncher:
             self.argvals.pop("lightweight_mode")
             setattr(self, "lightweight_mode", False)
 
-        if self.additional_arguments:
-            _raise_exception_g_gu_in_windows_os(self.additional_arguments)
-
         if os.getenv("PYFLUENT_FLUENT_DEBUG") == "1":
             self.argvals["fluent_debug"] = True
 
@@ -194,7 +188,6 @@ class StandaloneLauncher:
         launch_string = _generate_launch_string(
             self.argvals,
             self.mode,
-            self.show_gui,
             self.additional_arguments,
             server_info_file_name,
         )

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -74,7 +74,7 @@ class StandaloneLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
-            Installed version of Ansys. The string must be in a format like
+            Version of Ansys Fluent to launch. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2), matching the documented version format in the
             FluentVersion class. The default is ``None``, in which case the newest installed
             version is used.

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -68,7 +68,7 @@ class StandaloneLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         ui : FluentUI
-            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
+            Fluent user interface mode. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -8,8 +8,9 @@ from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
     FluentExposure,
-    FluentGraphicsDriver,
+    FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentWindowsGraphicsDriver,
     LaunchFluentError,
     _await_fluent_launch,
     _build_journal_argument,
@@ -35,7 +36,7 @@ class StandaloneLauncher:
         self,
         mode: FluentMode,
         exposure: FluentExposure,
-        graphics_driver: FluentGraphicsDriver,
+        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -66,6 +67,13 @@ class StandaloneLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
+        exposure : FluentExposure
+            Sets the exposure of Fluent. The possible values are the values of the
+            ``FluentExposure`` enum.
+        graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
+            Sets the graphics driver of Fluent. The possible values are the values of
+            the ``FluentWindowsGraphicsDriver`` enum in Windows or the values of
+            the ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : str, optional
             Select an installed version of ANSYS. The string must be in a format like
             ``"23.2.0"`` (for 2023 R2) matching the documented version format in the

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -68,7 +68,7 @@ class StandaloneLauncher:
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
         ui : FluentUI
-            Exposure of Fluent. Options are the values of the ``FluentUI`` enum.
+            UI option of Fluent. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -18,14 +18,14 @@ from ansys.fluent.core.launcher.launcher_utils import (
     _generate_launch_string,
     _get_server_info,
     _get_server_info_file_name,
+    _get_standalone_launch_fluent_version,
     _get_subprocess_kwargs_for_fluent,
     _is_windows,
     _process_invalid_args,
+    _raise_non_gui_exception_in_windows,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
 
-_THIS_DIR = os.path.dirname(__file__)
-_OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
 logger = logging.getLogger("pyfluent.launcher")
 
 
@@ -188,6 +188,9 @@ class StandaloneLauncher:
             # note argvals is no longer locals() here due to _get_session_info() pass
             self.argvals.pop("lightweight_mode")
             setattr(self, "lightweight_mode", False)
+        fluent_version = _get_standalone_launch_fluent_version(self.product_version)
+        if fluent_version:
+            _raise_non_gui_exception_in_windows(self.exposure, fluent_version)
 
         if os.getenv("PYFLUENT_FLUENT_DEBUG") == "1":
             self.argvals["fluent_debug"] = True

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -7,9 +7,9 @@ import subprocess
 from typing import Any, Dict, Optional, Union
 
 from ansys.fluent.core.launcher.launcher_utils import (
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
     LaunchFluentError,
     _await_fluent_launch,
@@ -35,7 +35,7 @@ class StandaloneLauncher:
     def __init__(
         self,
         mode: FluentMode,
-        exposure: FluentExposure,
+        ui: FluentUI,
         graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
         product_version: Optional[str] = None,
         version: Optional[str] = None,
@@ -67,8 +67,8 @@ class StandaloneLauncher:
         ----------
         mode : FluentMode
             Launch mode of Fluent to point to a specific session type.
-        exposure : FluentExposure
-            Exposure of Fluent. Options are the values of the ``FluentExposure`` enum.
+        ui : FluentUI
+            Exposure of Fluent. Options are the values of the ``FluentUI`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
@@ -189,7 +189,7 @@ class StandaloneLauncher:
             setattr(self, "lightweight_mode", False)
         fluent_version = _get_standalone_launch_fluent_version(self.product_version)
         if fluent_version:
-            _raise_non_gui_exception_in_windows(self.exposure, fluent_version)
+            _raise_non_gui_exception_in_windows(self.ui, fluent_version)
 
         if os.getenv("PYFLUENT_FLUENT_DEBUG") == "1":
             self.argvals["fluent_debug"] = True
@@ -214,7 +214,7 @@ class StandaloneLauncher:
             # Using 'start.exe' is better, otherwise Fluent is more susceptible to bad termination attempts
             launch_cmd = 'start "" ' + launch_string
         else:
-            if self.exposure < FluentExposure.HIDDEN_GUI:
+            if self.ui < FluentUI.HIDDEN_GUI:
                 # Using nohup to hide Fluent output from the current terminal
                 launch_cmd = "nohup " + launch_string + " &"
             else:

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -204,7 +204,11 @@ class StandaloneLauncher:
             # Using 'start.exe' is better, otherwise Fluent is more susceptible to bad termination attempts
             launch_cmd = 'start "" ' + launch_string
         else:
-            launch_cmd = launch_string
+            if self.exposure < FluentExposure.HIDDEN_GUI:
+                # Using nohup to hide Fluent output from the current terminal
+                launch_cmd = "nohup " + launch_string + " &"
+            else:
+                launch_cmd = launch_string
 
         try:
             logger.debug(f"Launching Fluent with command: {launch_cmd}")

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -478,7 +478,7 @@ class Textual(Property):
     """Exposes attribute accessor on settings object - specific to string objects."""
 
 
-class DeprecatedSettingWarning(DeprecationWarning):
+class DeprecatedSettingWarning(FutureWarning):
     pass
 
 
@@ -493,7 +493,6 @@ def _show_warning(message, category, *args, **kwargs):
 
 
 warnings.showwarning = _show_warning
-warnings.simplefilter("default", category=DeprecatedSettingWarning)
 
 
 class _Alias:

--- a/src/ansys/fluent/core/warnings.py
+++ b/src/ansys/fluent/core/warnings.py
@@ -1,2 +1,4 @@
 class PyFluentDeprecationWarning(FutureWarning):
+    """Common warning class for all deprecated PyFluent feature."""
+
     pass

--- a/src/ansys/fluent/core/warnings.py
+++ b/src/ansys/fluent/core/warnings.py
@@ -1,4 +1,4 @@
 class PyFluentDeprecationWarning(FutureWarning):
-    """Common warning class for all deprecated PyFluent feature."""
+    """Provides the common warning class for all deprecated PyFluent feature."""
 
     pass

--- a/src/ansys/fluent/core/warnings.py
+++ b/src/ansys/fluent/core/warnings.py
@@ -1,0 +1,2 @@
+class PyFluentDeprecationWarning(FutureWarning):
+    pass

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1002,7 +1002,9 @@ def _check_vector_units(obj, units):
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
-    assert isinstance(solver._root.state_with_units(), dict)
+
+    # disabling due to ansys/pyfluent#2529
+    # assert isinstance(solver._root.state_with_units(), dict)
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1002,9 +1002,7 @@ def _check_vector_units(obj, units):
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
-
-    # disabling due to ansys/pyfluent#2529
-    # assert isinstance(solver._root.state_with_units(), dict)
+    assert isinstance(solver._root.state_with_units(), dict)
     hot_inlet = solver.setup.boundary_conditions.velocity_inlet["hot-inlet"]
     turbulence = hot_inlet.turbulence
     turbulence.turbulent_specification = "Intensity and Hydraulic Diameter"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -11,9 +11,9 @@ from ansys.fluent.core.launcher import launcher_utils
 from ansys.fluent.core.launcher.launcher import create_launcher
 from ansys.fluent.core.launcher.launcher_utils import (
     DockerContainerLaunchNotSupported,
-    FluentExposure,
     FluentLinuxGraphicsDriver,
     FluentMode,
+    FluentUI,
     FluentWindowsGraphicsDriver,
     GPUSolverSupportError,
     LaunchFluentError,
@@ -70,28 +70,22 @@ def test_non_gui_in_windows_throws_exception():
     launcher_utils._is_windows = lambda: True
     try:
         with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(FluentUI.NO_GUI, FluentVersion.v232)
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(FluentUI.NO_GUI, FluentVersion.v231)
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(FluentUI.NO_GUI, FluentVersion.v222)
+        with pytest.raises(InvalidArgument):
             _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI, FluentVersion.v232
+                FluentUI.NO_GUI_OR_GRAPHICS, FluentVersion.v232
             )
         with pytest.raises(InvalidArgument):
             _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI, FluentVersion.v231
+                FluentUI.NO_GUI_OR_GRAPHICS, FluentVersion.v231
             )
         with pytest.raises(InvalidArgument):
             _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI, FluentVersion.v222
-            )
-        with pytest.raises(InvalidArgument):
-            _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v232
-            )
-        with pytest.raises(InvalidArgument):
-            _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v231
-            )
-        with pytest.raises(InvalidArgument):
-            _raise_non_gui_exception_in_windows(
-                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v222
+                FluentUI.NO_GUI_OR_GRAPHICS, FluentVersion.v222
             )
     finally:
         launcher_utils._is_windows = lambda: default_windows_flag
@@ -102,13 +96,13 @@ def test_non_gui_in_windows_does_not_throw_exception():
     default_windows_flag = launcher_utils._is_windows()
     launcher_utils._is_windows = lambda: True
     try:
-        _raise_non_gui_exception_in_windows(FluentExposure.NO_GUI, FluentVersion.v241)
+        _raise_non_gui_exception_in_windows(FluentUI.NO_GUI, FluentVersion.v241)
         _raise_non_gui_exception_in_windows(
-            FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v241
+            FluentUI.NO_GUI_OR_GRAPHICS, FluentVersion.v241
         )
-        _raise_non_gui_exception_in_windows(FluentExposure.NO_GUI, FluentVersion.v242)
+        _raise_non_gui_exception_in_windows(FluentUI.NO_GUI, FluentVersion.v242)
         _raise_non_gui_exception_in_windows(
-            FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v242
+            FluentUI.NO_GUI_OR_GRAPHICS, FluentVersion.v242
         )
     finally:
         launcher_utils._is_windows = lambda: default_windows_flag
@@ -306,7 +300,7 @@ def test_watchdog_launch(monkeypatch):
 
 def test_fluent_launchers():
     kwargs = dict(
-        exposure=FluentExposure.NO_GUI,
+        ui=FluentUI.NO_GUI,
         graphics_driver=(
             FluentWindowsGraphicsDriver.AUTO
             if _is_windows()
@@ -381,24 +375,23 @@ def test_show_gui_raises_warning():
 
 
 def test_fluent_enums():
-    assert str(FluentExposure.GUI) == "gui"
-    assert FluentExposure("gui") == FluentExposure.GUI
+    assert str(FluentUI.GUI) == "gui"
+    assert FluentUI("gui") == FluentUI.GUI
     with pytest.raises(ValueError):
-        FluentExposure("")
-    assert FluentExposure.NO_GUI < FluentExposure.GUI
+        FluentUI("")
+    assert FluentUI.NO_GUI < FluentUI.GUI
     with pytest.raises(TypeError):
-        FluentExposure.NO_GUI < FluentWindowsGraphicsDriver.AUTO
+        FluentUI.NO_GUI < FluentWindowsGraphicsDriver.AUTO
 
 
 def test_exposure_and_graphics_driver_arguments():
     with pytest.raises(ValueError):
-        pyfluent.launch_fluent(exposure="gu")
+        pyfluent.launch_fluent(ui="gu")
     with pytest.raises(ValueError):
         pyfluent.launch_fluent(graphics_driver="x11" if _is_windows() else "dx11")
-    for m in FluentExposure:
+    for m in FluentUI:
         assert (
-            _build_fluent_launch_args_string(exposure=m).strip()
-            == f"3ddp -{m.value[0]}"
+            _build_fluent_launch_args_string(ui=m).strip() == f"3ddp -{m.value[0]}"
             if m.value[0]
             else " 3ddp"
         )

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -69,17 +69,29 @@ def test_non_gui_in_windows_throws_exception():
     default_windows_flag = launcher_utils._is_windows()
     launcher_utils._is_windows = lambda: True
     try:
-        with pytest.raises(InvalidArgument) as msg:
-            pyfluent.launch_fluent(
-                mode="solver",
-                exposure=FluentExposure.NO_GUI,
-                start_container=False,
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI, FluentVersion.v232
             )
-        with pytest.raises(InvalidArgument) as msg:
-            pyfluent.launch_fluent(
-                mode="solver",
-                exposure=FluentExposure.NO_GUI_OR_GRAPHICS,
-                start_container=False,
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI, FluentVersion.v231
+            )
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI, FluentVersion.v222
+            )
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v232
+            )
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v231
+            )
+        with pytest.raises(InvalidArgument):
+            _raise_non_gui_exception_in_windows(
+                FluentExposure.NO_GUI_OR_GRAPHICS, FluentVersion.v222
             )
     finally:
         launcher_utils._is_windows = lambda: default_windows_flag


### PR DESCRIPTION
Two new arguments `ui` and `graphics_driver` are added to `launch_fluent`. They accepts the values of `FluentUI` and `FluentWindowsGraphicsDriver | FluentLinuxGraphicsDriver` enums respectively. The default value of `ui` is `FluentUI.HIDDEN_GUI` (`-hidden`) in windows (no change) and `FluentUI.NO_GUI` (`-gu`) in linux. I haven't made the default value `FluentUI.NO_GUI` in windows as it shows Fluent output in the current cmd. The default value of `graphics_driver` is `AUTO`.

The `launch_fluent` argument `show_gui` has been made deprected.

TODO: Record `ui` and `graphics_driver` Python joural saved from Fluent.