### PR TITLE
fix: nightly dev doc import fix

### DIFF
--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -8,6 +8,7 @@ from rstgen import _get_file_or_folder, _write_datamodel_index_doc, generate
 def generate_meshing_datamodels():
     """Generate meshing datamodel RST files."""
     meshing_datamodel_roots = []
+    available_datamodels = []
     meshing_datamodels = [
         "meshing",
         "MeshingUtilities",
@@ -23,12 +24,11 @@ def generate_meshing_datamodels():
             )
             if datamodel:
                 meshing_datamodel_roots.append(datamodel.Root)
-            else:
-                meshing_datamodels.remove(meshing_datamodel)
+                available_datamodels.append(meshing_datamodel)
         except ModuleNotFoundError:
             pass
-            meshing_datamodel_roots.append(datamodel.Root)
-    _write_datamodel_index_doc(meshing_datamodels, "meshing")
+    print(available_datamodels)
+    _write_datamodel_index_doc(available_datamodels, "meshing")
     for root in meshing_datamodel_roots:
         generate(main_menu=root, mode="meshing", is_datamodel=True)
 

--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -17,11 +17,18 @@ def generate_meshing_datamodels():
         "workflow",
     ]
     for meshing_datamodel in meshing_datamodels:
-        datamodel = importlib.import_module(
-            f"ansys.fluent.core.{_get_file_or_folder(mode='meshing', is_datamodel=True)}.{meshing_datamodel}"
-        )
-        meshing_datamodel_roots.append(datamodel.Root)
-        _write_datamodel_index_doc(meshing_datamodels, "meshing")
+        try:
+            datamodel = importlib.import_module(
+                f"ansys.fluent.core.{_get_file_or_folder(mode='meshing', is_datamodel=True)}.{meshing_datamodel}"
+            )
+            if datamodel:
+                meshing_datamodel_roots.append(datamodel.Root)
+            else:
+                meshing_datamodels.remove(meshing_datamodel)
+        except ModuleNotFoundError:
+            pass
+            meshing_datamodel_roots.append(datamodel.Root)
+    _write_datamodel_index_doc(meshing_datamodels, "meshing")
     for root in meshing_datamodel_roots:
         generate(main_menu=root, mode="meshing", is_datamodel=True)
 
@@ -31,11 +38,17 @@ def generate_solver_datamodels():
     solver_datamodel_roots = []
     solver_datamodels = ["flicing", "preferences", "solverworkflow", "workflow"]
     for solver_datamodel in solver_datamodels:
-        datamodel = importlib.import_module(
-            f"ansys.fluent.core.{_get_file_or_folder(mode='solver', is_datamodel=True)}.{solver_datamodel}"
-        )
-        solver_datamodel_roots.append(datamodel.Root)
-        _write_datamodel_index_doc(solver_datamodels, "solver")
+        try:
+            datamodel = importlib.import_module(
+                f"ansys.fluent.core.{_get_file_or_folder(mode='solver', is_datamodel=True)}.{solver_datamodel}"
+            )
+            if datamodel:
+                solver_datamodel_roots.append(datamodel.Root)
+            else:
+                solver_datamodels.remove(solver_datamodel)
+        except ModuleNotFoundError:
+            pass
+    _write_datamodel_index_doc(solver_datamodels, "solver")
     for root in solver_datamodel_roots:
         generate(main_menu=root, mode="solver", is_datamodel=True)
 

--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -27,7 +27,6 @@ def generate_meshing_datamodels():
                 available_datamodels.append(meshing_datamodel)
         except ModuleNotFoundError:
             pass
-    print(available_datamodels)
     _write_datamodel_index_doc(available_datamodels, "meshing")
     for root in meshing_datamodel_roots:
         generate(main_menu=root, mode="meshing", is_datamodel=True)
@@ -36,6 +35,7 @@ def generate_meshing_datamodels():
 def generate_solver_datamodels():
     """Generate solver datamodel RST files."""
     solver_datamodel_roots = []
+    available_datamodels = []
     solver_datamodels = ["flicing", "preferences", "solverworkflow", "workflow"]
     for solver_datamodel in solver_datamodels:
         try:
@@ -44,11 +44,10 @@ def generate_solver_datamodels():
             )
             if datamodel:
                 solver_datamodel_roots.append(datamodel.Root)
-            else:
-                solver_datamodels.remove(solver_datamodel)
+                available_datamodels.append(solver_datamodel)
         except ModuleNotFoundError:
             pass
-    _write_datamodel_index_doc(solver_datamodels, "solver")
+    _write_datamodel_index_doc(available_datamodels, "solver")
     for root in solver_datamodel_roots:
         generate(main_menu=root, mode="solver", is_datamodel=True)
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2746

`MeshingUtilities` is available for >= 24R2 only. 

We have handled this condition now.

Nightly dev doc is working fine now.

![image](https://github.com/ansys/pyfluent/assets/106588300/1e196b23-0704-4b7a-a6c3-d1369dc43116)
