### PR TITLE
fix: ssl certificate fix for nltk.download() on Linux

### DIFF
--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -500,7 +500,16 @@ def _search_whole_word(
 
 def _download_nltk_data():
     """Download NLTK data on demand."""
+    import ssl
+
     import nltk
+
+    try:
+        _create_unverified_context = ssl._create_unverified_context
+    except AttributeError:
+        pass
+    else:
+        ssl._create_default_https_context = _create_unverified_context
 
     packages = ["wordnet", "omw-1.4"]
     for package in packages:


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2871

Resolves ssl certificate error for `nltk.download()` on Linux.

![image](https://github.com/ansys/pyfluent/assets/106588300/cbb1ba20-09cc-4368-b607-22b7b7954aa3)
