### PR TITLE
fix: Store alias objects at objects instead of classes

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -647,12 +647,10 @@ class SettingsBase(Base, Generic[StateT]):
             for k, v in value.items():
                 if hasattr(cls, "_child_aliases") and k in cls._child_aliases:
                     alias = cls._child_aliases[k]
-                    if not isinstance(alias, str):
-                        alias = alias.alias_path
                     # TODO: handle ".." in alias path
                     if ".." in alias:
                         raise NotImplementedError(
-                            'Cannot handle ".." in alias path while setting state.'
+                            'Cannot handle ".." in alias path while setting dictionary state.'
                         )
                     ret_alias = ret
                     comps = alias.split("/")

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -185,6 +185,7 @@ class Base:
         self._setattr("_file_transfer_service", None)
         if name is not None:
             self._setattr("_name", name)
+        self._setattr("_child_alias_objs", {})
 
     def set_flproxy(self, flproxy):
         """Set flproxy object."""
@@ -1017,14 +1018,13 @@ class Group(SettingsBase[DictStateType]):
                 raise InactiveObjectError(self.python_path)
         alias = super().__getattribute__("_child_aliases").get(name)
         if alias:
-            if isinstance(alias, str):
+            alias_obj = self._child_alias_objs.get(name)
+            if alias_obj is None:
                 obj = self.find_object(alias)
-                # replacing aliased paths with alias objects in _child_aliases
-                alias_obj = self._child_aliases[name] = _create_child(
+                alias_obj = self._child_alias_objs[name] = _create_child(
                     obj.__class__, None, obj.parent, alias
                 )
-                return alias_obj
-            return alias
+            return alias_obj
         try:
             return super().__getattribute__(name)
         except AttributeError as ex:
@@ -1315,14 +1315,13 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
     def __getattr__(self, name: str):
         alias = self._child_aliases.get(name)
         if alias:
-            if isinstance(alias, str):
+            alias_obj = self._child_alias_objs.get(name)
+            if alias_obj is None:
                 obj = self.find_object(alias)
-                # replacing aliased paths with alias objects in _child_aliases
-                alias_obj = self._child_aliases[name] = _create_child(
+                alias_obj = self._child_alias_objs[name] = _create_child(
                     obj.__class__, None, obj.parent, alias
                 )
-                return alias_obj
-            return alias
+            return alias_obj
         else:
             return getattr(super(), name)
 
@@ -1433,14 +1432,13 @@ class ListObject(SettingsBase[ListStateType], Generic[ChildTypeT]):
     def __getattr__(self, name: str):
         alias = self._child_aliases.get(name)
         if alias:
-            if isinstance(alias, str):
+            alias_obj = self._child_alias_objs.get(name)
+            if alias_obj is None:
                 obj = self.find_object(alias)
-                # replacing aliased paths with alias objects in _child_aliases
-                alias_obj = self._child_aliases[name] = _create_child(
+                alias_obj = self._child_alias_objs[name] = _create_child(
                     obj.__class__, None, obj.parent, alias
                 )
-                return alias_obj
-            return alias
+            return alias_obj
         else:
             return getattr(super(), name)
 
@@ -1512,14 +1510,13 @@ class Action(Base):
     def __getattr__(self, name: str):
         alias = self._child_aliases.get(name)
         if alias:
-            if isinstance(alias, str):
+            alias_obj = self._child_alias_objs.get(name)
+            if alias_obj is None:
                 obj = self.find_object(alias)
-                # replacing aliased paths with alias objects in _child_aliases
-                alias_obj = self._child_aliases[name] = _create_child(
+                alias_obj = self._child_alias_objs[name] = _create_child(
                     obj.__class__, None, obj.parent, alias
                 )
-                return alias_obj
-            return alias
+            return alias_obj
         else:
             return getattr(super(), name)
 

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -156,6 +156,26 @@ def test_deprecated_settings(new_solver_session):
     with pytest.warns(DeprecatedSettingWarning):
         solver.file.rcd(file_name=case_path)
 
+    solver.setup.boundary_conditions.velocity_inlet.child_object_type._child_aliases[
+        "mom"
+    ] = "momentum"
+    with pytest.warns(DeprecatedSettingWarning):
+        solver.setup.boundary_conditions.velocity_inlet["hot-inlet"].mom.velocity = 20
+    assert (
+        solver.setup.boundary_conditions.velocity_inlet[
+            "hot-inlet"
+        ].momentum.velocity.value()
+        == 20
+    )
+    with pytest.warns(DeprecatedSettingWarning):
+        solver.setup.boundary_conditions.velocity_inlet["cold-inlet"].mom.velocity = 2
+    assert (
+        solver.setup.boundary_conditions.velocity_inlet[
+            "cold-inlet"
+        ].momentum.velocity.value()
+        == 2
+    )
+
     solver.setup.boundary_conditions.wall["wall-inlet"].thermal.thermal_bc = (
         "Temperature"
     )
@@ -182,7 +202,7 @@ def test_deprecated_settings(new_solver_session):
         > 0
     )
     assert isinstance(
-        solver.setup.boundary_conditions.wall["wall-inlet"].thermal.t._child_aliases[
+        solver.setup.boundary_conditions.wall["wall-inlet"].thermal.t._child_alias_objs[
             "constant"
         ],
         _Alias,
@@ -216,17 +236,15 @@ def test_deprecated_settings(new_solver_session):
     with pytest.warns(DeprecatedSettingWarning):
         solver.results.gr.contour.create("c1")
 
-    # disabling due to ansys/pyfluent#2526
+    with pytest.warns(DeprecatedSettingWarning):
+        solver.results.gr.contour["c1"].field = "pressure"
 
-    # with pytest.warns(DeprecatedSettingWarning):
-    #     solver.results.gr.contour["c1"].field = "pressure"
+    assert solver.results.graphics.contour["c1"].field() == "pressure"
 
-    # assert solver.results.graphics.contour["c1"].field() == "pressure"
+    with pytest.warns(DeprecatedSettingWarning):
+        del solver.results.gr.contour["c1"]
 
-    # with pytest.warns(DeprecatedSettingWarning):
-    #     del solver.results.gr.contour["c1"]
-
-    # assert "c1" not in solver.results.graphics.contour
+    assert "c1" not in solver.results.graphics.contour
 
     solver.setup.boundary_conditions.velocity_inlet[
         "hot-inlet"
@@ -242,8 +260,7 @@ def test_deprecated_settings(new_solver_session):
         == 10
     )
 
-    # TODO: Enable after Fluent image is updated
-    # solver.setup.cell_zone_conditions.fluid["elbow-fluid"] = {"material": "air"}
+    solver.setup.cell_zone_conditions.fluid["elbow-fluid"] = {"material": "air"}
 
 
 @pytest.mark.fluent_version(">=24.2")


### PR DESCRIPTION
Storing alias objects within parent object instead of the parent class so that aliasing of named object children works correctly.