### PR TITLE
fix: root affected level

### DIFF
--- a/src/ansys/fluent/core/meshing/meshing_workflow.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow.py
@@ -71,12 +71,16 @@ class MeshingWorkflow(Workflow):
         self._identifier = identifier
 
     def reinitialize(self) -> None:
+        """Reinitialize the same workflow."""
+        self._new_workflow(name=self._name, reinitialize=True)
+
+    def initialize(self) -> None:
         """Initialize a workflow."""
-        self._init_workflow(name=self._name)
+        self._new_workflow(name=self._name)
 
     def __getattribute__(self, item: str):
         if (
-            item != "reinitialize"
+            item not in ["reinitialize", "initialize"]
             and not item.startswith("_")
             and not getattr(self._meshing.GlobalSettings, self._identifier)()
         ):

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -117,17 +117,17 @@ class PureMeshing(BaseSession):
 
     def watertight(self):
         """Get a new watertight workflow."""
-        self._base_meshing.watertight_workflow.reinitialize()
+        self._base_meshing.watertight_workflow.initialize()
         return self._base_meshing.watertight_workflow
 
     def fault_tolerant(self):
         """Get a new fault-tolerant workflow."""
-        self._base_meshing.fault_tolerant_workflow.reinitialize()
+        self._base_meshing.fault_tolerant_workflow.initialize()
         return self._base_meshing.fault_tolerant_workflow
 
     def two_dimensional_meshing(self):
         """Get a new 2D meshing workflow."""
-        self._base_meshing.two_dimensional_meshing_workflow.reinitialize()
+        self._base_meshing.two_dimensional_meshing_workflow.initialize()
         return self._base_meshing.two_dimensional_meshing_workflow
 
     def load_workflow(self, file_path: str):
@@ -150,7 +150,7 @@ class PureMeshing(BaseSession):
         """
         if not self.scheme_eval.scheme_eval("(is-beta-feature-available?)"):
             raise RuntimeError("Topology-based Meshing is a beta feature in Fluent.")
-        self._base_meshing.topology_based_meshing_workflow.reinitialize()
+        self._base_meshing.topology_based_meshing_workflow.initialize()
         return self._base_meshing.topology_based_meshing_workflow
 
     @property

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1466,13 +1466,14 @@ class Workflow:
         self._dynamic_interface = dynamic_interface
         self._initialize_methods(dynamic_interface=dynamic_interface)
 
-    def _new_workflow(self, name: str, dynamic_interface: bool = True):
-        if self._workflow.service in self._root_affected_cb_by_server:
-            self._root_affected_cb_by_server[self._workflow.service].unsubscribe()
-            self._root_affected_cb_by_server.pop(self._workflow.service)
-        self._init_workflow(name=name, dynamic_interface=dynamic_interface)
-
-    def _init_workflow(self, name: str, dynamic_interface: bool = True):
+    def _new_workflow(
+        self, name: str, dynamic_interface: bool = True, reinitialize: bool = False
+    ):
+        if not reinitialize:
+            # if the same workflow is not being reinitialized, unsubscribe the root affected callback
+            if self._workflow.service in self._root_affected_cb_by_server:
+                self._root_affected_cb_by_server[self._workflow.service].unsubscribe()
+                self._root_affected_cb_by_server.pop(self._workflow.service)
         self._workflow.InitializeWorkflow(WorkflowType=name)
         self._activate_dynamic_interface(dynamic_interface=dynamic_interface)
 


### PR DESCRIPTION
Distinguishing between `initialize` and `reinitialize`:
`initialize` - A different workflow is created, root affected callback is cleared.
`reinitialize` - The same workflow is reinitialized, root affected callback is not cleared.