### PR TITLE
fix: Fix a settingsgen issue when multiple children under same parent have identical python name

### DIFF
--- a/codegen/settingsgen.py
+++ b/codegen/settingsgen.py
@@ -135,6 +135,7 @@ def _populate_hash_dict(name, info, cls, api_tree):
 
     cls_tuple = (
         name,
+        cls.__name__,
         cls.__bases__,
         info["type"],
         info.get("help"),

--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -259,8 +259,6 @@ class SettingsService:
             ret["children"] = {
                 child.name: self._extract_static_info(child.value)
                 for child in info.children
-                # TODO: resolve the case when multiple children under same parent have identical python name
-                if child.name not in ("fensapice-drop-vrh?", "fensapice-drop-vrh")
             }
         if info.commands:
             ret["commands"] = {

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1757,7 +1757,7 @@ _bases_by_class = {}
 
 
 # pylint: disable=missing-raises-doc
-def get_cls(name, info, parent=None, version=None):
+def get_cls(name, info, parent=None, version=None, parent_taboo=None):
     """Create a class for the object identified by "path"."""
     try:
         if name == "":
@@ -1817,16 +1817,19 @@ def get_cls(name, info, parent=None, version=None):
             bases += (_InOutFile,)
 
         original_pname = pname
-        if any(
-            x in bases for x in (_InputFile, _OutputFile, _InOutFile)
-        ):  # not generalizing for performance
-            i = 0
-            while pname in _bases_by_class and _bases_by_class[pname] != bases:
-                if i > 0:
-                    pname = pname[: pname.rfind("_")]
+        i = 1
+        if parent_taboo:
+            while pname in parent_taboo:
+                pname = f"{original_pname}_{i}"
                 i += 1
-                pname += f"_{str(i)}"
+        parent_attr_name = pname
+        if info.get("file_purpose"):  # not generalizing for performance
+            while pname in _bases_by_class and _bases_by_class[pname] != bases:
+                pname = f"{original_pname}_{i}"
+                i += 1
             _bases_by_class[pname] = bases
+        if parent_taboo:
+            parent_taboo.add(pname)
 
         dct["_child_classes"] = {}
         cls = type(pname, bases, dct)
@@ -1849,10 +1852,10 @@ def get_cls(name, info, parent=None, version=None):
             nonlocal cls
 
             for cname, cinfo in info_dict.items():
-                ccls, original_pname = get_cls(cname, cinfo, cls, version=version)
-                ccls_name = ccls.__name__
+                ccls, parent_attr_name = get_cls(
+                    cname, cinfo, cls, version=version, parent_taboo=taboo
+                )
 
-                i = 0
                 if write_doc:
                     nonlocal doc
                     th = ccls._state_type
@@ -1860,16 +1863,9 @@ def get_cls(name, info, parent=None, version=None):
                     doc += f"    {ccls.__name__} : {th}\n"
                     doc += f"        {ccls.__doc__}\n"
 
-                while ccls_name in taboo:
-                    if i > 0:
-                        ccls_name = ccls_name[: ccls_name.rfind("_")]
-                    i += 1
-                    ccls_name += f"_{str(i)}"
-
-                ccls.__name__ = ccls_name
-                names.append(ccls.__name__ if i > 0 else original_pname)
-                taboo.add(ccls_name)
-                cls._child_classes[ccls.__name__ if i > 0 else original_pname] = ccls
+                names.append(parent_attr_name)
+                taboo.add(ccls.__name__)
+                cls._child_classes[parent_attr_name] = ccls
 
         children = info.get("children")
         if children:
@@ -1925,7 +1921,7 @@ def get_cls(name, info, parent=None, version=None):
             f"'{parent.fluent_name if parent else None}'"
         )
         raise
-    return cls, original_pname
+    return cls, parent_attr_name
 
 
 def _gethash(obj_info):

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -6,6 +6,9 @@ from ansys.fluent.core.solver.flobject import (
     DeprecatedSettingWarning,
     UnstableSettingWarning,
     _Alias,
+    _InputFile,
+    _OutputFile,
+    to_python_name,
 )
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
@@ -295,3 +298,33 @@ def test_unstable_settings_warning(new_solver_session, recwarn):
     solver.file.export
     assert len(recwarn) == 1
     assert recwarn.pop().category == UnstableSettingWarning
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_generated_code_special_cases(new_solver_session):
+    solver = new_solver_session
+    icing_cls = solver.setup.boundary_conditions._child_classes[
+        "velocity_inlet"
+    ].child_object_type._child_classes["icing"]
+    fensapice_drop_vrh_cls = icing_cls._child_classes["fensapice_drop_vrh"]
+    fensapice_drop_vrh_1_cls = icing_cls._child_classes["fensapice_drop_vrh_1"]
+    assert fensapice_drop_vrh_cls.fluent_name != fensapice_drop_vrh_1_cls.fluent_name
+    assert to_python_name(fensapice_drop_vrh_cls.fluent_name) == to_python_name(
+        fensapice_drop_vrh_1_cls.fluent_name
+    )
+    assert fensapice_drop_vrh_cls.__name__ != fensapice_drop_vrh_1_cls.__name__
+
+    assert (
+        solver.file.read_case.file_name.fluent_name
+        == solver.file.write_case.file_name.fluent_name
+    )
+    assert (
+        solver.file.read_case.file_name.__class__.__name__
+        != solver.file.write_case.file_name.__class__.__name__
+    )
+    read_file_bases = solver.file.read_case.file_name.__class__.__bases__
+    assert _InputFile in read_file_bases
+    assert _OutputFile not in read_file_bases
+    write_file_bases = solver.file.write_case.file_name.__class__.__bases__
+    assert _InputFile not in write_file_bases
+    assert _OutputFile in write_file_bases


### PR DESCRIPTION
The `icing` setting has children `fensapice-drop-vrh?` and `fensapice-drop-vrh` which yield same python name. This PR fixes an issue in the generated settigs code and reverts the temporary fix #2601 