### PR TITLE
fix: workflow validation

### DIFF
--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -868,9 +868,6 @@ class CommandTask(BaseTask):
         return cmd
 
     def _command(self):
-        cmd = self._cmd
-        del cmd
-        self._cmd = None
         if not self._cmd:
             self._cmd = _new_command_for_task(self._task, self._source)
         return self._cmd

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -615,8 +615,8 @@ class ArgumentsWrapper(PyCallableStateObject):
         return state_dict
 
     def _assign(self, args: dict, fn) -> None:
-        # this function sets the task arguments' state, either via update_dict
-        # or set_state. Datamodel dicts are not subject to rules at the
+        # This function sets the task arguments' state, either via update_dict()
+        # or set_state(). Datamodel dicts are not subject to rules at the
         # key-value level. In order to trigger rules validation, it's necessary
         # to apply the arguments' state to the actual command, and that is what
         # we do here. If the introduced arguments' state is invalid, we leave the
@@ -625,12 +625,12 @@ class ArgumentsWrapper(PyCallableStateObject):
             # We get the initial state for exception safety, but this also
             # has the positive side effect of populating the name map.
             # So, if this initial state access is removed then we must ensure
-            # that we populate that map. But we can also optimise by keeping
+            # that we still populate that map. But we can also optimise by keeping
             # a global map and only fetching the remote state for unpopulated
             # paths. Furthermore we can generate all name information statically,
-            # avoiding remote trips. In order to avoid the initial get_state for
-            # exception safety, we could optionally return the current state from
-            # set_state.
+            # avoiding remote trips for such purposes. In order to avoid the initial
+            # get_state (to support exception safety), we could optionally return the
+            # current state from the prior set_state invocation.
             old_state = self.get_state()
         except Exception:
             old_state = None

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -618,11 +618,19 @@ class ArgumentsWrapper(PyCallableStateObject):
 
     def _assign(self, args: dict, fn) -> None:
         try:
+            # We get the initial state for exception safety, but this also
+            # has the positive side effect of populating the name map.
+            # So, if this initial state access is removed then we must ensure
+            # that we populate that map. But we can also optimise by keeping
+            # a global map and only fetching the remote state for unpopulated
+            # paths. Furthermore we can generate all name information statically,
+            # avoiding remote trips. In order to avoid the initial get_state for
+            # exception safety, we could optionally return the current state from
+            # set_state.
             old_state = self.get_state()
         except Exception:
             old_state = None
         if self._dynamic_interface:
