### PR TITLE
refactor: Pass scheme eval as argument to session.

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -222,14 +222,17 @@ class DockerLauncher:
 
         port, password = start_fluent_container(args, self.container_dict)
 
+        fluent_connection = FluentConnection(
+            port=port,
+            password=password,
+            cleanup_on_exit=self.cleanup_on_exit,
+            slurm_job_id=self.argvals and self.argvals.get("slurm_job_id"),
+            inside_container=True,
+        )
+
         session = self.new_session(
-            fluent_connection=FluentConnection(
-                port=port,
-                password=password,
-                cleanup_on_exit=self.cleanup_on_exit,
-                slurm_job_id=self.argvals and self.argvals.get("slurm_job_id"),
-                inside_container=True,
-            ),
+            fluent_connection=fluent_connection,
+            scheme_eval=fluent_connection._connection_interface.scheme_eval,
             file_transfer_service=self.file_transfer_service,
             start_transcript=self.start_transcript,
         )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -373,5 +373,6 @@ def connect_to_fluent(
 
     return new_session(
         fluent_connection=fluent_connection,
+        scheme_eval=fluent_connection._connection_interface.scheme_eval,
         start_transcript=start_transcript,
     )

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -303,6 +303,7 @@ def launch_remote_fluent(
 
     return session_cls(
         fluent_connection=fluent_connection,
+        scheme_eval=fluent_connection._connection_interface.scheme_eval,
         file_transfer_service=file_transfer_service,
         start_transcript=start_transcript,
     )

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -76,8 +76,7 @@ class BaseSession:
     Attributes
     ----------
     scheme_eval: SchemeEval
-        Instance of SchemeEval on which Fluent's scheme code can be
-        executed.
+        Instance of ``SchemeEval`` to execute Fluent's scheme code on.
 
     Methods
     -------
@@ -105,8 +104,7 @@ class BaseSession:
         fluent_connection (:ref:`ref_fluent_connection`):
             Encapsulates a Fluent connection.
         scheme_eval: SchemeEval
-            Instance of SchemeEval on which Fluent's scheme code can be
-            executed.
+            Instance of ``SchemeEval`` to execute Fluent's scheme code on.
         file_transfer_service : Optional
             Supports file upload and download.
         start_transcript : bool, optional

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -106,7 +106,7 @@ class BaseSession:
         scheme_eval: SchemeEval
             Instance of ``SchemeEval`` to execute Fluent's scheme code on.
         file_transfer_service : Optional
-            Supports file upload and download.
+            Service for uploading and downloading files.
         start_transcript : bool, optional
             Whether to start the Fluent transcript in the client.
             The default is ``True``, in which case the Fluent

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -10,6 +10,7 @@ from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.journaling import Journal
 from ansys.fluent.core.services import service_creator
 from ansys.fluent.core.services.field_data import FieldDataService
+from ansys.fluent.core.services.scheme_eval import SchemeEval
 from ansys.fluent.core.session_shared import (  # noqa: F401
     _CODEGEN_MSG_DATAMODEL,
     _CODEGEN_MSG_TUI,
@@ -80,7 +81,7 @@ class BaseSession:
 
     Methods
     -------
-    create_from_server_info_file(
+    _create_from_server_info_file(
         server_info_file_name, cleanup_on_exit, start_transcript
         )
         Create a Session instance from server-info file
@@ -92,6 +93,7 @@ class BaseSession:
     def __init__(
         self,
         fluent_connection: FluentConnection,
+        scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
@@ -102,6 +104,9 @@ class BaseSession:
         ----------
         fluent_connection (:ref:`ref_fluent_connection`):
             Encapsulates a Fluent connection.
+        scheme_eval: SchemeEval
+            Instance of SchemeEval on which Fluent's scheme code can be
+            executed.
         file_transfer_service : Optional
             Supports file upload and download.
         start_transcript : bool, optional
@@ -113,19 +118,23 @@ class BaseSession:
         self._start_transcript = start_transcript
         self._launcher_args = launcher_args
         BaseSession._build_from_fluent_connection(
-            self, fluent_connection, file_transfer_service
+            self,
+            fluent_connection,
+            scheme_eval,
+            file_transfer_service,
         )
 
     def _build_from_fluent_connection(
         self,
         fluent_connection: FluentConnection,
+        scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
     ):
         """Build a BaseSession object from fluent_connection object."""
         self._fluent_connection = fluent_connection
         self._file_transfer_service = file_transfer_service
         self._error_state = fluent_connection._error_state
-        self.scheme_eval = fluent_connection._connection_interface.scheme_eval
+        self.scheme_eval = scheme_eval
         self.rp_vars = RPVars(self.scheme_eval.string_eval)
         self._preferences = None
         self.journal = Journal(self.scheme_eval)
@@ -295,10 +304,12 @@ class BaseSession:
             Session instance
         """
         ip, port, password = _parse_server_info_file(server_info_file_name)
+        fluent_connection = FluentConnection(
+            ip=ip, port=port, password=password, **connection_kwargs
+        )
         session = cls(
-            fluent_connection=FluentConnection(
-                ip=ip, port=port, password=password, **connection_kwargs
-            ),
+            fluent_connection=fluent_connection,
+            scheme_eval=fluent_connection._connection_interface.scheme_eval,
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 
 from ansys.fluent.core.fluent_connection import FluentConnection
+from ansys.fluent.core.services import SchemeEval
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 
@@ -20,6 +21,7 @@ class Meshing(PureMeshing):
     def __init__(
         self,
         fluent_connection: FluentConnection,
+        scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
@@ -28,10 +30,17 @@ class Meshing(PureMeshing):
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
+            scheme_eval: SchemeEval
+                Instance of SchemeEval on which Fluent's scheme code can be executed.
             file_transfer_service: Supports file upload and download.
+            start_transcript : bool, optional
+                Whether to start the Fluent transcript in the client.
+                The default is ``True``, in which case the Fluent transcript can be subsequently
+                started and stopped using method calls on the ``Session`` object.
         """
         super(Meshing, self).__init__(
             fluent_connection=fluent_connection,
+            scheme_eval=scheme_eval,
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,
@@ -43,6 +52,7 @@ class Meshing(PureMeshing):
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(
             fluent_connection=self._fluent_connection,
+            scheme_eval=self.scheme_eval,
             file_transfer_service=self._file_transfer_service,
         )
         delattr(self, "switch_to_solver")

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -32,7 +32,8 @@ class Meshing(PureMeshing):
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
                 Instance of ``SchemeEval`` to execute Fluent's scheme code on.
-            file_transfer_service: Supports file upload and download.
+            file_transfer_service: Optional
+                Service for uploading and downloading files.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.
                 The default is ``True``, in which case the Fluent transcript can be subsequently

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -31,7 +31,7 @@ class Meshing(PureMeshing):
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
-                Instance of SchemeEval on which Fluent's scheme code can be executed.
+                Instance of ``SchemeEval`` to execute Fluent's scheme code on.
             file_transfer_service: Supports file upload and download.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -41,7 +41,7 @@ class PureMeshing(BaseSession):
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
-                Instance of SchemeEval on which Fluent's scheme code can be executed.
+                Instance of ``SchemeEval`` to execute Fluent's scheme code on.
             file_transfer_service: Supports file upload and download.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.data_model_cache import DataModelCache, NameKey
 from ansys.fluent.core.fluent_connection import FluentConnection
+from ansys.fluent.core.services import SchemeEval
 from ansys.fluent.core.services.meshing_queries import (
     MeshingQueries,
     MeshingQueriesService,
@@ -30,6 +31,7 @@ class PureMeshing(BaseSession):
     def __init__(
         self,
         fluent_connection: FluentConnection,
+        scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
@@ -38,10 +40,17 @@ class PureMeshing(BaseSession):
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
+            scheme_eval: SchemeEval
+                Instance of SchemeEval on which Fluent's scheme code can be executed.
             file_transfer_service: Supports file upload and download.
+            start_transcript : bool, optional
+                Whether to start the Fluent transcript in the client.
+                The default is ``True``, in which case the Fluent transcript can be subsequently
+                started and stopped using method calls on the ``Session`` object.
         """
         super(PureMeshing, self).__init__(
             fluent_connection=fluent_connection,
+            scheme_eval=scheme_eval,
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -87,7 +87,7 @@ class Solver(BaseSession):
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
-                Instance of SchemeEval on which Fluent's scheme code can be executed.
+                Instance of ``SchemeEval`` to execute Fluent's scheme code on.
             file_transfer_service: Supports file upload and download.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -7,6 +7,7 @@ import importlib
 from typing import Any, Dict, Optional
 
 from ansys.fluent.core.fluent_connection import FluentConnection
+from ansys.fluent.core.services import SchemeEval
 from ansys.fluent.core.session_solver import Solver
 
 
@@ -20,6 +21,7 @@ class SolverIcing(Solver):
     def __init__(
         self,
         fluent_connection: FluentConnection,
+        scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
@@ -28,10 +30,17 @@ class SolverIcing(Solver):
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
+            scheme_eval: SchemeEval
+                Instance of SchemeEval on which Fluent's scheme code can be executed.
             file_transfer_service: Supports file upload and download.
+            start_transcript : bool, optional
+                Whether to start the Fluent transcript in the client.
+                The default is ``True``, in which case the Fluent transcript can be subsequently
+                started and stopped using method calls on the ``Session`` object.
         """
         super(SolverIcing, self).__init__(
             fluent_connection=fluent_connection,
+            scheme_eval=scheme_eval,
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -31,7 +31,7 @@ class SolverIcing(Solver):
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
-                Instance of SchemeEval on which Fluent's scheme code can be executed.
+                Instance of ``SchemeEval`` to execute Fluent's scheme code on.
             file_transfer_service: Supports file upload and download.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.

--- a/src/ansys/fluent/core/session_solver_lite.py
+++ b/src/ansys/fluent/core/session_solver_lite.py
@@ -25,7 +25,7 @@ class SolverLite(Solver):
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
             scheme_eval: SchemeEval
-                Instance of SchemeEval on which Fluent's scheme code can be executed.
+                Instance of ``SchemeEval`` to execute Fluent's scheme code on.
             start_transcript : bool, optional
                 Whether to start the Fluent transcript in the client.
                 The default is ``True``, in which case the Fluent transcript can be subsequently

--- a/src/ansys/fluent/core/session_solver_lite.py
+++ b/src/ansys/fluent/core/session_solver_lite.py
@@ -16,6 +16,7 @@ class SolverLite(Solver):
     def __init__(
         self,
         fluent_connection=None,
+        scheme_eval=None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
     ):
@@ -23,9 +24,16 @@ class SolverLite(Solver):
 
         Args:
             fluent_connection (:ref:`ref_fluent_connection`): Encapsulates a Fluent connection.
+            scheme_eval: SchemeEval
+                Instance of SchemeEval on which Fluent's scheme code can be executed.
+            start_transcript : bool, optional
+                Whether to start the Fluent transcript in the client.
+                The default is ``True``, in which case the Fluent transcript can be subsequently
+                started and stopped using method calls on the ``Session`` object.
         """
         super().__init__(
             fluent_connection=fluent_connection,
+            scheme_eval=scheme_eval,
             start_transcript=start_transcript,
             launcher_args=launcher_args,
         )
@@ -38,5 +46,7 @@ class SolverLite(Solver):
 
     def switch_to_full_solver(self):
         """A switch to move to the full-solver session from solver-lite."""
-        solver_session = Solver(fluent_connection=self._fluent_connection)
+        solver_session = Solver(
+            fluent_connection=self._fluent_connection, scheme_eval=self.scheme_eval
+        )
         return solver_session

--- a/src/ansys/fluent/core/utils/setup_for_fluent.py
+++ b/src/ansys/fluent/core/utils/setup_for_fluent.py
@@ -12,7 +12,10 @@ def setup_for_fluent(*args, **kwargs):
         globals["meshing"] = session
         globals["PartManagement"] = session.PartManagement
         globals["PMFileManagement"] = session.PMFileManagement
-        globals["solver"] = Solver(fluent_connection=session._fluent_connection)
+        globals["solver"] = Solver(
+            fluent_connection=session._fluent_connection,
+            scheme_eval=session._fluent_connection._connection_interface.scheme_eval,
+        )
     else:
         globals["solver"] = session
 

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -145,6 +145,7 @@ def test_file_purpose_on_remote_instance(
 
     solver_session = Solver(
         fluent_connection=solver._fluent_connection,
+        scheme_eval=solver._fluent_connection._connection_interface.scheme_eval,
         file_transfer_service=file_service,
     )
 
@@ -160,6 +161,7 @@ def test_file_purpose_on_remote_instance(
 
     meshing_session = PureMeshing(
         fluent_connection=meshing._fluent_connection,
+        scheme_eval=meshing._fluent_connection._connection_interface.scheme_eval,
         file_transfer_service=file_service,
     )
 

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -100,14 +100,16 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     server.start()
 
     with pytest.raises(UnsupportedRemoteFluentInstance) as msg:
+        fluent_connection = FluentConnection(
+            ip=ip,
+            port=port,
+            password="12345",
+            remote_instance=mock_instance,
+            cleanup_on_exit=False,
+        )
         session = BaseSession(
-            FluentConnection(
-                ip=ip,
-                port=port,
-                password="12345",
-                remote_instance=mock_instance,
-                cleanup_on_exit=False,
-            )
+            fluent_connection=fluent_connection,
+            scheme_eval=fluent_connection._connection_interface.scheme_eval,
         )
         session.exit(wait=60)
         session._fluent_connection.wait_process_finished(wait=60)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -113,12 +113,20 @@ def test_create_mock_session_by_passing_ip_port_password() -> None:
     server.start()
 
     with pytest.raises(PortNotProvided) as msg:
+        fluent_connection = FluentConnection(
+            ip=ip, password="12345", cleanup_on_exit=False
+        )
         session = BaseSession(
-            FluentConnection(ip=ip, password="12345", cleanup_on_exit=False)
+            fluent_connection=fluent_connection,
+            scheme_eval=fluent_connection._connection_interface.scheme_eval,
         )
 
+    fluent_connection = FluentConnection(
+        ip=ip, port=port, password="12345", cleanup_on_exit=False
+    )
     session = BaseSession(
-        FluentConnection(ip=ip, port=port, password="12345", cleanup_on_exit=False)
+        fluent_connection=fluent_connection,
+        scheme_eval=fluent_connection._connection_interface.scheme_eval,
     )
     assert session.health_check.is_serving
     server.stop(None)
@@ -140,7 +148,11 @@ def test_create_mock_session_by_setting_ip_port_env_var(
     server.start()
     monkeypatch.setenv("PYFLUENT_FLUENT_IP", ip)
     monkeypatch.setenv("PYFLUENT_FLUENT_PORT", str(port))
-    session = BaseSession(FluentConnection(password="12345", cleanup_on_exit=False))
+    fluent_connection = FluentConnection(password="12345", cleanup_on_exit=False)
+    session = BaseSession(
+        fluent_connection=fluent_connection,
+        scheme_eval=fluent_connection._connection_interface.scheme_eval,
+    )
     assert session.health_check.is_serving
     server.stop(None)
     session.exit()
@@ -158,8 +170,12 @@ def test_create_mock_session_by_passing_grpc_channel() -> None:
     )
     server.start()
     channel = grpc.insecure_channel(f"{ip}:{port}")
+    fluent_connection = FluentConnection(
+        channel=channel, cleanup_on_exit=False, password="12345"
+    )
     session = BaseSession(
-        FluentConnection(channel=channel, cleanup_on_exit=False, password="12345")
+        fluent_connection=fluent_connection,
+        scheme_eval=fluent_connection._connection_interface.scheme_eval,
     )
     assert session.health_check.is_serving
     server.stop(None)
@@ -373,7 +389,9 @@ def test_build_from_fluent_connection(make_new_session):
     # The below hack is performed to check the base class method
     # (child class has a method with same name)
     solver1.__class__.__bases__[0]._build_from_fluent_connection(
-        solver1, fluent_connection=solver2._fluent_connection
+        solver1,
+        fluent_connection=solver2._fluent_connection,
+        scheme_eval=solver2._fluent_connection._connection_interface.scheme_eval,
     )
     assert solver1.health_check.is_serving
     assert solver2.health_check.is_serving

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,6 +23,7 @@ from ansys.fluent.core.fluent_connection import FluentConnection, PortNotProvide
 from ansys.fluent.core.launcher.error_handler import LaunchFluentError
 from ansys.fluent.core.session import BaseSession
 from ansys.fluent.core.utils.execution import timeout_loop
+from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.utils.networking import get_free_port
 
 
@@ -405,7 +406,7 @@ def test_recover_grpc_error_from_connection_error():
 def test_solver_methods(new_solver_session):
     solver = new_solver_session
 
-    if int(solver._version) == 222:
+    if solver.get_fluent_version() == FluentVersion.v222:
         api_keys = {
             "file",
             "setup",
@@ -415,7 +416,7 @@ def test_solver_methods(new_solver_session):
             "current_parametric_study",
         }
         assert api_keys.issubset(set(dir(solver)))
-    if int(solver._version) == 232:
+    if solver.get_fluent_version() == FluentVersion.v232:
         api_keys = {
             "file",
             "mesh",
@@ -429,7 +430,7 @@ def test_solver_methods(new_solver_session):
             "report",
         }
         assert api_keys.issubset(set(dir(solver)))
-    if int(solver._version) >= 241:
+    if solver.get_fluent_version() >= FluentVersion.v241:
         api_keys = {
             "file",
             "mesh",


### PR DESCRIPTION
Pass scheme eval as an argument to session instead of taking it directly from FluentConnection.