### PR TITLE
ci: Reduce the number of Fluent version to run for each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,9 +48,9 @@ def pytest_runtest_setup(item):
     if fluent_version_markers:
         spec = fluent_version_markers[0].args[0]
         # Tests which depend on the current development Fluent version or tracking
-        # Fluent API change are marked as fluent_version("latest"). They are run only
+        # Fluent API change are marked as fluent_version("develop"). They are run only
         # with the development Fluent version.
-        if spec == "latest":
+        if spec == "develop":
             fluent_version_spec = f"=={_fluent_develop_version}"
         # Tests which depend on a specific released Fluent version are marked as
         # fluent_version("==<version>"). They are run only with that specific Fluent

--- a/tests/integration/test_optislang/test_optislang_integration.py
+++ b/tests/integration/test_optislang/test_optislang_integration.py
@@ -12,7 +12,6 @@ from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
 def test_simple_solve(load_mixing_elbow_param_case_dat):
     """Use case 1: This optiSLang integration test performs these steps.
 
@@ -103,7 +102,6 @@ def test_simple_solve(load_mixing_elbow_param_case_dat):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
 def test_generate_read_mesh(mixing_elbow_geometry):
     """Use case 2: This optiSLang integration test performs these steps.
 

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -16,7 +16,6 @@ def pytest_approx(expected):
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version("latest")
 def test_parametric_workflow():
     # parent path needs to exist for mkdtemp
     Path(pyfluent.EXAMPLES_PATH).mkdir(parents=True, exist_ok=True)
