### PR TITLE
fix: Disable Local FTS for Standalone Launcher and fix for `ui_mode` argument

### DIFF
--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -252,12 +252,15 @@ def _get_standalone_launch_fluent_version(
 
 
 def _get_ui_mode(
+    ui_mode: UIMode,
     show_gui: Optional[bool] = None,
 ):
     """Get the graphics driver.
 
     Parameters
     ----------
+    ui_mode: UIMode
+        Fluent GUI mode.
     show_gui: bool
         Whether to show the Fluent GUI.
 
@@ -266,7 +269,6 @@ def _get_ui_mode(
     ui_mode: UIMode
         Fluent GUI mode.
     """
-    ui_mode = None
     if show_gui is not None:
         warnings.warn(
             "'show_gui' is deprecated. Use 'ui_mode' instead.",

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -47,7 +47,6 @@ from ansys.fluent.core.launcher.server_info import (
     _get_server_info_file_name,
 )
 import ansys.fluent.core.launcher.watchdog as watchdog
-from ansys.fluent.core.utils.file_transfer_service import LocalFileTransferStrategy
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 logger = logging.getLogger("pyfluent.launcher")
@@ -197,11 +196,7 @@ class StandaloneLauncher:
             setattr(self, arg_name, arg_values)
         self.argvals = argvals
         self.new_session = self.mode.value[0]
-        self.file_transfer_service = (
-            file_transfer_service
-            if file_transfer_service
-            else LocalFileTransferStrategy(server_cwd=argvals["cwd"])
-        )
+        self.file_transfer_service = file_transfer_service
 
     def __call__(self):
         if self.lightweight_mode is None:

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -185,7 +185,7 @@ class StandaloneLauncher:
         """
         _validate_gpu(gpu, version)
         graphics_driver = _get_graphics_driver(graphics_driver)
-        ui_mode = _get_ui_mode(show_gui)
+        ui_mode = _get_ui_mode(show_gui, ui_mode)
         del show_gui
         mode = _get_mode(mode)
         argvals = locals().copy()


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2753, https://github.com/ansys/pyfluent/issues/2754

Disable local FTS for standalone launcher.

This is due to specific case of `read_case_data` where we specify single file path but we need to move 2 files to Fluent's cwd.

`ui_mode` argument is fixed now.