### PR TITLE
refactor: `_generate_launch_string()` and callable launchers

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -47,9 +47,11 @@ class DockerLauncher:
 
     def __init__(
         self,
-        mode: FluentMode,
-        ui_mode: UIMode,
-        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
+        mode: Optional[Union[FluentMode, str, None]] = None,
+        ui_mode: Union[UIMode, str, None] = None,
+        graphics_driver: Union[
+            FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
+        ] = None,
         product_version: Optional[FluentVersion] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -58,7 +58,7 @@ def create_launcher(fluent_launch_mode: LaunchMode = None, **kwargs):
     DisallowedValuesError
         If an unknown Fluent launch mode is passed.
     """
-    _process_invalid_args(kwargs["dry_run"], fluent_launch_mode, kwargs)
+    _process_invalid_args(kwargs.get("dry_run"), fluent_launch_mode, kwargs)
     if fluent_launch_mode == LaunchMode.STANDALONE:
         unsupported_args = ["container_dict", "dry_run", "scheduler_options"]
         for arg_name in unsupported_args:

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -45,9 +45,11 @@ class PIMLauncher:
 
     def __init__(
         self,
-        mode: FluentMode,
-        ui_mode: UIMode,
-        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
+        mode: Optional[Union[FluentMode, str, None]] = None,
+        ui_mode: Union[UIMode, str, None] = None,
+        graphics_driver: Union[
+            FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
+        ] = None,
         product_version: Optional[FluentVersion] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -81,7 +81,6 @@ def _build_fluent_launch_args_string(**kwargs) -> str:
 
 def _generate_launch_string(
     argvals,
-    mode: FluentMode,
     server_info_file_name: str,
 ):
     """Generates the launch string to launch fluent."""
@@ -92,10 +91,10 @@ def _generate_launch_string(
     else:
         exe_path = str(get_fluent_exe_path(**argvals))
     launch_string = exe_path
-    if mode == FluentMode.SOLVER_ICING:
+    if argvals["mode"] == FluentMode.SOLVER_ICING:
         argvals["fluent_icing"] = True
     launch_string += _build_fluent_launch_args_string(**argvals)
-    if FluentMode.is_meshing(mode):
+    if FluentMode.is_meshing(argvals["mode"]):
         launch_string += " -meshing"
     if " " in server_info_file_name:
         server_info_file_name = '"' + server_info_file_name + '"'

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -57,9 +57,11 @@ class StandaloneLauncher:
 
     def __init__(
         self,
-        mode: FluentMode,
-        ui_mode: UIMode,
-        graphics_driver: Union[FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver],
+        mode: Optional[Union[FluentMode, str, None]] = None,
+        ui_mode: Union[UIMode, str, None] = None,
+        graphics_driver: Union[
+            FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
+        ] = None,
         product_version: Optional[FluentVersion] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
@@ -201,7 +203,6 @@ class StandaloneLauncher:
         self._server_info_file_name = _get_server_info_file_name()
         self._launch_string = _generate_launch_string(
             argvals,
-            argvals["mode"],
             self._server_info_file_name,
         )
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2833, https://github.com/ansys/pyfluent/issues/2827

Refactor _generate_launch_string() - pass only argals instead of argvals and mode