### PR TITLE
fix: temporary fix for a settingsgen issue

### DIFF
--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -255,10 +255,11 @@ class SettingsService:
         if info.has_allowed_values:
             ret["has-allowed-values"] = info.has_allowed_values
         if info.children:
-            ret["children"] = {
-                child.name: self._extract_static_info(child.value)
-                for child in info.children
-            }
+            ret["children"] = {}
+            for child in info.children:
+                # TODO: resolve the case when multiple children under same parent have identical python name
+                if child.name not in ("fensapice-drop-vrh?", "fensapice-drop-vrh"):
+                    ret["children"][child.name] = self._extract_static_info(child.value)
         if info.commands:
             ret["commands"] = {
                 child.name: self._extract_static_info(child.value)

--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -255,11 +255,12 @@ class SettingsService:
         if info.has_allowed_values:
             ret["has-allowed-values"] = info.has_allowed_values
         if info.children:
-            ret["children"] = {}
-            for child in info.children:
+            ret["children"] = {
+                child.name: self._extract_static_info(child.value)
+                for child in info.children
                 # TODO: resolve the case when multiple children under same parent have identical python name
-                if child.name not in ("fensapice-drop-vrh?", "fensapice-drop-vrh"):
-                    ret["children"][child.name] = self._extract_static_info(child.value)
+                if child.name not in ("fensapice-drop-vrh?", "fensapice-drop-vrh")
+            }
         if info.commands:
             ret["commands"] = {
                 child.name: self._extract_static_info(child.value)

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -744,7 +744,7 @@ def test_accessor_methods_on_settings_object_types(load_static_mixer_settings_on
 @pytest.mark.codegen_required
 def test_find_children_from_settings_root_231(load_static_mixer_settings_only):
     setup_cls = load_static_mixer_settings_only.setup.__class__
-    assert len(find_children(setup_cls())) >= 18514
+    assert len(find_children(setup_cls())) >= 10000
     assert len(find_children(setup_cls(), "gen*")) >= 9
     assert set(find_children(setup_cls(), "general*")) >= {
         "general",
@@ -769,7 +769,7 @@ def test_find_children_from_settings_root_231(load_static_mixer_settings_only):
 @pytest.mark.codegen_required
 def test_find_children_from_settings_root_232(load_static_mixer_settings_only):
     setup_cls = load_static_mixer_settings_only.setup.__class__
-    assert len(find_children(setup_cls())) >= 18514
+    assert len(find_children(setup_cls())) >= 10000
     assert len(find_children(setup_cls(), "gen*")) >= 9
     assert set(find_children(setup_cls(), "general*")) >= {
         "general",


### PR DESCRIPTION
This is temporay fix so that exisiting PRs can go in. I'll look into the actual issue separately.

Although I'm removing the problematic parameters at the static-info level, still there is a hash-mismatch during pyfluent runtime. But the current fix will be good enough for pyconsole integration where only the generated classes are used.

Update: the hash-mismatch issue is present also in main branch - will be fixed in #2602