-            self._build_naming_map_for_state_assign_method()
             camel_args = {}
             for key, val in args.items():
                 camel_args[

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -607,7 +607,7 @@ class ArgumentsWrapper(PyCallableStateObject):
         Exception
             If operation fails.
         """
-        self._assign(args)
+        self._assign(args, "update_dict")
 
     def get_state(self, explicit_only=False) -> dict:
         """Get the state of the arguments.
@@ -641,7 +641,7 @@ class ArgumentsWrapper(PyCallableStateObject):
 
         return state_dict
 
-    def _assign(self, args: dict) -> None:
+    def _assign(self, args: dict, fn) -> None:
         try:
             old_state = self.get_state()
         except Exception:
@@ -653,9 +653,9 @@ class ArgumentsWrapper(PyCallableStateObject):
                 camel_args[
                     _global_snake_to_camel_map[key] if key.islower() else key
                 ] = val
-            self._task.Arguments.update_dict(camel_args)
+            getattr(self._task.Arguments, fn)(camel_args)
         else:
-            self._task.Arguments.update_dict(args)
+            getattr(self._task.Arguments, fn)(args)
         # implicitly refresh the command arguments
         # - adding a safety net
         try:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -568,7 +568,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             If operation fails.
         """
         try:
-            old_state = self._task.Arguments.get_state()
+            old_state = self.get_state()  # self._task.Arguments.get_state()
         except Exception:
             old_state = None
         if self._dynamic_interface:
@@ -584,8 +584,10 @@ class ArgumentsWrapper(PyCallableStateObject):
         try:
             self._task._command_arguments()
         except Exception as ex:
-            if old_state is not None:
-                self.set_state(dict(number_of_flow_volumes=1))  # (old_state)
+            if True:  # old_state is not None:
+                self._just_set_state(
+                    old_state
+                )  # (dict(number_of_flow_volumes=1))  # (old_state)
                 try:
                     self._task._command_arguments()
                 except Exception:
@@ -606,7 +608,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             If operation fails.
         """
         try:
-            old_state = self._task.Arguments.get_state()
+            old_state = self.get_state()  # self._task.Arguments.get_state()
         except Exception:
             old_state = None
         if self._dynamic_interface:
@@ -624,8 +626,10 @@ class ArgumentsWrapper(PyCallableStateObject):
         try:
             self._task._command_arguments()
         except Exception as ex:
-            if old_state is not None:
-                self.set_state(dict(number_of_flow_volumes=1))  # (old_state)
+            if True:  # old_state is not None:
+                self._just_set_state(
+                    old_state
+                )  # (dict(number_of_flow_volumes=1))  # (old_state)
                 try:
                     self._task._command_arguments()
                 except Exception:
@@ -669,6 +673,16 @@ class ArgumentsWrapper(PyCallableStateObject):
             self.get_state()
         except Exception:
             pass
+
+    def _just_set_state(self, args):
+        if self._dynamic_interface:
+            camel_args = {}
+            if isinstance(args, dict):
+                for key, val in args.items():
+                    camel_args[_global_snake_to_camel_map[key]] = val
+            self._task.Arguments.set_state(camel_args)
+        else:
+            self._task.Arguments.set_state(args)
 
     def __getattr__(self, attr):
         return getattr(self._task._command_arguments, attr)
@@ -854,6 +868,8 @@ class CommandTask(BaseTask):
         return cmd
 
     def _command(self):
+        cmd = self._cmd
+        del cmd
         self._cmd = None
         if not self._cmd:
             self._cmd = _new_command_for_task(self._task, self._source)

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -615,6 +615,12 @@ class ArgumentsWrapper(PyCallableStateObject):
         return state_dict
 
     def _assign(self, args: dict, fn) -> None:
+        # this function sets the task arguments' state, either via update_dict
+        # or set_state. Datamodel dicts are not subject to rules at the
+        # key-value level. In order to trigger rules validation, it's necessary
+        # to apply the arguments' state to the actual command, and that is what
+        # we do here. If the introduced arguments' state is invalid, we leave the
+        # target state unaffected (by repairing it) and throw an exception.
         try:
             # We get the initial state for exception safety, but this also
             # has the positive side effect of populating the name map.
@@ -648,7 +654,7 @@ class ArgumentsWrapper(PyCallableStateObject):
                 self._task._refreshed_command()()
             except Exception:
                 pass
-            raise ex
+            raise ValueError("Invalid task argument state") from ex
 
     def _build_naming_map_for_state_assign_method(self):
         try:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -646,7 +646,9 @@ class ArgumentsWrapper(PyCallableStateObject):
         try:
             self._refresh_command_after_changing_args(old_state)
         except Exception as ex:
-            raise ValueError("Invalid task arguments, {args} for '{self._task.python_name()}'.") from ex
+            raise ValueError(
+                "Invalid task arguments, {args} for '{self._task.python_name()}'."
+            ) from ex
 
     def _refresh_command_after_changing_args(self, recovery_state) -> None:
         try:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -854,6 +854,7 @@ class CommandTask(BaseTask):
         return cmd
 
     def _command(self):
+        self._cmd = None
         if not self._cmd:
             self._cmd = _new_command_for_task(self._task, self._source)
         return self._cmd

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -18,8 +18,6 @@ from ansys.fluent.core.services.datamodel_se import (
 )
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
-_global_snake_to_camel_map = {}
-
 
 def camel_to_snake_case(camel_case_str: str) -> str:
     """Convert camel case input string to snake case output string."""
@@ -339,7 +337,7 @@ class BaseTask:
         _args = self.arguments
         _camel_args = []
         for arg in _args().keys():
-            _camel_args.append(_global_snake_to_camel_map[arg])
+            _camel_args.append(_args._snake_to_camel_map[arg])
 
         return _camel_args
 
@@ -606,11 +604,11 @@ class ArgumentsWrapper(PyCallableStateObject):
                     PySingletonCommandArgumentsSubItem,
                 ):
                     for k, v in val.items():
