### PR TITLE
Fix/typing stub

### DIFF
--- a/src/ansys/fluent/core/session_meshing.pyi
+++ b/src/ansys/fluent/core/session_meshing.pyi
@@ -3,12 +3,10 @@ from ansys.fluent.core.datamodel_241.PMFileManagement import (
 )
 from ansys.fluent.core.datamodel_241.PartManagement import Root as partmanagement_root
 from ansys.fluent.core.datamodel_241.meshing import Root as meshing_root
-from ansys.fluent.core.datamodel_241.meshing_utilities import (
-    Root as meshing_utilities_root,
-)
 from ansys.fluent.core.datamodel_241.preferences import Root as preferences_root
 from ansys.fluent.core.datamodel_241.workflow import Root as workflow_root
-from ansys.fluent.core.solver.tui_241 import main_menu
+from ansys.fluent.core.meshing.tui_241 import main_menu
+from ansys.fluent.core.services.meshing_queries import MeshingQueries
 
 class Meshing:
     @property
@@ -16,7 +14,7 @@ class Meshing:
     @property
     def meshing(self) -> meshing_root: ...
     @property
-    def meshing_utilities(self) -> meshing_utilities_root: ...
+    def meshing_queries(self) -> MeshingQueries: ...
     @property
     def workflow(self) -> workflow_root: ...
     @property

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -81,7 +81,7 @@ class PureMeshing(BaseSession):
         return self._base_meshing.meshing
 
     @property
-    def meshing_queries(self):
+    def meshing_queries(self) -> MeshingQueries:
         """Datamodel root of meshing_queries."""
         if self.get_fluent_version() >= FluentVersion.v232:
             return MeshingQueries(self.meshing_queries_service)

--- a/src/ansys/fluent/core/session_pure_meshing.pyi
+++ b/src/ansys/fluent/core/session_pure_meshing.pyi
@@ -3,12 +3,10 @@ from ansys.fluent.core.datamodel_241.PMFileManagement import (
 )
 from ansys.fluent.core.datamodel_241.PartManagement import Root as partmanagement_root
 from ansys.fluent.core.datamodel_241.meshing import Root as meshing_root
-from ansys.fluent.core.datamodel_241.meshing_utilities import (
-    Root as meshing_utilities_root,
-)
 from ansys.fluent.core.datamodel_241.preferences import Root as preferences_root
 from ansys.fluent.core.datamodel_241.workflow import Root as workflow_root
-from ansys.fluent.core.solver.tui_241 import main_menu
+from ansys.fluent.core.meshing.tui_241 import main_menu
+from ansys.fluent.core.services.meshing_queries import MeshingQueries
 
 class PureMeshing:
     @property
@@ -16,7 +14,7 @@ class PureMeshing:
     @property
     def meshing(self) -> meshing_root: ...
     @property
-    def meshing_utilities(self) -> meshing_utilities_root: ...
+    def meshing_utilities(self) -> MeshingQueries: ...
     @property
     def workflow(self) -> workflow_root: ...
     def watertight(self): ...

--- a/src/ansys/fluent/core/session_solver.pyi
+++ b/src/ansys/fluent/core/session_solver.pyi
@@ -1,5 +1,4 @@
 from ansys.fluent.core.datamodel_241.preferences import Root as preferences_root
-from ansys.fluent.core.datamodel_241.solverworkflow import Root as solverworkflow_root
 from ansys.fluent.core.datamodel_241.workflow import Root as workflow_root
 from ansys.fluent.core.solver.settings_241.current_parametric_study import (
     current_parametric_study,
@@ -7,8 +6,8 @@ from ansys.fluent.core.solver.settings_241.current_parametric_study import (
 from ansys.fluent.core.solver.settings_241.file import file
 from ansys.fluent.core.solver.settings_241.mesh import mesh
 from ansys.fluent.core.solver.settings_241.parallel import parallel
+from ansys.fluent.core.solver.settings_241.parameters import parameters
 from ansys.fluent.core.solver.settings_241.parametric_studies import parametric_studies
-from ansys.fluent.core.solver.settings_241.report import report
 from ansys.fluent.core.solver.settings_241.results import results
 from ansys.fluent.core.solver.settings_241.server import server
 from ansys.fluent.core.solver.settings_241.setup import setup
@@ -43,8 +42,6 @@ class Solver:
     def solution(self) -> solution: ...
     @property
     def results(self) -> results: ...
-    @property
-    def design(self) -> design: ...
     @property
     def parametric_studies(self) -> parametric_studies: ...
     @property


### PR DESCRIPTION
The stub is currently missing some common public methods, We shall update those while updating the stub files for 24.2. Also, we need to find a way to compare the static and runtime hints (mypy's [stubtest](https://mypy.readthedocs.io/en/latest/stubtest.htmlhttps://mypy.readthedocs.io/en/latest/stubtest.html) seems to be for that purpose).