### PR TITLE
fix: Fix EventSubscription when an event cannot be subscribed.

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -342,12 +342,14 @@ class EventSubscription:
         SubscribeEventError
             If server fails to subscribe from event.
         """
+        self.is_subscribed = False
         self._service = service
         response = service.subscribe_events(request_dict)
         response = response[0]
         if response["status"] != DataModelProtoModule.STATUS_SUBSCRIBED:
             raise SubscribeEventError(request_dict)
-        self.status = response["status"]
+        else:
+            self.is_subscribed = True
         self.tag = response["tag"]
         self._service.events[self.tag] = self
 
@@ -359,13 +361,14 @@ class EventSubscription:
         UnsubscribeEventError
             If server fails to unsubscribe from event.
         """
-        if self.status == DataModelProtoModule.STATUS_SUBSCRIBED:
+        if self.is_subscribed:
             self._service.event_streaming.unregister_callback(self.tag)
             response = self._service.unsubscribe_events([self.tag])
             response = response[0]
             if response["status"] != DataModelProtoModule.STATUS_UNSUBSCRIBED:
                 raise UnsubscribeEventError(self.tag)
-            self.status = response["status"]
+            else:
+                self.is_subscribed = False
             self._service.events.pop(self.tag, None)
 
     def __del__(self) -> None:


### PR DESCRIPTION
This will fix the error seen from `EventScubscription.__del__` in recent code. I'm not able to write a unittest as pytest doesn't seem to detect the error (or the warning which is converted from the error).

Note: this error will not be present in PyConsole