@@ -211,7 +210,7 @@ def test_parametric_workflow():
     solver_session.exit()
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_parameters_list_function(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
     solver.tui.define.parameters.enable_in_TUI("yes")

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -210,7 +210,7 @@ def test_parametric_workflow():
     solver_session.exit()
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_parameters_list_function(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
     solver.tui.define.parameters.enable_in_TUI("yes")

--- a/tests/test_batch_ops.py
+++ b/tests/test_batch_ops.py
@@ -5,7 +5,6 @@ import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_batch_ops_create_mesh(new_solver_session):
     solver = new_solver_session
     mesh = solver.results.graphics.mesh
@@ -23,7 +22,6 @@ def test_batch_ops_create_mesh(new_solver_session):
     assert "mesh-1" in mesh.get_object_names()
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_batch_ops_create_mesh_and_access_fails(new_solver_session):
     solver = new_solver_session
     mesh = solver.results.graphics.mesh

--- a/tests/test_creatable.py
+++ b/tests/test_creatable.py
@@ -1,8 +1,6 @@
-import pytest
 from util.fixture_fluent import load_static_mixer_settings_only  # noqa: F401
 
 
-@pytest.mark.fluent_version("latest")
 def test_creatable(load_static_mixer_settings_only) -> None:
     setup = load_static_mixer_settings_only.setup
     has_not = (

--- a/tests/test_data_model_cache.py
+++ b/tests/test_data_model_cache.py
@@ -211,7 +211,6 @@ def test_update_cache_internal_names_as_keys(
     assert cache_rules == final_cache
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_get_cached_values_in_command_arguments(new_mesh_session):
     new_mesh_session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -274,7 +274,7 @@ def test_datamodel_streaming_no_commands_diff_state(
     assert "ImportGeometry:ImportGeometry1" not in (y for x in cb.states for y in x)
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 @pytest.mark.codegen_required
 def test_get_object_names_wtm(new_mesh_session):
     meshing = new_mesh_session
@@ -347,7 +347,7 @@ def test_generic_datamodel(new_solver_session):
     assert flserver.Case.Solution.Calculation.TimeStepSize() == 1.0
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_named_object_specific_methods_using_flserver(new_solver_session):
     import_file_name = examples.download_file(
         "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -428,7 +428,7 @@ def test_named_object_specific_methods_using_flserver(new_solver_session):
     assert not flserver.Case.Results.Graphics.Contour.get_object_names()
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_named_object_specific_methods(new_mesh_session):
     meshing = new_mesh_session
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -17,7 +17,6 @@ from ansys.fluent.core.services.datamodel_se import (
 from ansys.fluent.core.streaming_services.datamodel_streaming import DatamodelStream
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_event_subscription(new_mesh_session):
     session = new_mesh_session
@@ -71,7 +70,6 @@ def test_event_subscription(new_mesh_session):
     )
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_child_created(new_mesh_session):
     meshing = new_mesh_session
@@ -90,7 +88,6 @@ def test_add_on_child_created(new_mesh_session):
     assert child_paths == []
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_deleted(new_mesh_session):
     meshing = new_mesh_session
@@ -105,7 +102,6 @@ def test_add_on_deleted(new_mesh_session):
     assert len(data) > 0
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_changed(new_mesh_session):
     meshing = new_mesh_session
@@ -126,7 +122,6 @@ def test_add_on_changed(new_mesh_session):
     assert data == []
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_affected(new_mesh_session):
     meshing = new_mesh_session
@@ -180,7 +175,6 @@ def test_add_on_affected(new_mesh_session):
     assert data == []
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_affected_at_type_path(new_mesh_session):
     meshing = new_mesh_session
@@ -200,7 +194,6 @@ def test_add_on_affected_at_type_path(new_mesh_session):
     assert data == []
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_add_on_command_executed(new_mesh_session):
     meshing = new_mesh_session
@@ -229,7 +222,6 @@ def disable_datamodel_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(pyfluent, "DATAMODEL_USE_STATE_CACHE", False)
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_datamodel_streaming_full_diff_state(disable_datamodel_cache, new_mesh_session):
     meshing = new_mesh_session
@@ -255,7 +247,6 @@ def test_datamodel_streaming_full_diff_state(disable_datamodel_cache, new_mesh_s
     assert "ImportGeometry:ImportGeometry1" in (y for x in cb.states for y in x)
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_datamodel_streaming_no_commands_diff_state(
     disable_datamodel_cache, new_mesh_session
@@ -283,7 +274,7 @@ def test_datamodel_streaming_no_commands_diff_state(
     assert "ImportGeometry:ImportGeometry1" not in (y for x in cb.states for y in x)
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 @pytest.mark.codegen_required
 def test_get_object_names_wtm(new_mesh_session):
     meshing = new_mesh_session
@@ -309,7 +300,6 @@ def test_get_object_names_wtm(new_mesh_session):
     assert meshing.workflow.TaskObject.get_object_names() == child_object_names
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_get_and_set_state_for_command_arg_instance(new_mesh_session):
     meshing = new_mesh_session
@@ -357,7 +347,7 @@ def test_generic_datamodel(new_solver_session):
     assert flserver.Case.Solution.Calculation.TimeStepSize() == 1.0
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_named_object_specific_methods_using_flserver(new_solver_session):
     import_file_name = examples.download_file(
         "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -438,7 +428,7 @@ def test_named_object_specific_methods_using_flserver(new_solver_session):
     assert not flserver.Case.Results.Graphics.Contour.get_object_names()
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_named_object_specific_methods(new_mesh_session):
     meshing = new_mesh_session
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
@@ -469,7 +459,6 @@ def test_named_object_specific_methods(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.1")
 def test_command_creation_inside_singleton(new_mesh_session):
     meshing = new_mesh_session
     read_mesh = meshing.meshing.File.ReadMesh.create_instance()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -4,7 +4,6 @@ import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.parametrize(
     "error_code,raises",
     [

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -369,7 +369,7 @@ def test_field_info_validators(new_solver_session) -> None:
 
 
 @pytest.mark.skip("https://github.com/ansys/pyfluent/issues/2404")
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_field_data_does_not_modify_case(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -10,7 +10,6 @@ from ansys.fluent.core.services.field_data import FieldUnavailable, SurfaceDataT
 HOT_INLET_TEMPERATURE = 313.15
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_field_data(new_solver_session) -> None:
     solver = new_solver_session
     import_file_name = examples.download_file(
@@ -167,7 +166,6 @@ def test_field_data_allowed_values(new_solver_session) -> None:
     assert expected_allowed_args == allowed_args
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_field_data_objects_3d(new_solver_session) -> None:
     solver = new_solver_session
     import_file_name = examples.download_file(
@@ -238,7 +236,6 @@ def test_field_data_objects_3d(new_solver_session) -> None:
     assert all(path_lines_data["lines"][100].node_indices == [100, 101])
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_field_data_objects_2d(load_disk_mesh) -> None:
     solver = load_disk_mesh
 
@@ -344,7 +341,6 @@ def test_field_data_errors(new_solver_session) -> None:
         )
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_field_info_validators(new_solver_session) -> None:
     solver = new_solver_session
     import_file_name = examples.download_file(
@@ -373,7 +369,7 @@ def test_field_info_validators(new_solver_session) -> None:
 
 
 @pytest.mark.skip("https://github.com/ansys/pyfluent/issues/2404")
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_field_data_does_not_modify_case(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -863,7 +863,7 @@ def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     assert energy_parent == "\n energy is a child of models \n"
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     root = solver.settings
@@ -958,7 +958,7 @@ def test_strings_with_allowed_values(load_static_mixer_settings_only):
     ]
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_parent_class_attributes(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
     assert solver.setup.models.energy.enabled
@@ -1044,7 +1044,7 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     )
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
 
@@ -1066,7 +1066,7 @@ def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
     }
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_bug_1001124_quantity_assignment(load_mixing_elbow_mesh):
     speed = ansys.units.Quantity(100, "m s^-1")
     solver = load_mixing_elbow_mesh
@@ -1141,7 +1141,7 @@ def test_static_info_hash_identity(new_solver_session):
     assert hash1 == hash2
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_default_argument_names_for_commands(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -660,7 +660,6 @@ class root(Group):
     )  # noqa: W293
 
 
-@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 
@@ -723,7 +722,6 @@ def test_accessor_methods_on_settings_object(load_static_mixer_settings_only):
     assert solver.results.graphics.mesh.get_object_names() == ["mesh_242"]
 
 
-@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_object_types(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 
@@ -767,7 +765,6 @@ def test_find_children_from_settings_root(load_static_mixer_settings_only):
     )
 
 
-@pytest.mark.fluent_version("latest")
 def test_find_children_from_fluent_solver_session(load_static_mixer_settings_only):
     setup_children = find_children(load_static_mixer_settings_only.setup)
     load_mixer = load_static_mixer_settings_only.setup
@@ -806,7 +803,6 @@ def test_find_children_from_fluent_solver_session(load_static_mixer_settings_onl
         }
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_settings_wild_card_access(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
 
@@ -838,7 +834,6 @@ def test_settings_wild_card_access(new_solver_session_no_transcript) -> None:
     )
 
 
-@pytest.mark.fluent_version("latest")
 def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
 
@@ -868,7 +863,7 @@ def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     assert energy_parent == "\n energy is a child of models \n"
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_accessor_methods_on_settings_objects(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     root = solver.settings
@@ -948,7 +943,6 @@ def get_child_nodes(node, nodes, type_list):
                     return
 
 
-@pytest.mark.fluent_version("latest")
 def test_strings_with_allowed_values(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 
@@ -964,7 +958,7 @@ def test_strings_with_allowed_values(load_static_mixer_settings_only):
     ]
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_parent_class_attributes(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
     assert solver.setup.models.energy.enabled
@@ -984,7 +978,6 @@ def _check_vector_units(obj, units):
         assert obj.as_quantity() == ansys.units.Quantity(obj.get_state(), units)
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
     assert isinstance(solver.settings.state_with_units(), dict)
@@ -1051,7 +1044,7 @@ def test_ansys_units_integration(load_mixing_elbow_mesh):
     )
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
     solver = load_mixing_elbow_mesh
 
@@ -1073,7 +1066,7 @@ def test_ansys_units_integration_nested_state(load_mixing_elbow_mesh):
     }
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_bug_1001124_quantity_assignment(load_mixing_elbow_mesh):
     speed = ansys.units.Quantity(100, "m s^-1")
     solver = load_mixing_elbow_mesh
@@ -1148,7 +1141,7 @@ def test_static_info_hash_identity(new_solver_session):
     assert hash1 == hash2
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_default_argument_names_for_commands(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -87,7 +87,7 @@ def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     ]
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_empty_vector_field_data_2339(new_solver_session):
     solver = new_solver_session
 

--- a/tests/test_fluent_fixes.py
+++ b/tests/test_fluent_fixes.py
@@ -35,7 +35,6 @@ def test_allowed_values_on_report_definitions_1364(new_solver_session):
     assert report_def.expr_list.allowed_values() == None
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     solver_session = new_solver_session
 
@@ -88,7 +87,7 @@ def test_monitors_list_set_data_637_974_1744_2188(new_solver_session):
     ]
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_empty_vector_field_data_2339(new_solver_session):
     solver = new_solver_session
 

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -217,7 +217,6 @@ def test_fluent_freeze_kill(
     assert session._fluent_connection.wait_process_finished(wait=5)
 
 
-@pytest.mark.fluent_version(">=23.1")
 def test_interrupt(load_static_mixer_case):
     solver = load_static_mixer_case
     solver.setup.general.solver.time = "unsteady-2nd-order"

--- a/tests/test_fluent_version_marker.py
+++ b/tests/test_fluent_version_marker.py
@@ -5,7 +5,7 @@ def test_dev_fluent_any():
     pass
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_dev_fluent_latest():
     pass
 
@@ -41,7 +41,7 @@ def test_nightly_fluent_any():
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_nightly_fluent_latest():
     pass
 

--- a/tests/test_fluent_version_marker.py
+++ b/tests/test_fluent_version_marker.py
@@ -10,23 +10,28 @@ def test_dev_fluent_latest():
     pass
 
 
-@pytest.mark.fluent_version(">=24.1")
-def test_dev_fluent_ge_241():
+@pytest.mark.fluent_version("==24.2")
+def test_dev_fluent_242():
     pass
 
 
-@pytest.mark.fluent_version(">=23.2")
-def test_dev_fluent_ge_232():
+@pytest.mark.fluent_version("==24.1")
+def test_dev_fluent_241():
     pass
 
 
-@pytest.mark.fluent_version(">=23.1")
-def test_dev_fluent_ge_231():
+@pytest.mark.fluent_version("==23.2")
+def test_dev_fluent_232():
     pass
 
 
-@pytest.mark.fluent_version(">=22.2")
-def test_dev_fluent_ge_222():
+@pytest.mark.fluent_version("==23.1")
+def test_dev_fluent_231():
+    pass
+
+
+@pytest.mark.fluent_version("==22.2")
+def test_dev_fluent_222():
     pass
 
 
@@ -42,24 +47,24 @@ def test_nightly_fluent_latest():
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=24.1")
-def test_nightly_fluent_ge_241():
+@pytest.mark.fluent_version("==24.1")
+def test_nightly_fluent_241():
     pass
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.2")
-def test_nightly_fluent_ge_232():
+@pytest.mark.fluent_version("==23.2")
+def test_nightly_fluent_232():
     pass
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
-def test_nightly_fluent_ge_231():
+@pytest.mark.fluent_version("==23.1")
+def test_nightly_fluent_231():
     pass
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=22.2")
-def test_nightly_fluent_ge_222():
+@pytest.mark.fluent_version("==22.2")
+def test_nightly_fluent_222():
     pass

--- a/tests/test_icing_session.py
+++ b/tests/test_icing_session.py
@@ -1,9 +1,6 @@
-import pytest
-
 import ansys.fluent.core as pyfluent
 
 
-@pytest.mark.fluent_version(">=23.1")
 def test_icing_session():
     icing_session = pyfluent.launch_fluent(mode=pyfluent.FluentMode.SOLVER_ICING)
     assert "icing" in dir(icing_session)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -70,7 +70,7 @@ def test_unsuccessful_fluent_connection():
         pyfluent.launch_fluent(mode="solver", start_timeout=2)
 
 
-@pytest.mark.fluent_version("<24.1")
+@pytest.mark.fluent_version("==23.2")
 def test_non_gui_in_windows_throws_exception():
     default_windows_flag = launcher_utils.is_windows()
     launcher_utils.is_windows = lambda: True
@@ -97,7 +97,6 @@ def test_non_gui_in_windows_throws_exception():
         launcher_utils.is_windows = lambda: default_windows_flag
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_non_gui_in_windows_does_not_throw_exception():
     default_windows_flag = launcher_utils.is_windows()
     launcher_utils.is_windows = lambda: True
@@ -154,7 +153,6 @@ def test_case_load():
 
 
 @pytest.mark.standalone
-@pytest.mark.fluent_version(">=23.2")
 def test_case_lightweight_setup():
     # Test that launch_fluent() correctly performs lightweight setup
     _, cas_path = download_input_file(

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -137,7 +137,7 @@ class TransferRequestRecorder:
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_file_purpose_on_remote_instance(
     monkeypatch, new_solver_session, new_mesh_session
 ):

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -137,7 +137,7 @@ class TransferRequestRecorder:
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_file_purpose_on_remote_instance(
     monkeypatch, new_solver_session, new_mesh_session
 ):

--- a/tests/test_meshing_utilities.py
+++ b/tests/test_meshing_utilities.py
@@ -13,7 +13,7 @@ def pytest_approx(expected):
 
 @pytest.mark.codegen_required
 @pytest.mark.nightly
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_meshing_utilities(new_mesh_session):
     meshing_session = new_mesh_session
     meshing_session.tui.file.read_case(import_filename)

--- a/tests/test_meshing_utilities.py
+++ b/tests/test_meshing_utilities.py
@@ -13,7 +13,7 @@ def pytest_approx(expected):
 
 @pytest.mark.codegen_required
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_meshing_utilities(new_mesh_session):
     meshing_session = new_mesh_session
     meshing_session.tui.file.read_case(import_filename)

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -15,7 +15,6 @@ from ansys.fluent.core import examples
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.nightly
 @pytest.mark.codegen_required
 def test_mixing_elbow_meshing_workflow(
@@ -188,7 +187,6 @@ def test_meshing_workflow_raises_exception_on_invalid_key_in_task_args_2(
 """
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_command_args_datamodel_se(new_mesh_session):
     session_new = new_mesh_session
@@ -200,7 +198,6 @@ def test_command_args_datamodel_se(new_mesh_session):
     assert igt.arguments.CadImportOptions.OneZonePer.getAttribValue("default")
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     session_new = new_mesh_session
@@ -213,7 +210,6 @@ def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     assert igt.arguments.CadImportOptions.OneZonePer.getAttribValue("default")
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_attribute_query_list_types(new_mesh_session):
     session_new = new_mesh_session
@@ -223,7 +219,6 @@ def test_attribute_query_list_types(new_mesh_session):
     assert ["CAD", "Mesh"] == igt.arguments.FileFormat.getAttribValue("allowedValues")
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_accessors_for_argument_sub_items(new_mesh_session):
     session_new = new_mesh_session
@@ -305,7 +300,6 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
 
 
 @pytest.mark.skip("Wait for later implementation.")
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_read_only_behaviour_of_command_arguments(new_mesh_session):
     session_new = new_mesh_session
@@ -324,7 +318,6 @@ def test_read_only_behaviour_of_command_arguments(new_mesh_session):
     assert "set_state" in dir(m().NumParts)
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.codegen_required
 def test_sample_use_of_command_arguments(new_mesh_session):
     w = new_mesh_session.workflow
@@ -406,7 +399,6 @@ def test_nonexistent_attrs(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_old_workflow_structure(new_mesh_session):
     meshing = new_mesh_session
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
@@ -421,7 +413,7 @@ def test_old_workflow_structure(new_mesh_session):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_new_2d_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file("NACA0012.fmd", "pyfluent/airfoils")

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -413,7 +413,7 @@ def test_old_workflow_structure(new_mesh_session):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_new_2d_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file("NACA0012.fmd", "pyfluent/airfoils")

--- a/tests/test_meshingmode/test_meshing_launch.py
+++ b/tests/test_meshingmode/test_meshing_launch.py
@@ -5,7 +5,6 @@ from util.fixture_fluent import download_input_file
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version("latest")
 @pytest.mark.codegen_required
 def test_launch_pure_meshing(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -473,7 +473,7 @@ def test_new_fault_tolerant_workflow(new_mesh_session):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_new_2d_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file("NACA0012.fmd", "pyfluent/airfoils")
@@ -1218,7 +1218,7 @@ def test_new_meshing_workflow_without_dm_caching(
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_new_meshing_workflow_validate_arguments(new_mesh_session):
     watertight = new_mesh_session.watertight()
     watertight.create_regions.number_of_flow_volumes = 1

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -10,7 +10,6 @@ from tests.test_datamodel_service import disable_datamodel_cache  # noqa: F401
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.1")
 def test_new_watertight_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file(
@@ -82,7 +81,6 @@ def test_new_watertight_workflow(new_mesh_session):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.1")
 def test_new_fault_tolerant_workflow(new_mesh_session):
     meshing = new_mesh_session
 
@@ -475,7 +473,7 @@ def test_new_fault_tolerant_workflow(new_mesh_session):
 
 @pytest.mark.nightly
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_new_2d_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file("NACA0012.fmd", "pyfluent/airfoils")
@@ -591,7 +589,6 @@ def test_new_2d_meshing_workflow(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_updating_state_in_new_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file(
@@ -621,7 +618,6 @@ def _assert_snake_case_attrs(attrs: Iterable):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_snake_case_attrs_in_new_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file(
@@ -639,7 +635,6 @@ def test_snake_case_attrs_in_new_meshing_workflow(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.1")
 def test_workflow_and_data_model_methods_new_meshing_workflow(new_mesh_session):
     # Import geometry
     meshing = new_mesh_session
@@ -680,7 +675,6 @@ def test_workflow_and_data_model_methods_new_meshing_workflow(new_mesh_session):
     assert len(watertight._task_list) == 14
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_watertight_workflow(mixing_elbow_geometry, new_mesh_session):
     watertight = new_mesh_session.watertight()
@@ -698,7 +692,6 @@ def test_watertight_workflow(mixing_elbow_geometry, new_mesh_session):
     assert added_sizing.boi_face_label_list() == ["elbow-fluid"]
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_watertight_workflow_children(mixing_elbow_geometry, new_mesh_session):
     watertight = new_mesh_session.watertight()
@@ -734,7 +727,6 @@ def test_watertight_workflow_children(mixing_elbow_geometry, new_mesh_session):
 
 
 @pytest.mark.skip("Randomly failing in CI")
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_watertight_workflow_dynamic_interface(mixing_elbow_geometry, new_mesh_session):
     watertight = new_mesh_session.watertight()
@@ -792,7 +784,6 @@ def test_fault_tolerant_workflow(exhaust_system_geometry, new_mesh_session):
     import_cad()
 
 
-@pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_extended_wrapper(new_mesh_session, mixing_elbow_geometry):
     watertight = new_mesh_session.watertight()
@@ -839,7 +830,6 @@ def test_extended_wrapper(new_mesh_session, mixing_elbow_geometry):
     assert len(import_geometry_state) > 2
 
 
-@pytest.mark.fluent_version(">=23.1")
 @pytest.mark.skip
 def test_meshing_workflow_structure(new_mesh_session):
     """
@@ -1057,7 +1047,6 @@ def test_meshing_workflow_structure(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_new_workflow_structure(new_mesh_session):
     meshing = new_mesh_session
     watertight = meshing.watertight()
@@ -1068,7 +1057,6 @@ def test_new_workflow_structure(new_mesh_session):
 
 @pytest.mark.skip("Randomly failing in CI")
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_attrs_in_watertight_meshing_workflow(new_mesh_session):
     # Import geometry
     import_file_name = examples.download_file(
@@ -1094,7 +1082,6 @@ def test_attrs_in_watertight_meshing_workflow(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_ordered_children_in_enhanced_meshing_workflow(new_mesh_session):
     watertight = new_mesh_session.watertight()
     assert set([repr(x) for x in watertight.ordered_children()]) == {
@@ -1114,7 +1101,6 @@ def test_ordered_children_in_enhanced_meshing_workflow(new_mesh_session):
 
 @pytest.mark.skip("Randomly failing in CI")
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_attrs_in_fault_tolerant_meshing_workflow(new_mesh_session):
     # Import CAD
     import_file_name = examples.download_file(
@@ -1141,7 +1127,6 @@ def test_attrs_in_fault_tolerant_meshing_workflow(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.2")
 def test_switch_between_workflows(new_mesh_session):
     meshing = new_mesh_session
 
@@ -1194,7 +1179,6 @@ def test_switch_between_workflows(new_mesh_session):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.1")
 def test_new_meshing_workflow_without_dm_caching(
     disable_datamodel_cache, new_mesh_session
 ):
@@ -1234,7 +1218,7 @@ def test_new_meshing_workflow_without_dm_caching(
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_new_meshing_workflow_validate_arguments(new_mesh_session):
     watertight = new_mesh_session.watertight()
     watertight.create_regions.number_of_flow_volumes = 1

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -4,7 +4,6 @@ from ansys.fluent.core.examples import download_file
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.1")
 def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing
     # check a few dir elements
@@ -26,7 +25,6 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.1")
 def test_meshing_mode(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     # check a few dir elements
@@ -42,7 +40,6 @@ def test_meshing_mode(load_mixing_elbow_meshing):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.1")
 def test_meshing_and_solver_mode_exit(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     solver_session = meshing_session.switch_to_solver()
@@ -52,7 +49,6 @@ def test_meshing_and_solver_mode_exit(load_mixing_elbow_meshing):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version(">=23.1")
 def test_meshing_mode_post_switching_to_solver(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     meshing_session.switch_to_solver()

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -335,7 +335,6 @@ def _test_sum_if(solver):
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
 def test_reductions(load_static_mixer_case, load_static_mixer_case_2) -> None:
     solver1 = load_static_mixer_case
     solver2 = load_static_mixer_case_2
@@ -353,7 +352,7 @@ def test_reductions(load_static_mixer_case, load_static_mixer_case_2) -> None:
     _test_sum_if(solver1)
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_reduction_does_not_modify_case(load_static_mixer_case):
     solver = load_static_mixer_case
     assert not solver.scheme_eval.scheme_eval("(case-modified?)")
@@ -364,7 +363,7 @@ def test_reduction_does_not_modify_case(load_static_mixer_case):
     assert not solver.scheme_eval.scheme_eval("(case-modified?)")
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_fix_for_invalid_location_inputs(load_static_mixer_case):
     solver = load_static_mixer_case
     solver.solution.initialization.hybrid_initialize()

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -352,7 +352,7 @@ def test_reductions(load_static_mixer_case, load_static_mixer_case_2) -> None:
     _test_sum_if(solver1)
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_reduction_does_not_modify_case(load_static_mixer_case):
     solver = load_static_mixer_case
     assert not solver.scheme_eval.scheme_eval("(case-modified?)")
@@ -363,7 +363,7 @@ def test_reduction_does_not_modify_case(load_static_mixer_case):
     assert not solver.scheme_eval.scheme_eval("(case-modified?)")
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_fix_for_invalid_location_inputs(load_static_mixer_case):
     solver = load_static_mixer_case
     solver.solution.initialization.hybrid_initialize()

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -25,7 +25,7 @@ def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
     assert before_init_mod_2[1][1][1] == ("value", True)
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
     solver = new_solver_session_no_transcript

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -25,7 +25,7 @@ def test_get_and_set_rp_vars(new_solver_session_no_transcript) -> None:
     assert before_init_mod_2[1][1][1] == ("value", True)
 
 
-@pytest.mark.fluent_version(">=23.1, !=24.1")
+@pytest.mark.fluent_version("latest")
 def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
     solver = new_solver_session_no_transcript
@@ -49,7 +49,6 @@ def test_get_all_rp_vars(new_solver_session_no_transcript) -> None:
     assert len(case_vars) == pytest.approx(9000, 450)
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_rp_vars_allowed_values(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
     rp_vars = solver.rp_vars

--- a/tests/test_scheme_eval_231.py
+++ b/tests/test_scheme_eval_231.py
@@ -233,7 +233,6 @@ def test_two_way_conversion_for_pairs() -> None:
     assert val[1] == 5.0
 
 
-@pytest.mark.fluent_version(">=23.1")
 def test_long_list(new_solver_session) -> None:
     length = 10**6
     assert new_solver_session.scheme_eval.eval(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,7 +54,6 @@ def test_search(capsys):
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
 def test_get_version_path_prefix_from_obj(
     new_watertight_workflow_session, new_solver_session
 ):
@@ -126,7 +125,6 @@ def test_get_version_path_prefix_from_obj(
 
 
 @pytest.mark.codegen_required
-@pytest.mark.fluent_version("latest")
 def test_search_from_root(capsys, new_watertight_workflow_session):
     meshing = new_watertight_workflow_session
     pyfluent.search("display", search_root=meshing)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -285,7 +285,6 @@ def test_create_mock_session_from_launch_fluent_by_setting_ip_port_env_var(
 
 
 @pytest.mark.parametrize("file_format", ["jou", "py"])
-@pytest.mark.fluent_version(">=23.2")
 def test_journal_creation(file_format, new_mesh_session):
     fd, file_name = tempfile.mkstemp(
         suffix=f"-{os.getpid()}.{file_format}",
@@ -314,7 +313,6 @@ def test_journal_creation(file_format, new_mesh_session):
     assert new_stat.st_mtime > prev_mtime or new_stat.st_size > prev_size
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_start_transcript_file_write(new_mesh_session):
     fd, file_name = tempfile.mkstemp(
         suffix=f"-{os.getpid()}.trn",
@@ -339,20 +337,17 @@ def test_start_transcript_file_write(new_mesh_session):
     assert new_stat.st_mtime > prev_mtime or new_stat.st_size > prev_size
 
 
-@pytest.mark.fluent_version(">=23.1")
 def test_expected_interfaces_in_solver_session(new_solver_session):
     assert all(
         intf in dir(new_solver_session) for intf in ("preferences", "tui", "workflow")
     )
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_solverworkflow_not_in_solver_session(new_solver_session):
     assert "solverworkflow" not in dir(new_solver_session)
 
 
 @pytest.mark.standalone
-@pytest.mark.fluent_version(">=23.2")
 def test_read_case_using_lightweight_mode():
     import_file_name = examples.download_file(
         "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -464,7 +459,6 @@ def test_solver_methods(new_solver_session):
 
 
 @pytest.mark.skip("github issue: https://github.com/ansys/pyfluent/issues/2684")
-@pytest.mark.fluent_version(">=23.2")
 def test_get_set_state_on_solver(new_solver_session):
     solver = new_solver_session
     state = solver.get_state()

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -14,7 +14,6 @@ from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=23.1")
 def test_setup_models_viscous_model_settings(new_solver_session) -> None:
     solver_session = new_solver_session
     case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
@@ -33,7 +32,6 @@ def test_setup_models_viscous_model_settings(new_solver_session) -> None:
     assert viscous_model.model() == "inviscid"
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_wildcard(new_solver_session):
     solver = new_solver_session
     case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
@@ -95,7 +93,6 @@ def test_wildcard(new_solver_session):
         boundary_conditions.velocity_inlet["inl*"].moment
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_wildcard_fnmatch(new_solver_session):
     solver = new_solver_session
     case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
@@ -117,7 +114,6 @@ def test_wildcard_fnmatch(new_solver_session):
     assert sorted(mesh["mesh-[!2-5]"]()) == sorted(["mesh-1", "mesh-a"])
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_wildcard_path_is_iterable(new_solver_session):
     solver = new_solver_session
     case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
@@ -147,7 +143,6 @@ def test_wildcard_path_is_iterable(new_solver_session):
     assert test_data[1][1].path == r"setup/boundary-conditions/velocity-inlet/inlet1"
 
 
-@pytest.mark.fluent_version(">=23.1")
 def test_api_upgrade(new_solver_session, capsys):
     solver = new_solver_session
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")
@@ -155,7 +150,7 @@ def test_api_upgrade(new_solver_session, capsys):
     "<solver_session>.file.read_case" in capsys.readouterr().out
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_deprecated_settings(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
@@ -295,7 +290,7 @@ def test_deprecated_settings(new_solver_session):
     }
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_command_return_type(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
@@ -309,7 +304,7 @@ def test_command_return_type(new_solver_session):
     assert ret is not None
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_unstable_settings_warning(new_solver_session, recwarn):
     solver = new_solver_session
     solver.file.export
@@ -333,7 +328,7 @@ def test_unstable_settings_warning(new_solver_session, recwarn):
     # assert len(recwarn) == 0
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_generated_code_special_cases(new_solver_session):
     solver = new_solver_session
     icing_cls = solver.setup.boundary_conditions._child_classes[

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -150,7 +150,7 @@ def test_api_upgrade(new_solver_session, capsys):
     "<solver_session>.file.read_case" in capsys.readouterr().out
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_deprecated_settings(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
@@ -290,7 +290,7 @@ def test_deprecated_settings(new_solver_session):
     }
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_command_return_type(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
@@ -304,7 +304,7 @@ def test_command_return_type(new_solver_session):
     assert ret is not None
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_unstable_settings_warning(new_solver_session, recwarn):
     solver = new_solver_session
     solver.file.export
@@ -328,7 +328,7 @@ def test_unstable_settings_warning(new_solver_session, recwarn):
     # assert len(recwarn) == 0
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_generated_code_special_cases(new_solver_session):
     solver = new_solver_session
     icing_cls = solver.setup.boundary_conditions._child_classes[

--- a/tests/test_solution_variables.py
+++ b/tests/test_solution_variables.py
@@ -387,7 +387,7 @@ def test_svars_single_precision(new_solver_session_single_precision):
     assert str(fluid_temp.dtype) == "float32"
 
 
-@pytest.mark.fluent_version("latest")
+@pytest.mark.fluent_version("develop")
 def test_solution_variable_does_not_modify_case(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_solution_variables.py
+++ b/tests/test_solution_variables.py
@@ -9,7 +9,6 @@ from ansys.fluent.core import examples
 from ansys.fluent.core.examples.downloads import download_file
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_solution_variables(new_solver_session):
     solver = new_solver_session
     import_file_name = examples.download_file(
@@ -121,7 +120,6 @@ def test_solution_variables(new_solver_session):
     assert updated_sv_p_data["elbow-fluid"][-1] == 600.0
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_solution_variables_single_precision(new_solver_session_single_precision):
     solver = new_solver_session_single_precision
     import_file_name = examples.download_file(
@@ -202,7 +200,6 @@ def test_solution_variables_single_precision(new_solver_session_single_precision
     assert str(fluid_temp.dtype) == "float32"
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_svars(new_solver_session):
     solver = new_solver_session
     import_file_name = examples.download_file(
@@ -310,7 +307,6 @@ def test_svars(new_solver_session):
     assert updated_sv_p_data["elbow-fluid"][-1] == 600.0
 
 
-@pytest.mark.fluent_version(">=23.2")
 def test_svars_single_precision(new_solver_session_single_precision):
     solver = new_solver_session_single_precision
     import_file_name = examples.download_file(
@@ -391,7 +387,7 @@ def test_svars_single_precision(new_solver_session_single_precision):
     assert str(fluid_temp.dtype) == "float32"
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version("latest")
 def test_solution_variable_does_not_modify_case(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -8,7 +8,6 @@ from util.solver import SettingsValDict as D
 from util.solver import assign_settings_value_from_value_dict as assign_dict_val
 
 
-@pytest.mark.fluent_version(">=24.1")
 @pytest.mark.settings_only
 @pytest.mark.codegen_required
 def test_boundaries_elbow(load_mixing_elbow_settings_only):
@@ -75,7 +74,6 @@ def test_boundaries_elbow(load_mixing_elbow_settings_only):
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_boundaries_periodic(load_periodic_rot_settings_only):
     solver_session = load_periodic_rot_settings_only
     print(__file__)

--- a/tests/test_solvermode/test_calculationactivities.py
+++ b/tests/test_solvermode/test_calculationactivities.py
@@ -1,9 +1,6 @@
-import pytest
-
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
-@pytest.mark.fluent_version("latest")
 def test_solver_calculation(load_mixing_elbow_mesh):
     solver_session = load_mixing_elbow_mesh
     scheme_eval = solver_session.scheme_eval.scheme_eval

--- a/tests/test_solvermode/test_controls.py
+++ b/tests/test_solvermode/test_controls.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_controls(load_mixing_elbow_settings_only):
     solver = load_mixing_elbow_settings_only
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_general.py
+++ b/tests/test_solvermode/test_general.py
@@ -7,7 +7,6 @@ import ansys.fluent.core as pyfluent
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_solver_import_mixingelbow(load_mixing_elbow_settings_only):
     solver_session = load_mixing_elbow_settings_only
     assert solver_session.settings.is_active()
@@ -82,7 +81,6 @@ def test_solver_import_mixingelbow(load_mixing_elbow_settings_only):
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_disk_2d_setup(load_disk_settings_only):
     session = load_disk_settings_only
     assert session.settings.is_active()

--- a/tests/test_solvermode/test_initialization.py
+++ b/tests/test_solvermode/test_initialization.py
@@ -71,7 +71,6 @@ def test_initialization_settings(launch_fluent_solver_3ddp_t2):
     }
 
 
-@pytest.mark.fluent_version(">=24.1")
 def test_fmg_initialize(launch_fluent_solver_3ddp_t2):
     solver = launch_fluent_solver_3ddp_t2
     input_type, input_name = download_input_file(

--- a/tests/test_solvermode/test_materials.py
+++ b/tests/test_solvermode/test_materials.py
@@ -3,7 +3,6 @@ from util.solver import copy_database_material
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_solver_material(load_mixing_elbow_settings_only):
     solver_session = load_mixing_elbow_settings_only
     setup_materials = solver_session.setup.materials

--- a/tests/test_solvermode/test_methods.py
+++ b/tests/test_solvermode/test_methods.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_methods(load_mixing_elbow_settings_only):
     solver = load_mixing_elbow_settings_only
     solver.setup.models.multiphase.models = "vof"

--- a/tests/test_solvermode/test_models.py
+++ b/tests/test_solvermode/test_models.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_solver_models(load_mixing_elbow_settings_only):
     solver_session = load_mixing_elbow_settings_only
     models = solver_session.setup.models
@@ -22,7 +21,6 @@ def test_solver_models(load_mixing_elbow_settings_only):
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_disk_2d_models(load_disk_settings_only):
     solver_session = load_disk_settings_only
     models = solver_session.setup.models

--- a/tests/test_solvermode/test_named_expressions.py
+++ b/tests/test_solvermode/test_named_expressions.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version(">=24.1")
 def test_expression(load_mixing_elbow_settings_only):
     solver_session = load_mixing_elbow_settings_only
     # Case file already has energy model turned on

--- a/tests/test_solvermode/test_post_vector.py
+++ b/tests/test_solvermode/test_post_vector.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version("latest")
 def test_post_elbow(load_mixing_elbow_settings_only):
     load_mixing_elbow_settings_only.results.graphics.vector[
         "velocity_vector_symmetry"

--- a/tests/test_solvermode/test_species_model.py
+++ b/tests/test_solvermode/test_species_model.py
@@ -2,7 +2,6 @@ import pytest
 
 
 @pytest.mark.settings_only
-@pytest.mark.fluent_version(">=24.1")
 def test_change_create_mixture(load_mixing_elbow_settings_only):
     solver_session = load_mixing_elbow_settings_only
 


### PR DESCRIPTION
Following are the 3 categories of unittests:

1. **Tests which do not require to run Fluent at all or can be run with any stable Fluent version:**  Such tests aren't marked with the `fluent_version` marker and will be run only with the latest released Fluent version during PRs and with the latest released and the current development Fluent versions during nightly. If these tests get broken due to a recent Fluent API change, that will be caught during nightly.
2.  **Tests which depend on the current development Fluent version or are tracking Fluent API change:** Such tests are marked as `fluent_version("develop")` and will be run only with the current development Fluent version.
3. **Tests which depend on a specific released Fluent version:** Such tests are marked as `fluent_version("==<version>")` and will be run only with that specific Fluent version.

After this PR is merged, we only need to add the `fluent_version` marker for tests which depends on the current development Fluent version or a specific released Fluent version. We should make sure a test is not marked to run with more than one Fluent version unless there is very specific scenario.