### PR TITLE
fix:  `show_gui` and `ui_mode` value swap

### DIFF
--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -252,17 +252,17 @@ def _get_standalone_launch_fluent_version(
 
 
 def _get_ui_mode(
+    show_gui: bool,
     ui_mode: UIMode,
-    show_gui: Optional[bool] = None,
 ):
     """Get the graphics driver.
 
     Parameters
     ----------
-    ui_mode: UIMode
-        Fluent GUI mode.
     show_gui: bool
         Whether to show the Fluent GUI.
+    ui_mode: UIMode
+        Fluent GUI mode.
 
     Returns
     -------


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2773 https://github.com/ansys/pyfluent/issues/2754

`show_gui` and `ui_mode` values were swapping. It's resolved now.

![image](https://github.com/ansys/pyfluent/assets/106588300/d6c43b67-9fc0-443e-b971-1c3101b3d149)
