### PR TITLE
refactor: using blacklist approach instead of whitelist for launch args

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -60,68 +60,43 @@ def create_launcher(fluent_launch_mode: LaunchMode = None, **kwargs):
     """
     _process_invalid_args(kwargs["dry_run"], fluent_launch_mode, kwargs)
     if fluent_launch_mode == LaunchMode.STANDALONE:
-        return StandaloneLauncher(
-            mode=kwargs["mode"],
-            ui_mode=kwargs["ui_mode"],
-            graphics_driver=kwargs["graphics_driver"],
-            product_version=kwargs["product_version"],
-            version=kwargs["version"],
-            precision=kwargs["precision"],
-            processor_count=kwargs["processor_count"],
-            journal_file_names=kwargs["journal_file_names"],
-            start_timeout=kwargs["start_timeout"],
-            additional_arguments=kwargs["additional_arguments"],
-            env=kwargs["env"],
-            cleanup_on_exit=kwargs["cleanup_on_exit"],
-            start_transcript=kwargs["start_transcript"],
-            case_file_name=kwargs["case_file_name"],
-            case_data_file_name=kwargs["case_data_file_name"],
-            lightweight_mode=kwargs["lightweight_mode"],
-            py=kwargs["py"],
-            gpu=kwargs["gpu"],
-            cwd=kwargs["cwd"],
-            topy=kwargs["topy"],
-            start_watchdog=kwargs["start_watchdog"],
-            file_transfer_service=kwargs["file_transfer_service"],
-        )
+        unsupported_args = ["container_dict", "dry_run", "scheduler_options"]
+        for arg_name in unsupported_args:
+            if arg_name in kwargs:
+                kwargs.pop(arg_name)
+        return StandaloneLauncher(**kwargs)
     elif fluent_launch_mode == LaunchMode.CONTAINER:
-        return DockerLauncher(
-            mode=kwargs["mode"],
-            ui_mode=kwargs["ui_mode"],
-            graphics_driver=kwargs["graphics_driver"],
-            product_version=kwargs["product_version"],
-            version=kwargs["version"],
-            precision=kwargs["precision"],
-            processor_count=kwargs["processor_count"],
-            start_timeout=kwargs["start_timeout"],
-            additional_arguments=kwargs["additional_arguments"],
-            container_dict=kwargs["container_dict"],
-            dry_run=kwargs["dry_run"],
-            cleanup_on_exit=kwargs["cleanup_on_exit"],
-            start_transcript=kwargs["start_transcript"],
-            py=kwargs["py"],
-            gpu=kwargs["gpu"],
-            start_watchdog=kwargs["start_watchdog"],
-            file_transfer_service=kwargs["file_transfer_service"],
-        )
+        unsupported_args = [
+            "journal_file_names",
+            "env",
+            "case_file_name",
+            "case_data_file_name",
+            "lightweight_mode",
+            "cwd",
+            "topy",
+            "scheduler_options",
+        ]
+        for arg_name in unsupported_args:
+            if arg_name in kwargs:
+                kwargs.pop(arg_name)
+        return DockerLauncher(**kwargs)
     elif fluent_launch_mode == LaunchMode.PIM:
-        return PIMLauncher(
-            mode=kwargs["mode"],
-            ui_mode=kwargs["ui_mode"],
-            graphics_driver=kwargs["graphics_driver"],
-            product_version=kwargs["product_version"],
-            version=kwargs["version"],
-            precision=kwargs["precision"],
-            processor_count=kwargs["processor_count"],
-            start_timeout=kwargs["start_timeout"],
-            additional_arguments=kwargs["additional_arguments"],
-            cleanup_on_exit=kwargs["cleanup_on_exit"],
-            start_transcript=kwargs["start_transcript"],
-            py=kwargs["py"],
-            gpu=kwargs["gpu"],
-            start_watchdog=kwargs["start_watchdog"],
-            file_transfer_service=kwargs["file_transfer_service"],
-        )
+        unsupported_args = [
+            "journal_file_names",
+            "env",
+            "container_dict",
+            "dry_run",
+            "case_file_name",
+            "case_data_file_name",
+            "lightweight_mode",
+            "cwd",
+            "topy",
+            "scheduler_options",
+        ]
+        for arg_name in unsupported_args:
+            if arg_name in kwargs:
+                kwargs.pop(arg_name)
+        return PIMLauncher(**kwargs)
     elif fluent_launch_mode == LaunchMode.SLURM:
         return SlurmLauncher(**kwargs)
 


### PR DESCRIPTION
Suggestion for #2822, from https://github.com/ansys/pyfluent/pull/2822#discussion_r1601721601, merges into that PR

Additional benefit is that it becomes easier to be aware of which arguments exactly are _not_ supported by each launcher, just by looking at the code (work to be done to add support for some of these unsupported arguments?).

Edit: @hpohekar unintentionally exposed another reason to use this suggested approach instead of the current implementation, see: https://github.com/ansys/pyfluent/pull/2826#discussion_r1603013555, in addition to issues where `create_launcher()` isn't currently set up to be directly exposed to users (unrelated to these changes, issue tracker: https://github.com/ansys/pyfluent/issues/2827).