### PR TITLE
fix: Delete files inside examples folder for nightly doc build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,5 +22,5 @@ help:
 clean:
 	rm -rf build_errors.txt
 	rm -rf $(BUILDDIR)/*
-	rm -rf $(SOURCEDIR)/examples
+	rm -rf $(SOURCEDIR)/examples/*
 	find . -type d -name "_autosummary" -exec rm -rf {} +

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -34,7 +34,7 @@ goto end
 
 :clean
 rmdir /s /q %BUILDDIR% > /NUL 2>&1
-rmdir /s /q %SOURCEDIR%\examples > /NUL 2>&1
+del /q %SOURCEDIR%\examples\* > /NUL 2>&1
 for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
 del build_errors.txt > /NUL 2>&1
 goto end


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2733

Do not delete `examples` folder.