### PR TITLE
fix: Set boundary values default to True

### DIFF
--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -100,7 +100,7 @@ class Transaction:
         surface_ids: Optional[List[int]] = None,
         surface_names: Optional[List[str]] = None,
         node_value: Optional[bool] = True,
-        boundary_value: Optional[bool] = False,
+        boundary_value: Optional[bool] = True,
     ) -> None:
         """Add request to get scalar field data on surfaces.
 
@@ -117,7 +117,7 @@ class Transaction:
             ``False``, the element location is provided.
         boundary_value : bool, optional
             Whether to provide the slip velocity at the wall boundaries. The default
-            is ``False``. When ``True``, no slip velocity is provided.
+            is ``True``. When ``True``, no slip velocity is provided.
 
         Returns
         -------
@@ -394,7 +394,7 @@ class FileFieldData:
         surface_ids: Optional[List[int]] = None,
         surface_name: Optional[str] = None,
         node_value: Optional[bool] = True,
-        boundary_value: Optional[bool] = False,
+        boundary_value: Optional[bool] = True,
     ):
         """Get scalar field data on a surface.
 
@@ -411,7 +411,7 @@ class FileFieldData:
             When ``False``, data is provided for the element location.
         boundary_value : bool, optional
             Whether to provide slip velocity at the wall boundaries. The default is
-            ``False``. When ``True``, no slip velocity is provided.
+            ``True``. When ``True``, no slip velocity is provided.
 
         Returns
         -------

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -478,7 +478,7 @@ class FieldTransaction:
         surface_ids: Optional[List[int]] = None,
         surface_names: Optional[List[str]] = None,
         node_value: Optional[bool] = True,
-        boundary_value: Optional[bool] = False,
+        boundary_value: Optional[bool] = True,
     ) -> None:
         """Add request to get scalar field data on surfaces.
 
@@ -495,7 +495,7 @@ class FieldTransaction:
             ``False``, the element location is provided.
         boundary_value : bool, optional
             Whether to provide the slip velocity at the wall boundaries. The default
-            is ``False``. When ``True``, no slip velocity is provided.
+            is ``True``. When ``True``, no slip velocity is provided.
 
         Returns
         -------
@@ -1155,7 +1155,7 @@ class FieldData:
         surface_ids: Optional[List[int]] = None,
         surface_name: Optional[str] = None,
         node_value: Optional[bool] = True,
-        boundary_value: Optional[bool] = False,
+        boundary_value: Optional[bool] = True,
     ) -> Union[ScalarFieldData, Dict[int, ScalarFieldData]]:
         """Get scalar field data on a surface.
 
@@ -1172,7 +1172,7 @@ class FieldData:
             When ``False``, data is provided for the element location.
         boundary_value : bool, optional
             Whether to provide slip velocity at the wall boundaries. The default is
-            ``False``. When ``True``, no slip velocity is provided.
+            ``True``. When ``True``, no slip velocity is provided.
 
         Returns
         -------


### PR DESCRIPTION
Fixes Fluent bug 1014887. The boundary values default is True in Fluent.