### PR TITLE
build: Bump version 0.21.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-fluent-core"
-version = "0.20.dev12"
+version = "0.21.dev0"
 description = "PyFluent provides Pythonic access to Ansys Fluent"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 20, "dev12"
+version_info = 0, 21, "dev0"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -201,3 +201,34 @@ def test_parametric_workflow():
     solver_session.file.parametric_project.archive(archive_name=write_archive_name)
     assert archive_name.exists()
     solver_session.exit()
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_parameters_list_function(load_static_mixer_settings_only):
+    solver = load_static_mixer_settings_only
+    solver.tui.define.parameters.enable_in_TUI("yes")
+
+    velocity_inlet = solver.tui.define.boundary_conditions.set.velocity_inlet
+    velocity_inlet("inlet1", (), "vmag", "yes", "inlet1_vel", 1, "quit")
+    velocity_inlet("inlet1", (), "temperature", "yes", "inlet1_temp", 300, "quit")
+    velocity_inlet("inlet2", (), "vmag", "yes", "no", "inlet2_vel", 1, "quit")
+    velocity_inlet("inlet2", (), "temperature", "yes", "no", "inlet2_temp", 350, "quit")
+
+    solver.solution.report_definitions.surface["outlet-temp-avg"] = {}
+    outlet_temp_avg = solver.solution.report_definitions.surface["outlet-temp-avg"]
+    outlet_temp_avg.report_type = "surface-areaavg"
+    outlet_temp_avg.field = "temperature"
+    outlet_temp_avg.surface_names = ["outlet"]
+
+    solver.solution.report_definitions.surface["outlet-vel-avg"] = {}
+    outlet_vel_avg = solver.solution.report_definitions.surface["outlet-vel-avg"]
+    outlet_vel_avg.report_type = "surface-areaavg"
+    outlet_vel_avg.field = "velocity-magnitude"
+    outlet_vel_avg.surface_names = ["outlet"]
+
+    create_output_param = solver.tui.define.parameters.output_parameters.create
+    create_output_param("report-definition", "outlet-temp-avg")
+    create_output_param("report-definition", "outlet-vel-avg")
+
+    assert len(solver.parameters.input_parameters.list()) == 4
+    assert len(solver.parameters.output_parameters.list()) == 2

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -5,7 +5,6 @@ import pytest
 
 from ansys.fluent.core import examples
 from ansys.fluent.core.meshing.watertight import watertight_workflow
-from ansys.fluent.core.utils.fluent_version import FluentVersion
 from tests.test_datamodel_service import disable_datamodel_cache  # noqa: F401
 
 
@@ -522,7 +521,6 @@ def test_snake_case_attrs_in_new_meshing_workflow(new_mesh_session):
     watertight.import_geometry()
 
 
-@pytest.mark.skip
 @pytest.mark.codegen_required
 @pytest.mark.fluent_version(">=24.1")
 def test_workflow_and_data_model_methods_new_meshing_workflow(new_mesh_session):
@@ -551,11 +549,8 @@ def test_workflow_and_data_model_methods_new_meshing_workflow(new_mesh_session):
         "import_body_of_influence_geometry",
         "set_up_periodic_boundaries",
         "create_local_refinement_regions",
-        "load_cad_geometry",
         "run_custom_journal",
     ]
-    if meshing.get_fluent_version() < FluentVersion.v242:
-        _next_possible_tasks.remove("load_cad_geometry")
     assert (
         watertight.task("import_geom_wtm").get_next_possible_tasks()
         == _next_possible_tasks

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -522,6 +522,7 @@ def test_snake_case_attrs_in_new_meshing_workflow(new_mesh_session):
     watertight.import_geometry()
 
 
+@pytest.mark.skip
 @pytest.mark.codegen_required
 @pytest.mark.fluent_version(">=24.1")
 def test_workflow_and_data_model_methods_new_meshing_workflow(new_mesh_session):

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -154,6 +154,7 @@ def test_api_upgrade(new_solver_session, capsys):
     "<solver_session>.file.read_case" in capsys.readouterr().out
 
 
+@pytest.mark.skip
 @pytest.mark.fluent_version(">=24.2")
 def test_deprecated_settings(new_solver_session):
     solver = new_solver_session


### PR DESCRIPTION
I have also pushed a tag as we need a build for optislang with the `session.parameters.output_parameters.list()` Fluent fix.