### PR TITLE
fix: pyzmq version fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pandas = "^1.1.5"
 platformdirs = "^3.5.1"
 psutil = "^5.9.5"
 pyyaml = "^6.0"
+pyzmq = "^26.0.2"
 requests = "^2.31.0"
 
 [tool.poetry.group.docs]


### PR DESCRIPTION
Trying to resolve following error. (is occurring in every PR)

![image](https://github.com/ansys/pyfluent/assets/106588300/e4e40abf-047e-4c1b-be68-90798a3e4163)