-                        _global_snake_to_camel_map[camel_to_snake_case(k)] = k
+                        self._snake_to_camel_map[camel_to_snake_case(k)] = k
                         nested_val[camel_to_snake_case(k)] = v
                 else:
                     nested_val = val
-                _global_snake_to_camel_map[camel_to_snake_case(key)] = key
+                self._snake_to_camel_map[camel_to_snake_case(key)] = key
                 snake_case_state_dict[camel_to_snake_case(key)] = nested_val
             return snake_case_state_dict
 
@@ -633,9 +631,9 @@ class ArgumentsWrapper(PyCallableStateObject):
         if self._dynamic_interface:
             camel_args = {}
             for key, val in args.items():
-                camel_args[
-                    _global_snake_to_camel_map[key] if key.islower() else key
-                ] = val
+                camel_args[self._snake_to_camel_map[key] if key.islower() else key] = (
+                    val
+                )
             getattr(self._task.Arguments, fn)(camel_args)
         else:
             getattr(self._task.Arguments, fn)(args)
@@ -663,7 +661,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             camel_args = {}
             if isinstance(args, dict):
                 for key, val in args.items():
-                    camel_args[_global_snake_to_camel_map[key]] = val
+                    camel_args[self._snake_to_camel_map[key]] = val
             self._task.Arguments.set_state(camel_args)
         else:
             self._task.Arguments.set_state(args)
@@ -737,7 +735,7 @@ class ArgumentWrapper(PyCallableStateObject):
         ):
             snake_case_state_dict = {}
             for key, val in state_dict.items():
-                _global_snake_to_camel_map[camel_to_snake_case(key)] = key
+                self._snake_to_camel_map[camel_to_snake_case(key)] = key
                 snake_case_state_dict[camel_to_snake_case(key)] = val
             return snake_case_state_dict
 
@@ -748,7 +746,7 @@ class ArgumentWrapper(PyCallableStateObject):
         _camel_args = []
         for arg in _args().keys():
             try:
-                _camel_args.append(_global_snake_to_camel_map[arg])
+                _camel_args.append(self._snake_to_camel_map[arg])
             except KeyError:
                 _camel_args.append(arg)
 

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -567,32 +567,7 @@ class ArgumentsWrapper(PyCallableStateObject):
         Exception
             If operation fails.
         """
-        try:
-            old_state = self.get_state()  # self._task.Arguments.get_state()
-        except Exception:
-            old_state = None
-        if self._dynamic_interface:
-            self._build_naming_map_for_state_assign_method()
-            camel_args = {}
-            for key, val in args.items():
-                camel_args[_global_snake_to_camel_map[key]] = val
-            self._task.Arguments.set_state(camel_args)
-        else:
-            self._task.Arguments.set_state(args)
-        # implicitly refresh the command arguments
-        # - adding a safety net
-        try:
-            self._task._command_arguments()
-        except Exception as ex:
-            if True:  # old_state is not None:
-                self._just_set_state(
-                    old_state
-                )  # (dict(number_of_flow_volumes=1))  # (old_state)
-                try:
-                    self._task._command_arguments()
-                except Exception:
-                    pass
-            raise ex
+        self._assign(args, "set_state")
 
     def update_dict(self, args: dict) -> None:
         """Merge with arguments.

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -656,12 +656,6 @@ class ArgumentsWrapper(PyCallableStateObject):
                 pass
             raise ValueError("Invalid task argument state") from ex
 
