### PR TITLE
fix: launcher additional arguments

### DIFF
--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -54,6 +54,7 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
                 argval = fluent_map[json_key]
             launch_args_string += v["fluent_format"].replace("{}", str(argval))
     addArgs = kwargs["additional_arguments"]
+    launch_args_string += " " + addArgs
     if "-t" not in addArgs and "-cnf=" not in addArgs:
         parallel_options = build_parallel_options(
             load_machines(ncores=kwargs["processor_count"])
@@ -79,7 +80,6 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
 def _generate_launch_string(
     argvals,
     mode: FluentMode,
-    additional_arguments: str,
     server_info_file_name: str,
 ):
     """Generates the launch string to launch fluent."""
@@ -95,8 +95,6 @@ def _generate_launch_string(
     launch_string += _build_fluent_launch_args_string(**argvals)
     if FluentMode.is_meshing(mode):
         launch_string += " -meshing"
-    if additional_arguments:
-        launch_string += f" {additional_arguments}"
     if " " in server_info_file_name:
         server_info_file_name = '"' + server_info_file_name + '"'
     launch_string += f" -sifile={server_info_file_name}"

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -54,7 +54,8 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
                 argval = fluent_map[json_key]
             launch_args_string += v["fluent_format"].replace("{}", str(argval))
     addArgs = kwargs["additional_arguments"]
-    launch_args_string += " " + addArgs
+    if addArgs:
+        launch_args_string += " " + addArgs
     if "-t" not in addArgs and "-cnf=" not in addArgs:
         parallel_options = build_parallel_options(
             load_machines(ncores=kwargs["processor_count"])

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -53,10 +53,10 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
                     json_key = json.dumps(argval)
                 argval = fluent_map[json_key]
             launch_args_string += v["fluent_format"].replace("{}", str(argval))
-    addArgs = kwargs["additional_arguments"]
-    if addArgs:
-        launch_args_string += " " + addArgs
-    if "-t" not in addArgs and "-cnf=" not in addArgs:
+    additional_arguments = kwargs["additional_arguments"]
+    if additional_arguments:
+        launch_args_string += " " + additional_arguments
+    if "-t" not in additional_arguments and "-cnf=" not in additional_arguments:
         parallel_options = build_parallel_options(
             load_machines(ncores=kwargs["processor_count"])
         )

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -214,7 +214,6 @@ class SlurmLauncher:
         launch_cmd = _generate_launch_string(
             self._argvals,
             self.mode,
-            self._additional_arguments,
             self._server_info_file_name,
         )
 

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -206,7 +206,6 @@ class StandaloneLauncher:
         launch_string = _generate_launch_string(
             self.argvals,
             self.mode,
-            self.additional_arguments,
             server_info_file_name,
         )
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -422,14 +422,11 @@ def test_exposure_and_graphics_driver_arguments():
     with pytest.raises(ValueError):
         pyfluent.launch_fluent(graphics_driver="x11" if is_windows() else "dx11")
     for m in UIMode:
-        assert (
-            _build_fluent_launch_args_string(
-                ui_mode=m, additional_arguments="", processor_count=None
-            ).strip()
-            == f"3ddp -{m.value[0]}"
-            if m.value[0]
-            else " 3ddp"
-        )
+        string1 = _build_fluent_launch_args_string(
+            ui_mode=m, additional_arguments="", processor_count=None
+        ).strip()
+        string2 = f"3ddp -{m.value[0]}" if m.value[0] else "3ddp"
+        assert string1 == string2
     for e in (FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver):
         for m in e:
             assert (


### PR DESCRIPTION
`additional_arguments` was being evaluated in two different places: `_build_fluent_launch_args_string` and `_generate_launch_string`, and wasn't being passed properly to the container launcher

`additional_arguments` is also repeated inside `self.argvals` and `self.additional_arguments` in the launchers, not sure why, not changed in this PR

The suggestion in this PR is to evaluate `additional_arguments` only in `_build_fluent_launch_args_string`, so that it is also applicable to container launchers and not only launchers that call `_generate_launch_string` (slurm and standalone launchers currently)