### PR TITLE
test: run unittests in parallel with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,11 @@ optional = true
 pytest = "==8.0.2"
 pytest-cov = "==4.1.0"
 pytest-mock = "==3.12.0"
+pytest-xdist = "==3.6.1"
 
 [tool.poetry.extras]
 reader = ["h5py"]
-tests = ["pytest", "pytest-cov", "pytest-mock"]
+tests = ["pytest", "pytest-cov", "pytest-mock", "pytest-xdist"]
 
 [tool.poetry.urls]
 "Documentation" = "https://fluent.docs.pyansys.com/"
@@ -100,6 +101,7 @@ addopts = """
 -v
 --durations=0
 --show-capture=all
+-n auto
 """
 markers = [
     "settings_only: Read and modify the case settings only, without loading the mesh, initializing, or solving the case",

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -153,7 +153,7 @@ def test_file_purpose_on_remote_instance(
         "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
     )
     suffix = uuid.uuid4().hex
-    import_file_name = rename_downloaded_file(import_file_name, suffix)
+    import_file_name = rename_downloaded_file(import_file_name, f"_{suffix}")
 
     solver_session.file.read_case(file_name=import_file_name)
     assert len(file_service.uploads()) == 1

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -153,7 +153,7 @@ def test_file_purpose_on_remote_instance(
         "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
     )
     suffix = uuid.uuid4().hex
-    import_file_name = rename_downloaded_file(import_file_name, suffix, ".msh.h5")
+    import_file_name = rename_downloaded_file(import_file_name, suffix)
 
     solver_session.file.read_case(file_name=import_file_name)
     assert len(file_service.uploads()) == 1

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -3,6 +3,7 @@
 from concurrent import futures
 import os
 from unittest.mock import create_autospec
+import uuid
 
 import grpc
 from grpc_health.v1 import health_pb2_grpc
@@ -24,6 +25,7 @@ import ansys.fluent.core.utils.fluent_version as docker_image_version
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.utils.networking import get_free_port
 import ansys.platform.instancemanagement as pypim
+from tests.util import rename_downloaded_file
 
 
 def test_launch_remote_instance(monkeypatch, new_solver_session):
@@ -150,6 +152,8 @@ def test_file_purpose_on_remote_instance(
     import_file_name = examples.download_file(
         "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
     )
+    suffix = uuid.uuid4().hex
+    import_file_name = rename_downloaded_file(import_file_name, suffix, ".msh.h5")
 
     solver_session.file.read_case(file_name=import_file_name)
     assert len(file_service.uploads()) == 1

--- a/tests/test_tests_util.py
+++ b/tests/test_tests_util.py
@@ -16,7 +16,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
         file_path = Path(EXAMPLES_PATH) / f"{a}{ext}"
         file_path.touch()
         file_path = str(file_path)
-        new_file_path = rename_downloaded_file(file_path, "1")
+        new_file_path = rename_downloaded_file(file_path, "_1")
         assert new_file_path == str(Path(EXAMPLES_PATH) / f"{a}_1{ext}")
     except Exception:
         raise
@@ -26,7 +26,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
     try:
         file_path = f"{b}{ext}"
         (Path(EXAMPLES_PATH) / file_path).touch()
-        new_file_path = rename_downloaded_file(file_path, "1")
+        new_file_path = rename_downloaded_file(file_path, "_1")
         assert new_file_path == f"{b}_1{ext}"
     except Exception:
         raise
@@ -39,7 +39,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
         file_path = dir_path / f"{d}{ext}"
         file_path.touch()
         file_path = str(Path(c) / f"{d}{ext}")
-        new_file_path = rename_downloaded_file(file_path, "1")
+        new_file_path = rename_downloaded_file(file_path, "_1")
         assert new_file_path == str(Path(c) / f"{d}_1{ext}")
     except Exception:
         raise

--- a/tests/test_tests_util.py
+++ b/tests/test_tests_util.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import shutil
+
+import pytest
+
+from ansys.fluent.core import EXAMPLES_PATH
+from tests.util import rename_downloaded_file
+
+
+@pytest.mark.parametrize(
+    "ext,a,b,c,d",
+    [(".cas", "a1", "b1", "c1", "d1"), (".cas.gz", "a2", "b2", "c2", "d2")],
+)
+def test_rename_downloaded_file(ext, a, b, c, d):
+    try:
+        file_path = Path(EXAMPLES_PATH) / f"{a}{ext}"
+        file_path.touch()
+        file_path = str(file_path)
+        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        assert new_file_path == str(Path(EXAMPLES_PATH) / f"{a}_1{ext}")
+    except Exception:
+        raise
+    finally:
+        Path(new_file_path).unlink(missing_ok=True)
+
+    try:
+        file_path = f"{b}{ext}"
+        (Path(EXAMPLES_PATH) / file_path).touch()
+        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        assert new_file_path == f"{b}_1{ext}"
+    except Exception:
+        raise
+    finally:
+        (Path(EXAMPLES_PATH) / new_file_path).unlink(missing_ok=True)
+
+    try:
+        dir_path = Path(EXAMPLES_PATH) / c
+        dir_path.mkdir()
+        file_path = dir_path / f"{d}{ext}"
+        file_path.touch()
+        file_path = str(Path(c) / f"{d}{ext}")
+        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        assert new_file_path == str(Path(c) / f"{d}_1{ext}")
+    except Exception:
+        raise
+    finally:
+        shutil.rmtree(dir_path, ignore_errors=True)

--- a/tests/test_tests_util.py
+++ b/tests/test_tests_util.py
@@ -16,7 +16,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
         file_path = Path(EXAMPLES_PATH) / f"{a}{ext}"
         file_path.touch()
         file_path = str(file_path)
-        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        new_file_path = rename_downloaded_file(file_path, "1")
         assert new_file_path == str(Path(EXAMPLES_PATH) / f"{a}_1{ext}")
     except Exception:
         raise
@@ -26,7 +26,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
     try:
         file_path = f"{b}{ext}"
         (Path(EXAMPLES_PATH) / file_path).touch()
-        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        new_file_path = rename_downloaded_file(file_path, "1")
         assert new_file_path == f"{b}_1{ext}"
     except Exception:
         raise
@@ -39,7 +39,7 @@ def test_rename_downloaded_file(ext, a, b, c, d):
         file_path = dir_path / f"{d}{ext}"
         file_path.touch()
         file_path = str(Path(c) / f"{d}{ext}")
-        new_file_path = rename_downloaded_file(file_path, "1", ext)
+        new_file_path = rename_downloaded_file(file_path, "1")
         assert new_file_path == str(Path(c) / f"{d}_1{ext}")
     except Exception:
         raise

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from typing import Optional
+
+from ansys.fluent.core import EXAMPLES_PATH
+
+
+def rename_downloaded_file(
+    file_path: str, suffix: str, ext: Optional[str] = None
+) -> str:
+    """Rename downloaded file by appending a suffix to the file name.
+
+    Parameters
+    ----------
+    file_path : str
+        Downloaded file path. Can be absolute or relative.
+    suffix : str
+        Suffix to append to the file name.
+    ext : str, optional
+        Extension of the file, by default None. Must be provided if the file has multiple extensions (e.g. .cas.gz).
+
+    Returns:
+    --------
+    str
+        New file path with the suffix appended to the file name.
+    """
+    orig_path = Path(file_path)
+    if ext:
+        file_path = file_path.removesuffix(ext)
+    file_path = Path(file_path)
+    if file_path.is_absolute():
+        new_stem = f"{file_path.stem}_{suffix}"
+        new_path = file_path.with_stem(new_stem)
+        if ext:
+            new_path = new_path.with_suffix(ext)
+        orig_path.rename(new_path)
+        return str(new_path)
+    else:
+        orig_abs_path = Path(EXAMPLES_PATH) / orig_path
+        abs_path = Path(EXAMPLES_PATH) / file_path
+        new_stem = f"{file_path.stem}_{suffix}"
+        new_path = abs_path.with_stem(new_stem)
+        if ext:
+            new_path = new_path.with_suffix(ext)
+        orig_abs_path.rename(new_path)
+        if ext:
+            return str(file_path.with_stem(new_stem).with_suffix(ext))
+        else:
+            return str(file_path.with_stem(new_stem))

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -23,7 +23,7 @@ def rename_downloaded_file(file_path: str, suffix: str) -> str:
     file_path = file_path.removesuffix(ext)
     file_path = Path(file_path)
     if file_path.is_absolute():
-        new_stem = f"{file_path.stem}_{suffix}"
+        new_stem = f"{file_path.stem}{suffix}"
         new_path = file_path.with_stem(new_stem)
         new_path = new_path.with_suffix(ext)
         orig_path.rename(new_path)
@@ -31,7 +31,7 @@ def rename_downloaded_file(file_path: str, suffix: str) -> str:
     else:
         orig_abs_path = Path(EXAMPLES_PATH) / orig_path
         abs_path = Path(EXAMPLES_PATH) / file_path
-        new_stem = f"{file_path.stem}_{suffix}"
+        new_stem = f"{file_path.stem}{suffix}"
         new_path = abs_path.with_stem(new_stem)
         new_path = new_path.with_suffix(ext)
         orig_abs_path.rename(new_path)

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,12 +1,9 @@
 from pathlib import Path
-from typing import Optional
 
 from ansys.fluent.core import EXAMPLES_PATH
 
 
-def rename_downloaded_file(
-    file_path: str, suffix: str, ext: Optional[str] = None
-) -> str:
+def rename_downloaded_file(file_path: str, suffix: str) -> str:
     """Rename downloaded file by appending a suffix to the file name.
 
     Parameters
@@ -15,23 +12,20 @@ def rename_downloaded_file(
         Downloaded file path. Can be absolute or relative.
     suffix : str
         Suffix to append to the file name.
-    ext : str, optional
-        Extension of the file, by default None. Must be provided if the file has multiple extensions (e.g. .cas.gz).
 
     Returns:
     --------
     str
         New file path with the suffix appended to the file name.
     """
+    ext = "".join(Path(file_path).suffixes)
     orig_path = Path(file_path)
-    if ext:
-        file_path = file_path.removesuffix(ext)
+    file_path = file_path.removesuffix(ext)
     file_path = Path(file_path)
     if file_path.is_absolute():
         new_stem = f"{file_path.stem}_{suffix}"
         new_path = file_path.with_stem(new_stem)
-        if ext:
-            new_path = new_path.with_suffix(ext)
+        new_path = new_path.with_suffix(ext)
         orig_path.rename(new_path)
         return str(new_path)
     else:
@@ -39,10 +33,6 @@ def rename_downloaded_file(
         abs_path = Path(EXAMPLES_PATH) / file_path
         new_stem = f"{file_path.stem}_{suffix}"
         new_path = abs_path.with_stem(new_stem)
-        if ext:
-            new_path = new_path.with_suffix(ext)
+        new_path = new_path.with_suffix(ext)
         orig_abs_path.rename(new_path)
-        if ext:
-            return str(file_path.with_stem(new_stem).with_suffix(ext))
-        else:
-            return str(file_path.with_stem(new_stem))
+        return str(file_path.with_stem(new_stem).with_suffix(ext))


### PR DESCRIPTION
Running unittests in parallel using pytest-xdist. The test test_launch_remote_instance has been adjusted as it was modifying the original downloaded file which was causing issue in another test test_field_data_objects_3d.

The 24.2 unittests runtime is reduced from ~56 min to ~31 min.