-    def _build_naming_map_for_state_assign_method(self):
-        try:
-            self.get_state()
-        except Exception:
-            pass
-
     def _just_set_state(self, args):
         if self._dynamic_interface:
             camel_args = {}

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -562,8 +562,8 @@ class ArgumentsWrapper(PyCallableStateObject):
 
         Raises
         ------
-        Exception
-            If operation fails.
+        ValueError
+            If input is invalid.
         """
         self._assign(args, "set_state")
 
@@ -577,8 +577,8 @@ class ArgumentsWrapper(PyCallableStateObject):
 
         Raises
         ------
-        Exception
-            If operation fails.
+        ValueError
+            If input is invalid.
         """
         self._assign(args, "update_dict")
 
@@ -643,7 +643,10 @@ class ArgumentsWrapper(PyCallableStateObject):
             getattr(self._task.Arguments, fn)(camel_args)
         else:
             getattr(self._task.Arguments, fn)(args)
-        self._refresh_command_after_changing_args(old_state)
+        try:
+            self._refresh_command_after_changing_args(old_state)
+        except Exception as ex:
+            raise ValueError("Invalid task arguments, {args} for '{self._task.python_name()}'.") from ex
 
     def _refresh_command_after_changing_args(self, recovery_state) -> None:
         try:
@@ -654,7 +657,7 @@ class ArgumentsWrapper(PyCallableStateObject):
                 self._task._refreshed_command()()
             except Exception:
                 pass
-            raise ValueError("Invalid task argument state") from ex
+            raise ex
 
     def _just_set_state(self, args):
         if self._dynamic_interface:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -631,14 +631,15 @@ class ArgumentsWrapper(PyCallableStateObject):
             getattr(self._task.Arguments, fn)(camel_args)
         else:
             getattr(self._task.Arguments, fn)(args)
-        # implicitly refresh the command arguments
-        # - adding a safety net
+        self._refresh_command_after_changing_args(old_state)
+
+    def _refresh_command_after_changing_args(self, recovery_state) -> None:
         try:
-            self._task._command_arguments()
+            self._task._refreshed_command()()
         except Exception as ex:
-            self._just_set_state(old_state)
+            self._just_set_state(recovery_state)
             try:
-                self._task._command_arguments()
+                self._task._refreshed_command()()
             except Exception:
                 pass
             raise ex

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -585,7 +585,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             self._task._command_arguments()
         except Exception as ex:
             if old_state is not None:
-                self._task.Arguments.set_state(old_state)
+                self.set_state(dict(number_of_flow_volumes=1))  # (old_state)
                 try:
                     self._task._command_arguments()
                 except Exception:
@@ -613,7 +613,9 @@ class ArgumentsWrapper(PyCallableStateObject):
             self._build_naming_map_for_state_assign_method()
             camel_args = {}
             for key, val in args.items():
-                camel_args[_global_snake_to_camel_map[key]] = val
+                camel_args[
+                    _global_snake_to_camel_map[key] if key.islower() else key
+                ] = val
             self._task.Arguments.update_dict(camel_args)
         else:
             self._task.Arguments.update_dict(args)
@@ -623,7 +625,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             self._task._command_arguments()
         except Exception as ex:
             if old_state is not None:
-                self._task.Arguments.set_state(old_state)
+                self.set_state(dict(number_of_flow_volumes=1))  # (old_state)
                 try:
                     self._task._command_arguments()
                 except Exception:
