### PR TITLE
fix: Support search_root properly with dynamic-path module import

### DIFF
--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -50,7 +50,7 @@ def _get_datamodel_attributes(session, attribute: str):
         from ansys.fluent.core import CODEGEN_OUTDIR
 
         preferences_module = load_module(
-            attribute,
+            f"{attribute}_{session._version}",
             CODEGEN_OUTDIR / f"datamodel_{session._version}" / f"{attribute}.py",
         )
         return preferences_module.Root(session._se_service, attribute, [])

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -81,7 +81,7 @@ class BaseMeshing:
                 from ansys.fluent.core import CODEGEN_OUTDIR
 
                 tui_module = load_module(
-                    f"tui_{self._version}",
+                    f"meshing_tui_{self._version}",
                     CODEGEN_OUTDIR / "meshing" / f"tui_{self._version}.py",
                 )
                 self._tui = tui_module.main_menu(
@@ -99,7 +99,8 @@ class BaseMeshing:
             from ansys.fluent.core import CODEGEN_OUTDIR
 
             meshing_module = load_module(
-                "meshing", CODEGEN_OUTDIR / f"datamodel_{self._version}" / "meshing.py"
+                f"meshing_{self._version}",
+                CODEGEN_OUTDIR / f"datamodel_{self._version}" / "meshing.py",
             )
             meshing_root = meshing_module.Root(self._se_service, "meshing", [])
         except ImportError:
@@ -122,7 +123,7 @@ class BaseMeshing:
                 from ansys.fluent.core import CODEGEN_OUTDIR
 
                 meshing_utilities_module = load_module(
-                    "MeshingUtilities",
+                    f"MeshingUtilities_{self._version}",
                     CODEGEN_OUTDIR
                     / f"datamodel_{self._version}"
                     / "MeshingUtilities.py",
@@ -152,7 +153,7 @@ class BaseMeshing:
             from ansys.fluent.core import CODEGEN_OUTDIR
 
             workflow_module = load_module(
-                "workflow",
+                f"workflow_{self._version}",
                 CODEGEN_OUTDIR / f"datamodel_{self._version}" / "workflow.py",
             )
             workflow_se = workflow_module.Root(self._se_service, "workflow", [])
@@ -248,7 +249,7 @@ class BaseMeshing:
                 from ansys.fluent.core import CODEGEN_OUTDIR
 
                 pm_module = load_module(
-                    "PartManagement",
+                    f"PartManagement_{self._version}",
                     CODEGEN_OUTDIR / f"datamodel_{self._version}" / "PartManagement.py",
                 )
                 self._part_management = pm_module.Root(
@@ -269,7 +270,7 @@ class BaseMeshing:
                 from ansys.fluent.core import CODEGEN_OUTDIR
 
                 pmfm_module = load_module(
-                    "PMFileManagement",
+                    f"PMFileManagement_{self._version}",
                     CODEGEN_OUTDIR
                     / f"datamodel_{self._version}"
                     / "PMFileManagement.py",

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -185,7 +185,7 @@ class Solver(BaseSession):
                 from ansys.fluent.core import CODEGEN_OUTDIR
 
                 tui_module = load_module(
-                    f"tui_{self._version}",
+                    f"solver_tui_{self._version}",
                     CODEGEN_OUTDIR / "solver" / f"tui_{self._version}.py",
                 )
                 self._tui = tui_module.main_menu(
@@ -203,7 +203,7 @@ class Solver(BaseSession):
             from ansys.fluent.core import CODEGEN_OUTDIR
 
             workflow_module = load_module(
-                "workflow",
+                f"workflow_{self._version}",
                 CODEGEN_OUTDIR / f"datamodel_{self._version}" / "workflow.py",
             )
             workflow_se = workflow_module.Root(self._se_service, "workflow", [])

--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -64,28 +64,43 @@ def _get_version_path_prefix_from_obj(obj: Any):
         version = get_version_for_file_name(obj.get_fluent_version().value)
         prefix = "<search_root>"
     elif isinstance(obj, TUIMenu):
-        path = ["<session>", "tui"]
-        path.extend(obj._path)
         module = obj.__class__.__module__
+        path = [
+            (
+                "<meshing_session>"
+                if module.startswith("meshing")
+                else "<solver_session>"
+            ),
+            "tui",
+        ]
+        path.extend(obj._path)
         version = module.rsplit("_", 1)[-1]
         prefix = "<search_root>"
     elif isinstance(obj, (ClassicWorkflow, Workflow)):
         path = ["<meshing_session>", obj.rules]
+        module = obj._workflow.__class__.__module__
+        version = module.rsplit("_", 1)[-1]
         prefix = "<search_root>"
     elif isinstance(obj, BaseTask):
         path = ["<meshing_session>", obj.rules]
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        module = obj._workflow.__class__.__module__
+        version = module.rsplit("_", 1)[-1]
         prefix = "<search_root>"
     elif isinstance(obj, TaskContainer):
         path = ["<meshing_session>", obj.rules]
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         path[-1] = f"{path[-1]}:<name>"
+        module = obj._container._workflow.__class__.__module__
+        version = module.rsplit("_", 1)[-1]
         prefix = '<search_root>["<name>"]'
     elif isinstance(obj, PyMenu):
         rules = obj.rules
         path = ["<meshing_session>" if rules in _meshing_rules else "<solver_session>"]
         path.append(rules)
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
+        module = obj.__class__.__module__
+        version = module.rsplit("_", 1)[-1]
         prefix = "<search_root>"
     elif isinstance(obj, PyNamedObjectContainer):
         rules = obj.rules
@@ -93,6 +108,8 @@ def _get_version_path_prefix_from_obj(obj: Any):
         path.append(rules)
         path.extend([f"{k[0]}:<name>" if k[1] else k[0] for k in obj.path])
         path[-1] = f"{path[-1]}:<name>"
+        module = obj.__class__.__module__
+        version = module.rsplit("_", 1)[-1]
         prefix = '<search_root>["<name>"]'
     elif isinstance(obj, flobject.Group):
         module = obj.__class__.__module__
@@ -193,11 +210,6 @@ def search(
             path = prefix
         while root_path:
             p = root_path.pop(0)
-            # With the dynamic loading of generated api modules, we loose the filepath information
-            # from which we were extracting the solver/meshing mode of the given object.
-            # Anyway, we are planning to remove search_root in the newer version of search function.
-            if p == "<session>":
-                p = "<solver_session>"
             if p in tree:
                 tree = tree[p]
             else:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -73,7 +73,7 @@ def test_get_version_path_prefix_from_obj(
     )
     assert _get_version_path_prefix_from_obj(meshing.tui.file.import_) == (
         version,
-        ["<session>", "tui", "file", "import_"],
+        ["<meshing_session>", "tui", "file", "import_"],
         "<search_root>",
     )
     assert _get_version_path_prefix_from_obj(meshing.tui.file.read_case) == (
@@ -82,34 +82,34 @@ def test_get_version_path_prefix_from_obj(
         None,
     )
     assert _get_version_path_prefix_from_obj(meshing.meshing) == (
-        None,
+        version,
         ["<meshing_session>", "meshing"],
         "<search_root>",
     )
     assert _get_version_path_prefix_from_obj(meshing.workflow) == (
-        None,
+        version,
         ["<meshing_session>", "workflow"],
         "<search_root>",
     )
     assert _get_version_path_prefix_from_obj(solver.workflow) == (
-        None,
+        version,
         ["<meshing_session>", "workflow"],
         "<search_root>",
     )
     assert _get_version_path_prefix_from_obj(meshing.workflow.TaskObject) == (
-        None,
+        version,
         ["<meshing_session>", "workflow", "TaskObject:<name>"],
         '<search_root>["<name>"]',
     )
     assert _get_version_path_prefix_from_obj(
         meshing.workflow.TaskObject["Import Geometry"]
     ) == (
-        None,
+        version,
         ["<meshing_session>", "workflow", "TaskObject:<name>"],
         "<search_root>",
     )
     assert _get_version_path_prefix_from_obj(meshing.preferences.Appearance.Charts) == (
-        None,
+        version,
         ["<solver_session>", "preferences", "Appearance", "Charts"],
         "<search_root>",
     )


### PR DESCRIPTION
This fixes the issue with search_root introduced due to the dynamic path of the generated API. Now the modules imported from the dynamic path will be qualified with mode and version information in their names, so we won't loose any information for the search function.