### PR TITLE
refactor: Skip failing test.

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -463,6 +463,7 @@ def test_solver_methods(new_solver_session):
         assert api_keys.issubset(set(dir(solver)))
 
 
+@pytest.mark.skip("github issue: https://github.com/ansys/pyfluent/issues/2684")
 @pytest.mark.fluent_version(">=23.2")
 def test_get_set_state_on_solver(new_solver_session):
     solver = new_solver_session


### PR DESCRIPTION
tests/test_session.py -> test_get_set_state_on_solver is failing which is causing other PRs to not get merged. A github issue has been created for this and this test has been temporarily skipped.