### PR TITLE
fix: Fix for `test_remote_grpc_fts_container` and nightly dev doc

### DIFF
--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -20,7 +20,7 @@ def generate_meshing_datamodels():
     for meshing_datamodel in meshing_datamodels:
         try:
             datamodel = importlib.import_module(
-                f"ansys.fluent.core.{_get_file_or_folder(mode='meshing', is_datamodel=True)}.{meshing_datamodel}"
+                f"ansys.fluent.core.generated.{_get_file_or_folder(mode='meshing', is_datamodel=True)}.{meshing_datamodel}"
             )
             if datamodel:
                 meshing_datamodel_roots.append(datamodel.Root)
@@ -40,7 +40,7 @@ def generate_solver_datamodels():
     for solver_datamodel in solver_datamodels:
         try:
             datamodel = importlib.import_module(
-                f"ansys.fluent.core.{_get_file_or_folder(mode='solver', is_datamodel=True)}.{solver_datamodel}"
+                f"ansys.fluent.core.generated.{_get_file_or_folder(mode='solver', is_datamodel=True)}.{solver_datamodel}"
             )
             if datamodel:
                 solver_datamodel_roots.append(datamodel.Root)

--- a/doc/tui_rstgen.py
+++ b/doc/tui_rstgen.py
@@ -7,14 +7,14 @@ from rstgen import _get_file_or_folder, generate
 if __name__ == "__main__":
     try:
         meshing_tui = importlib.import_module(
-            f"ansys.fluent.core.meshing.{_get_file_or_folder(mode='meshing', is_datamodel=False)}"
+            f"ansys.fluent.core.generated.meshing.{_get_file_or_folder(mode='meshing', is_datamodel=False)}"
         )
         generate(main_menu=meshing_tui.main_menu, mode="meshing", is_datamodel=False)
     except ModuleNotFoundError:
         pass
     try:
         solver_tui = importlib.import_module(
-            f"ansys.fluent.core.solver.{_get_file_or_folder(mode='solver', is_datamodel=False)}"
+            f"ansys.fluent.core.generated.solver.{_get_file_or_folder(mode='solver', is_datamodel=False)}"
         )
         generate(main_menu=solver_tui.main_menu, mode="solver", is_datamodel=False)
     except ModuleNotFoundError:

--- a/doc/tui_rstgen.py
+++ b/doc/tui_rstgen.py
@@ -5,11 +5,17 @@ import importlib
 from rstgen import _get_file_or_folder, generate
 
 if __name__ == "__main__":
-    meshing_tui = importlib.import_module(
-        f"ansys.fluent.core.meshing.{_get_file_or_folder(mode='meshing', is_datamodel=False)}"
-    )
-    generate(main_menu=meshing_tui.main_menu, mode="meshing", is_datamodel=False)
-    solver_tui = importlib.import_module(
-        f"ansys.fluent.core.solver.{_get_file_or_folder(mode='solver', is_datamodel=False)}"
-    )
-    generate(main_menu=solver_tui.main_menu, mode="solver", is_datamodel=False)
+    try:
+        meshing_tui = importlib.import_module(
+            f"ansys.fluent.core.meshing.{_get_file_or_folder(mode='meshing', is_datamodel=False)}"
+        )
+        generate(main_menu=meshing_tui.main_menu, mode="meshing", is_datamodel=False)
+    except ModuleNotFoundError:
+        pass
+    try:
+        solver_tui = importlib.import_module(
+            f"ansys.fluent.core.solver.{_get_file_or_folder(mode='solver', is_datamodel=False)}"
+        )
+        generate(main_menu=solver_tui.main_menu, mode="solver", is_datamodel=False)
+    except ModuleNotFoundError:
+        pass

--- a/tests/test_file_transfer_service.py
+++ b/tests/test_file_transfer_service.py
@@ -40,14 +40,16 @@ def file_downloaded_to_the_client(file_name: str) -> bool:
 def test_remote_grpc_fts_container(monkeypatch, new_solver_session, new_mesh_session):
     solver = new_solver_session
     solver.file.read_case(file_name=import_case_file_name)
-    solver.file.write_case(file_name="downloaded_solver_mixing_elbow.cas.h5")
     if solver._file_transfer_service:
+        solver.file.write_case(file_name="downloaded_solver_mixing_elbow.cas.h5")
         assert solver.file_exists_on_remote("downloaded_solver_mixing_elbow.cas.h5")
-    assert file_downloaded_to_the_client("downloaded_solver_mixing_elbow.cas.h5")
+        assert file_downloaded_to_the_client("downloaded_solver_mixing_elbow.cas.h5")
 
     meshing = new_mesh_session
     meshing.meshing.File.ReadMesh(FileName=import_mesh_file_name)
-    meshing.meshing.File.WriteMesh(FileName="downloaded_meshing_mixing_elbow.msh.h5")
     if meshing._file_transfer_service:
+        meshing.meshing.File.WriteMesh(
+            FileName="downloaded_meshing_mixing_elbow.msh.h5"
+        )
         assert meshing.file_exists_on_remote("downloaded_meshing_mixing_elbow.msh.h5")
-    assert file_downloaded_to_the_client("downloaded_meshing_mixing_elbow.msh.h5")
+        assert file_downloaded_to_the_client("downloaded_meshing_mixing_elbow.msh.h5")


### PR DESCRIPTION
Closes https://github.com/ansys/pyfluent/issues/2786, https://github.com/ansys/pyfluent/issues/2788

1. Fix for Nightly Dev Doc.

![image](https://github.com/ansys/pyfluent/assets/106588300/e24a9107-2f6b-4156-b3d6-30d64a07a026)

2. `test_remote_grpc_fts_container` was failing in Nightly Dev Test, it's fixed now.

![image](https://github.com/ansys/pyfluent/assets/106588300/f6b9bf1a-92ef-41ea-9bc0-3a9efc7a8a9e)