@@ -716,7 +718,7 @@ class ArgumentWrapper(PyCallableStateObject):
         value : Any
             Value of the argument.
         """
-        self._task.Arguments.update_dict({self._arg_name: value})
+        self._task.arguments.update_dict({self._arg_name: value})
 
     def get_state(self, explicit_only: bool = False) -> Any:
         """Get the state of this argument.

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1230,13 +1230,6 @@ def test_new_meshing_workflow_validate_arguments(new_mesh_session):
     with pytest.raises(Exception):
         watertight.create_regions.number_of_flow_volumes = 1.2
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
-
-
-@pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.2")
-def test_new_meshing_workflow_validate_arguments2(new_mesh_session):
-    watertight = new_mesh_session.watertight()
-    watertight.create_regions.number_of_flow_volumes = 1
     with pytest.raises(Exception):
         watertight.create_regions.arguments.update_dict(
             dict(number_of_flow_volumes=1.2)

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1227,30 +1227,30 @@ def test_new_meshing_workflow_without_dm_caching(
 def test_new_meshing_workflow_validate_arguments(new_mesh_session):
     watertight = new_mesh_session.watertight()
     watertight.create_regions.number_of_flow_volumes = 1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.number_of_flow_volumes = 1.2
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.arguments.update_dict(
             dict(number_of_flow_volumes=1.2)
         )
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
 
     watertight.create_regions.number_of_flow_volumes = 2
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.number_of_flow_volumes = 1.2
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 2
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.arguments.update_dict(
             dict(number_of_flow_volumes=1.2)
         )
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 2
 
     watertight.create_regions.number_of_flow_volumes = None
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.number_of_flow_volumes = 1.2
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         watertight.create_regions.arguments.update_dict(
             dict(number_of_flow_volumes=1.2)
         )

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1285,4 +1285,3 @@ def test_camel_to_snake_case_convertor():
     assert camel_to_snake_case("Abc2DDc$") == "abc_2d_dc$"
     assert camel_to_snake_case("A2DDc$") == "a2d_dc$"
     assert camel_to_snake_case("") == ""
-

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1220,3 +1220,25 @@ def test_new_meshing_workflow_without_dm_caching(
     with pytest.raises(RuntimeError):
         fault_tolerant.import_cad_and_part_management.arguments()
     assert watertight.import_geometry.arguments()
+
+
+@pytest.mark.codegen_required
+@pytest.mark.fluent_version(">=24.2")
+def test_new_meshing_workflow_validate_arguments(new_mesh_session):
+    watertight = new_mesh_session.watertight()
+    watertight.create_regions.number_of_flow_volumes = 1
+    with pytest.raises(Exception):
+        watertight.create_regions.number_of_flow_volumes = 1.2
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
+
+
+@pytest.mark.codegen_required
+@pytest.mark.fluent_version(">=24.2")
+def test_new_meshing_workflow_validate_arguments2(new_mesh_session):
+    watertight = new_mesh_session.watertight()
+    watertight.create_regions.number_of_flow_volumes = 1
+    with pytest.raises(Exception):
+        watertight.create_regions.arguments.update_dict(
+            dict(number_of_flow_volumes=1.2)
+        )
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1235,3 +1235,23 @@ def test_new_meshing_workflow_validate_arguments(new_mesh_session):
             dict(number_of_flow_volumes=1.2)
         )
     assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
+
+    watertight.create_regions.number_of_flow_volumes = 2
+    with pytest.raises(Exception):
+        watertight.create_regions.number_of_flow_volumes = 1.2
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 2
+    with pytest.raises(Exception):
+        watertight.create_regions.arguments.update_dict(
+            dict(number_of_flow_volumes=1.2)
+        )
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 2
+
+    watertight.create_regions.number_of_flow_volumes = None
+    with pytest.raises(Exception):
+        watertight.create_regions.number_of_flow_volumes = 1.2
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1
+    with pytest.raises(Exception):
+        watertight.create_regions.arguments.update_dict(
+            dict(number_of_flow_volumes=1.2)
+        )
+    assert watertight.create_regions.arguments()["number_of_flow_volumes"] == 1


### PR DESCRIPTION
Fix for some enhanced meshing workflow issues, one of which is reported on the Fluent side.

1. When an invalid task argument is set, an exception is not immediately triggered because the relevant server code does not do rules validation at the key-value level of dictionary parameters. The invalidity only becomes apparent at the command level. So, with this change, I ensure that when the task arguments are changed, the command arguments are also updated. That way the exception is triggered right away upon the relevant call. Also, the state is repaired within the same assignment implementation.

2. Code like `my_task.some_arg = 1` did not follow the same path through the code as `my_task.arguments.update_dict(dict(some_arg = 1))`, which is now rectified. I suspect that there could be similar issues for other methods at the same level. 