### PR TITLE
fix a typo in variable name

### DIFF
--- a/src/ansys/fluent/core/systemcoupling.py
+++ b/src/ansys/fluent/core/systemcoupling.py
@@ -116,7 +116,7 @@ class SystemCoupling:
 
             ext_vars = {
                 "force",
-                "lortentz-force",
+                "lorentz-force",
                 "heatrate",
                 "heatflow",
                 "mass-flow-rate",


### PR DESCRIPTION
Variable was mistakenly named `lortentz-force`. In practice, this section of the code should never be reached, but it is there to guard against missing information in the SCP file.