### PR TITLE
fix: requests 2.31.0 fix for docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pandas = "^2.0.3"
 platformdirs = "^3.5.1"
 psutil = "^5.9.5"
 pyyaml = "^6.0"
-requests = "^2.31.0"
+requests = "==2.31.0"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2846

Fix for `ansys.fluent.core.launcher.error_handler.DockerContainerLaunchNotSupported: Python Docker SDK is unsupported on this system.`

![image](https://github.com/ansys/pyfluent/assets/106588300/21eb9cc5-5cd5-453f-9883-4c8b703ac13a)
