### PR TITLE
fix: set start_timeout = -1 for Slurm launcher

### DIFF
--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -147,8 +147,9 @@ class DockerLauncher:
         passed to Fluent.
         """
         self.argvals, self.new_session = _get_argvals_and_session(locals().copy())
+        if self.argvals["start_timeout"] is None:
+            self.argvals["start_timeout"] = 60
         self.file_transfer_service = file_transfer_service
-
         if self.argvals["mode"] == FluentMode.SOLVER_ICING:
             self.argvals["fluent_icing"] = True
         if self.argvals["container_dict"] is None:

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -147,6 +147,8 @@ class PIMLauncher:
             )
         self.argvals, self.new_session = _get_argvals_and_session(locals().copy())
         self.file_transfer_service = file_transfer_service
+        if self.argvals["start_timeout"] is None:
+            self.argvals["start_timeout"] = 60
 
     def __call__(self):
         logger.info("Starting Fluent remotely. The startup configuration is ignored.")

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -294,7 +294,5 @@ def _get_argvals_and_session(argvals):
     argvals["graphics_driver"] = _get_graphics_driver(argvals["graphics_driver"])
     argvals["mode"] = _get_mode(argvals["mode"])
     del argvals["self"]
-    if argvals["start_timeout"] is None:
-        argvals["start_timeout"] = 60
     new_session = argvals["mode"].value[0]
     return argvals, new_session

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -213,7 +213,7 @@ class SlurmLauncher:
         precision: Optional[str] = None,
         processor_count: Optional[int] = None,
         journal_file_names: Union[None, str, list[str]] = None,
-        start_timeout: int = 60,
+        start_timeout: int = -1,
         additional_arguments: Optional[str] = "",
         env: Optional[Dict[str, Any]] = None,
         cleanup_on_exit: bool = True,

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -330,7 +330,8 @@ class SlurmLauncher:
         self._argvals, self._new_session = _get_argvals_and_session(locals().copy())
         self.file_transfer_service = file_transfer_service
         self._argvals["ui_mode"] = _get_ui_mode(ui_mode)
-
+        if self._argvals["start_timeout"] is None:
+            self._argvals["start_timeout"] = -1
         if self._argvals["scheduler_options"]:
             if "scheduler" not in self._argvals["scheduler_options"]:
                 raise InvalidArgument(

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -179,6 +179,8 @@ class StandaloneLauncher:
         self.argvals, self.new_session = _get_argvals_and_session(locals().copy())
         self.file_transfer_service = file_transfer_service
         self.argvals["ui_mode"] = _get_ui_mode(ui_mode)
+        if self.argvals["start_timeout"] is None:
+            self.argvals["start_timeout"] = 60
         if self.argvals["lightweight_mode"] is None:
             self.argvals["lightweight_mode"] = False
         fluent_version = _get_standalone_launch_fluent_version(


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2872

Set `start_timeout = -1` for Slurm launcher.

Thank you very much @millerj97 for testing this in Slurm environment quickly.

using `create_launcher`

```
>>> from ansys.fluent.core.launcher import create_launcher
>>> from ansys.fluent.core.launcher.pyfluent_enums import LaunchMode
>>> launcher = create_launcher(LaunchMode.SLURM,scheduler_options={"scheduler": "slurm"})
>>> slurm=launcher()
>>> type(slurm) # <class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
<class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
>>> slurm.pending(), slurm.running(), slurm.done() # (True, False, False)
(True, False, False)
>>> session = slurm.result()
>>> session # <ansys.fluent.core.session_solver.Solver object at 0x7f171eb40970>
<ansys.fluent.core.session_solver.Solver object at 0x7f6b86215db0>
>>> slurm.pending(), slurm.running(), slurm.done() # (False, True, False)
(False, True, False)
>>> session.exit()
>>> slurm.pending(), slurm.running(), slurm.done() # (False, False, True)
(False, False, True)
```

using `launch_fluent`

```
>>> from ansys.fluent.core import launch_fluent
>>> slurm = launch_fluent(scheduler_options={"scheduler": "slurm"})
>>> type(slurm) # <class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
<class 'ansys.fluent.core.launcher.slurm_launcher.SlurmFuture'>
>>> slurm.pending(), slurm.running(), slurm.done() # (True, False, False)
(True, False, False)
>>> session = slurm.result()
>>> session # <ansys.fluent.core.session_solver.Solver object at 0x7f171eb40970>
<ansys.fluent.core.session_solver.Solver object at 0x7f74febcdcf0>
>>> slurm.pending(), slurm.running(), slurm.done() # (False, True, False)
(False, True, False)
>>> session.exit()
>>> slurm.pending(), slurm.running(), slurm.done() # (False, False, True)
(False, False, True)
>>>
```