### PR TITLE
fix: Add default for argument_names in commands.

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1486,6 +1486,7 @@ class Action(Base):
 
     _child_classes = {}
     _child_aliases = {}
+    argument_names = []
 
     def __init__(self, name: Optional[str] = None, parent=None):
         """__init__ of Action class."""

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1166,5 +1166,5 @@ def test_default_argument_names_for_commands(load_static_mixer_settings_only):
 
     assert solver.results.graphics.contour.rename.argument_names == ["new", "old"]
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
-    # The below is the default behaviour when no arguments are associated with the command.
+    # The following is the default behavior when no arguments are associated with the command.
     assert solver.results.graphics.contour.list.argument_names == []

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1146,3 +1146,25 @@ def test_static_info_hash_identity(new_solver_session):
     hash1 = _gethash(solver._settings_service.get_static_info())
     hash2 = _gethash(solver._settings_service.get_static_info())
     assert hash1 == hash2
+
+
+@pytest.mark.fluent_version(">=24.2")
+def test_default_argument_names_for_commands(load_static_mixer_settings_only):
+    solver = load_static_mixer_settings_only
+
+    assert solver.results.graphics.contour.command_names == [
+        "delete",
+        "rename",
+        "list",
+        "list_properties",
+        "make_a_copy",
+        "display",
+        "copy",
+        "add_to_graphics",
+        "clear_history",
+    ]
+
+    assert solver.results.graphics.contour.rename.argument_names == ["new", "old"]
+    assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
+    # The below is the default behaviour when no arguments are associated with the command.
+    assert solver.results.graphics.contour.list.argument_names == []


### PR DESCRIPTION
For commands with no arguments, argument_names attribute returns an empty list instead of throwing an attribute error.