### PR TITLE
refactor: Revert datamodel set_state changes.

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -886,15 +886,9 @@ class PyStateContainer(PyCallableStateObject):
 
         Raises
         ------
-        TypeError
-            If no arguments are provided to the ``set_state()`` method.
         ReadOnlyObjectError
             If the object is read-only.
         """
-        if state is None and not kwargs:
-            raise TypeError(
-                "The `set_state()` method requires either 'state' or 'kwargs' arguments."
-            )
         if self.get_attr(Attribute.IS_READ_ONLY.value):
             raise ReadOnlyObjectError(type(self).__name__)
         self.service.set_state(

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -576,18 +576,3 @@ def test_new_2d_meshing_workflow(new_mesh_session):
     # Switch to solution mode
     solver = meshing.switch_to_solver()
     assert solver
-
-
-@pytest.mark.fluent_version(">=23.2")
-def test_set_state_behavior(new_mesh_session):
-    meshing = new_mesh_session
-    assert not meshing.meshing.GlobalSettings.EnableOversetMeshing()
-    meshing.meshing.GlobalSettings.EnableOversetMeshing.set_state(True)
-    assert meshing.meshing.GlobalSettings.EnableOversetMeshing()
-
-    meshing.meshing.GlobalSettings.set_state(EnableOversetMeshing=False)
-    assert not meshing.meshing.GlobalSettings.EnableOversetMeshing()
-    with pytest.raises(TypeError):
-        meshing.meshing.GlobalSettings.set_state()
-    with pytest.raises(TypeError):
-        meshing.meshing.GlobalSettings.EnableOversetMeshing.set_state()


### PR DESCRIPTION
'set_state' method was updated to work with arguments but actually set_state() should also work and this behaviour is also there in flobject -> Group class's set_state()

The earlier changes are reverted.