### PR TITLE
feat: Minimize number of fluent launches during codegen

### DIFF
--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -8,6 +8,7 @@ import print_fluent_version
 import settingsgen
 import tuigen
 
+from ansys.fluent.core import FluentMode, launch_fluent
 from ansys.fluent.core.utils.fluent_version import (
     FluentVersion,
     get_version_for_file_name,
@@ -49,11 +50,18 @@ if __name__ == "__main__":
             os.environ["PYFLUENT_FLUENT_ROOT"] = str(Path(awp_root) / "fluent")
         if args.fluent_path:
             os.environ["PYFLUENT_FLUENT_ROOT"] = args.fluent_path
-    version = get_version_for_file_name()
-    print_fluent_version.generate(version, args.pyfluent_path)
-    _update_first_level(api_tree, tuigen.generate(version, args.pyfluent_path))
-    _update_first_level(api_tree, datamodelgen.generate(version, args.pyfluent_path))
-    _update_first_level(api_tree, settingsgen.generate(version, args.pyfluent_path))
+    sessions = {FluentMode.SOLVER: launch_fluent()}
+    version = get_version_for_file_name(session=sessions[FluentMode.SOLVER])
+    print_fluent_version.generate(args.pyfluent_path, sessions)
+    _update_first_level(
+        api_tree, tuigen.generate(version, args.pyfluent_path, sessions)
+    )
+    _update_first_level(
+        api_tree, datamodelgen.generate(version, args.pyfluent_path, sessions)
+    )
+    _update_first_level(
+        api_tree, settingsgen.generate(version, args.pyfluent_path, sessions)
+    )
     api_tree_file = get_api_tree_file_name(version, args.pyfluent_path)
     Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)
     with open(api_tree_file, "wb") as f:

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -184,7 +184,7 @@ class DataModelGenerator:
             for _, info in self._static_info.items():
                 if "meshing" in info.modes:
                     info.static_info = self._get_static_info(info.rules, session)
-            session.exit()  # exiting the meshing session here as it won't be required during allapigen anymore
+            self.sessions.pop(FluentMode.MESHING_MODE)
 
         if run_solver_mode:
             if FluentMode.SOLVER not in self.sessions:
@@ -219,7 +219,7 @@ class DataModelGenerator:
                         print(
                             "Information: Problem accessing flserver datamodel for icing settings\n"
                         )
-            session.exit()  # exiting the solver-icing session here as it won't be required during allapigen anymore
+            self.sessions.pop(FluentMode.SOLVER_ICING)
 
     def _write_static_info(self, name: str, info: Any, f: FileIO, level: int = 0):
         api_tree = {}

--- a/codegen/print_fluent_version.py
+++ b/codegen/print_fluent_version.py
@@ -1,35 +1,37 @@
 import os
 from pathlib import Path
 
-import ansys.fluent.core as pyfluent
+from ansys.fluent.core import FluentMode, launch_fluent
 from ansys.fluent.core.utils.fluent_version import get_version_for_file_name
 
 _THIS_DIR = os.path.dirname(__file__)
 
 
-def print_fluent_version(version, pyfluent_path):
-    session = pyfluent.launch_fluent()
+def print_fluent_version(pyfluent_path, sessions: dict):
+    if FluentMode.SOLVER not in sessions:
+        sessions[FluentMode.SOLVER] = launch_fluent()
+    session = sessions[FluentMode.SOLVER]
+    fluent_version = session.get_fluent_version()
+    version_for_filename = get_version_for_file_name(fluent_version)
     eval = session.scheme_eval.scheme_eval
     version_file = (
         (Path(pyfluent_path) if pyfluent_path else (Path(_THIS_DIR) / ".." / "src"))
         / "ansys"
         / "fluent"
         / "core"
-        / f"fluent_version_{version}.py"
+        / f"fluent_version_{version_for_filename}.py"
     ).resolve()
     with open(version_file, "w", encoding="utf8") as f:
-        f.write(f'FLUENT_VERSION = "{session.get_fluent_version()}"\n')
+        f.write(f'FLUENT_VERSION = "{fluent_version}"\n')
         f.write(f'FLUENT_BUILD_TIME = "{eval("(inquire-build-time)")}"\n')
         f.write(f'FLUENT_BUILD_ID = "{eval("(inquire-build-id)")}"\n')
         f.write(f'FLUENT_REVISION = "{eval("(inquire-src-vcs-id)")}"\n')
         f.write(f'FLUENT_BRANCH = "{eval("(inquire-src-vcs-branch)")}"\n')
-    session.exit()
 
 
-def generate(version, pyfluent_path):
-    print_fluent_version(version, pyfluent_path)
+def generate(pyfluent_path, sessions: dict):
+    print_fluent_version(pyfluent_path, sessions)
 
 
 if __name__ == "__main__":
-    version = get_version_for_file_name()
-    generate(version, None)
+    generate(None, {})

--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -499,6 +499,7 @@ def generate(version, pyfluent_path, sessions: dict):
         sessions[FluentMode.SOLVER] = launch_fluent()
     session = sessions[FluentMode.SOLVER]
     sinfo = session._settings_service.get_static_info()
+    sessions.pop(FluentMode.SOLVER)
     session.exit()  # exiting the solver session here as it won't be required during allapigen anymore
     cls, _ = flobject.get_cls("", sinfo, version=version)
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,20 @@
+import importlib
+
+import pytest
+from util.solver_workflow import new_solver_session  # noqa: F401
+
+from ansys.fluent.core.utils.fluent_version import get_version_for_file_name
+
+
+@pytest.mark.codegen_required
+def test_allapigen_files(new_solver_session):
+    version = get_version_for_file_name(session=new_solver_session)
+    importlib.import_module(f"ansys.fluent.core.fluent_version_{version}")
+    importlib.import_module(f"ansys.fluent.core.meshing.tui_{version}")
+    importlib.import_module(f"ansys.fluent.core.solver.tui_{version}")
+    importlib.import_module(f"ansys.fluent.core.datamodel_{version}.meshing")
+    importlib.import_module(f"ansys.fluent.core.datamodel_{version}.workflow")
+    importlib.import_module(f"ansys.fluent.core.datamodel_{version}.preferences")
+    importlib.import_module(f"ansys.fluent.core.datamodel_{version}.PartManagement")
+    importlib.import_module(f"ansys.fluent.core.datamodel_{version}.PMFileManagement")
+    importlib.import_module(f"ansys.fluent.core.solver.settings_{version}.root")


### PR DESCRIPTION
Reducing number of times Fluent is launched from 8 to 3 while running allapigen.py. The session instances  for each mode (solver, meshing and solver-icing) are stored in a dictionary which is reused accross all *gen.py files.