### PR TITLE
test: additional arguments from _build_fluent_launch_args_string

### DIFF
--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -439,6 +439,14 @@ def test_exposure_and_graphics_driver_arguments():
             )
 
 
+def test_additional_arguments_fluent_launch_args_string():
+    additional_arguments = "-ws -ws-port=5000 -i test.jou"
+    assert additional_arguments in _build_fluent_launch_args_string(
+        additional_arguments=additional_arguments,
+        processor_count=4,
+    )
+
+
 def test_processor_count():
     def get_processor_count(solver):
         return int(solver.rp_vars("parallel/nprocs_string").strip('"'))


### PR DESCRIPTION
Forgot to include this additional test in https://github.com/ansys/pyfluent/pull/2807

Test fails in `main` @ cbab7df3853aa870b65e629774a3457ef01fe077 with `AssertionError: assert '-ws -ws-port=5000 -i test.jou' in ' 3ddp -t4'`
Passes after merge dcb2f69f181a0c9f68ac6515cf2b8aa8e97d167f