### PR TITLE
fix: Add a method to set console loggers' level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
+      - name: Cleanup previous docker containers
+        run: make cleanup-previous-docker-containers
+
       - name: Install pyfluent
         run: make install
 
@@ -231,6 +234,9 @@ jobs:
           key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Cleanup previous docker containers
+        run: make cleanup-previous-docker-containers
 
       - name: Add version information
         run: make version-info

--- a/Makefile
+++ b/Makefile
@@ -152,4 +152,4 @@ compare-flobject:
 
 cleanup-previous-docker-containers:
 	@if [ -n "$(docker ps -a -q)" ]; then docker stop $(docker ps -a -q); fi
-	@if [ -n "$(docker ps -a -q)" ]; then docker rm $(docker ps -a -q); fi
+	@if [ -n "$(docker ps -a -q)" ]; then docker rm -vf $(docker ps -a -q); fi

--- a/Makefile
+++ b/Makefile
@@ -149,3 +149,7 @@ build-all-docs:
 
 compare-flobject:
 	@python .ci/compare_flobject.py
+
+cleanup-previous-docker-containers:
+	@if [ -n "$(docker ps -a -q)" ]; then docker stop $(docker ps -a -q); fi
+	@if [ -n "$(docker ps -a -q)" ]; then docker rm $(docker ps -a -q); fi

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -217,7 +217,7 @@ How do you disable PyFluent warnings shown in the console?
 
    import ansys.fluent.core as pyfluent
    pyfluent.set_console_loggers_level("ERROR") # Disable all warning logs
-   pyfluent.warnings.disable() # Disable all warning messages
+   pyfluent.warning.disable() # Disable all warning messages
 
 
 How do you learn how to use PyFluent?

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -200,16 +200,28 @@ How does PyFluent infer the location to launch Fluent?
 PyFluent infers the Fluent location based on the following information, in
 increasing order of precedence:
 
+#. Value of ``product_version`` parameter passed to :func:`launch_fluent()
+   <ansys.fluent.core.launch_fluent>`.
 
 #. ``AWP_ROOT<ver>`` environment variable, which is configured on Windows system
    when Fluent is installed, where ``<ver>`` is the Fluent release number such
-   as ``241`` for release 2024 R1.  PyFluent automatically uses this environment
+   as ``242`` for release 2024 R2.  PyFluent automatically uses this environment
    variable to locate the latest Fluent installation. On Linux systems configure
    ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such
-   as ``/apps/ansys_inc/v241``.
+   as ``/apps/ansys_inc/v242``.
 
-#. Value of ``product_version`` parameter passed to :func:`launch_fluent()
-   <ansys.fluent.core.launch_fluent>`.
+
+How do you disable PyFluent logging to the console?
+-----------------------------------------------
+PyFluent uses several loggers based on the application area. The default verbosity
+level of these loggers is set to ``WARNING``. You can set the verbosity level to
+``ERROR`` for all loggers by using the following code. This will show only serious
+errors.
+
+.. code:: python
+
+   import ansys.fluent.core as pyfluent
+   pyfluent.set_console_loggers_level("ERROR")
 
 
 How do you learn how to use PyFluent?

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -213,10 +213,10 @@ increasing order of precedence:
 
 How do you disable PyFluent warnings logged to the console?
 -----------------------------------------------------------
-PyFluent uses several loggers based on the application area. The default verbosity
-level of these loggers is set to ``WARNING``. You can set the verbosity level to
-``ERROR`` for all loggers by using the following code. This will disable all
-warnings and show only errors.
+PyFluent uses several console loggers based on the application area. The default
+verbosity level of these loggers is set to ``WARNING``. You can set the verbosity
+level to ``ERROR`` for all console loggers by using the following code. This will
+hide all warnings and show only errors.
 
 .. code:: python
 

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -216,7 +216,7 @@ How do you disable PyFluent warnings shown in the console?
 .. code:: python
 
    import ansys.fluent.core as pyfluent
-   pyfluent.set_console_loggers_level("ERROR") # Disable all warning logs
+   pyfluent.set_console_logging_level("ERROR") # Disable all warning logs
    pyfluent.warning.disable() # Disable all warning messages
 
 

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -211,17 +211,13 @@ increasing order of precedence:
    as ``/apps/ansys_inc/v242``.
 
 
-How do you disable PyFluent warnings logged to the console?
------------------------------------------------------------
-PyFluent uses several console loggers based on the application area. The default
-verbosity level of these loggers is set to ``WARNING``. You can set the verbosity
-level to ``ERROR`` for all console loggers by using the following code. This will
-hide all warnings and show only errors.
-
+How do you disable PyFluent warnings shown in the console?
+----------------------------------------------------------
 .. code:: python
 
    import ansys.fluent.core as pyfluent
-   pyfluent.set_console_loggers_level("ERROR")
+   pyfluent.set_console_loggers_level("ERROR") # Disable all warning logs
+   pyfluent.warnings.disable() # Disable all warning messages
 
 
 How do you learn how to use PyFluent?

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -211,12 +211,12 @@ increasing order of precedence:
    as ``/apps/ansys_inc/v242``.
 
 
-How do you disable PyFluent logging to the console?
------------------------------------------------
+How do you disable PyFluent warnings logged to the console?
+-----------------------------------------------------------
 PyFluent uses several loggers based on the application area. The default verbosity
 level of these loggers is set to ``WARNING``. You can set the verbosity level to
-``ERROR`` for all loggers by using the following code. This will show only serious
-errors.
+``ERROR`` for all loggers by using the following code. This will disable all
+warnings and show only errors.
 
 .. code:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ addopts = """
 -v
 --durations=0
 --show-capture=all
+-n auto
 """
 markers = [
     "settings_only: Read and modify the case settings only, without loading the mesh, initializing, or solving the case",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ addopts = """
 -v
 --durations=0
 --show-capture=all
--n auto
 """
 markers = [
     "settings_only: Read and modify the case settings only, without loading the mesh, initializing, or solving the case",

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -6,6 +6,12 @@ import pydoc
 
 import platformdirs
 
+# isort: off
+# Logging has to be imported before importing other PyFluent modules
+from ansys.fluent.core.logging import set_console_loggers_level  # noqa: F401
+
+# isort: on
+
 from ansys.fluent.core._version import __version__  # noqa: F401
 from ansys.fluent.core.get_build_details import (  # noqa: F401
     get_build_version,
@@ -31,11 +37,6 @@ from ansys.fluent.core.warnings import (  # noqa: F401
     PyFluentDeprecationWarning,
     PyFluentUserWarning,
     warning,
-)
-
-# Logging has to be imported before importing other PyFluent modules
-from ansys.fluent.core.logging import (  # isort: skip # noqa: F401
-    set_console_loggers_level,
 )
 
 _VERSION_INFO = None

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -21,9 +21,6 @@ from ansys.fluent.core.launcher.pyfluent_enums import (  # noqa: F401
     FluentWindowsGraphicsDriver,
     UIMode,
 )
-
-# Logging has to be imported before importing other PyFluent modules
-from ansys.fluent.core.logging import set_console_loggers_level  # noqa: F401
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils import fldoc
@@ -34,6 +31,11 @@ from ansys.fluent.core.warnings import (  # noqa: F401
     PyFluentDeprecationWarning,
     PyFluentUserWarning,
     warning,
+)
+
+# Logging has to be imported before importing other PyFluent modules
+from ansys.fluent.core.logging import (  # isort: skip # noqa: F401
+    set_console_loggers_level,
 )
 
 _VERSION_INFO = None

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -6,12 +6,6 @@ import pydoc
 
 import platformdirs
 
-# Logging has to be set up before importing other PyFluent modules
-import ansys.fluent.core.logging as logging
-
-logging.root_config()
-logging.configure_env_var()
-
 from ansys.fluent.core._version import __version__  # noqa: F401
 from ansys.fluent.core.get_build_details import (  # noqa: F401
     get_build_version,
@@ -27,6 +21,9 @@ from ansys.fluent.core.launcher.pyfluent_enums import (  # noqa: F401
     FluentWindowsGraphicsDriver,
     UIMode,
 )
+
+# Logging has to be imported before importing other PyFluent modules
+from ansys.fluent.core.logging import set_console_loggers_level  # noqa: F401
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils import fldoc

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -8,7 +8,7 @@ import platformdirs
 
 # isort: off
 # Logging has to be imported before importing other PyFluent modules
-from ansys.fluent.core.logging import set_console_loggers_level  # noqa: F401
+from ansys.fluent.core.logging import set_console_logging_level  # noqa: F401
 
 # isort: on
 

--- a/src/ansys/fluent/core/logging.py
+++ b/src/ansys/fluent/core/logging.py
@@ -25,6 +25,24 @@ def root_config():
         logger.addHandler(ch)
 
 
+def set_console_loggers_level(level: Union[str, int]):
+    """Sets the level of all PyFluent loggers that write to console.
+
+    Parameters
+    ----------
+    level : str or int
+        Specified logging level to set PyFluent loggers to.
+
+    Notes
+    -----
+    See logging levels in https://docs.python.org/3/library/logging.html#logging-levels
+    """
+    logger = logging.getLogger("pyfluent")
+    logger.setLevel(level)
+    for ch in logger.handlers:
+        ch.setLevel(level)
+
+
 def is_active() -> bool:
     """Returns whether PyFluent logging to file is active."""
     return _logging_file_enabled
@@ -224,3 +242,7 @@ def configure_env_var() -> None:
                 "PYFLUENT_LOGGING environment variable specified, enabling logging..."
             )
             enable(env_logging_level)
+
+
+root_config()
+configure_env_var()

--- a/src/ansys/fluent/core/logging.py
+++ b/src/ansys/fluent/core/logging.py
@@ -25,8 +25,8 @@ def root_config():
         logger.addHandler(ch)
 
 
-def set_console_loggers_level(level: Union[str, int]):
-    """Sets the level of all PyFluent loggers that write to console.
+def set_console_logging_level(level: Union[str, int]):
+    """Sets the level of PyFluent logging being output to console.
 
     Parameters
     ----------

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -192,6 +192,7 @@ def test_fluent_connection_properties(
     assert isinstance(connection_properties.fluent_host_pid, int)
 
 
+@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/2899")
 def test_fluent_freeze_kill(
     new_solver_session,
 ) -> None:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -11,7 +11,6 @@ from ansys.fluent.core.launcher import launcher_utils
 from ansys.fluent.core.launcher.error_handler import (
     DockerContainerLaunchNotSupported,
     GPUSolverSupportError,
-    LaunchFluentError,
     _raise_non_gui_exception_in_windows,
 )
 from ansys.fluent.core.launcher.launcher import create_launcher
@@ -195,35 +194,34 @@ def test_case_data_load():
     session.exit()
 
 
-def test_gpu_launch_arg(helpers, monkeypatch):
-    # The launch process is terminated intentionally to verify whether the fluent launch string
-    # (which is available in the error message) is generated correctly.
-    helpers.mock_awp_vars()
-    monkeypatch.setenv("PYFLUENT_LAUNCH_CONTAINER", "0")
-    with pytest.raises(LaunchFluentError) as error:
-        pyfluent.launch_fluent(gpu=True, start_timeout=0)
+def test_gpu_launch_arg():
+    assert (
+        _build_fluent_launch_args_string(
+            gpu=True, additional_arguments="", processor_count=None
+        ).strip()
+        == "3ddp -gpu"
+    )
+    assert (
+        _build_fluent_launch_args_string(
+            gpu=[1, 2, 4], additional_arguments="", processor_count=None
+        ).strip()
+        == "3ddp -gpu=1,2,4"
+    )
 
-    with pytest.raises(LaunchFluentError) as error:
-        pyfluent.launch_fluent(gpu=[1, 2, 4], start_timeout=0)
 
-    with pytest.raises(GPUSolverSupportError):
-        pyfluent.launch_fluent(gpu=True, version="2d")
-
-
-def test_gpu_launch_arg_additional_arg(helpers, monkeypatch):
-    # The launch process is terminated intentionally to verify whether the fluent launch string
-    # (which is available in the error message) is generated correctly.
-    helpers.mock_awp_vars()
-    monkeypatch.setenv("PYFLUENT_LAUNCH_CONTAINER", "0")
-    with pytest.raises(LaunchFluentError) as error:
-        pyfluent.launch_fluent(additional_arguments="-gpu", start_timeout=0)
-
-    assert " -gpu" in str(error.value)
-
-    with pytest.raises(LaunchFluentError) as error:
-        pyfluent.launch_fluent(additional_arguments="-gpu=1,2,4", start_timeout=0)
-
-    assert " -gpu=1,2,4" in str(error.value)
+def test_gpu_launch_arg_additional_arg():
+    assert (
+        _build_fluent_launch_args_string(
+            additional_arguments="-gpu", processor_count=None
+        ).strip()
+        == "3ddp -gpu"
+    )
+    assert (
+        _build_fluent_launch_args_string(
+            additional_arguments="-gpu=1,2,4", processor_count=None
+        ).strip()
+        == "3ddp -gpu=1,2,4"
+    )
 
 
 def test_get_fluent_exe_path_when_nothing_is_set(helpers):

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -28,6 +28,7 @@ import ansys.platform.instancemanagement as pypim
 from tests.util import rename_downloaded_file
 
 
+@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/2910")
 def test_launch_remote_instance(monkeypatch, new_solver_session):
     fluent = new_solver_session
     # Create a mock pypim pretending it is configured and returning a channel to an already running Fluent

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 import ansys.fluent.core as pyfluent
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,13 @@
+import logging
+
+import ansys.fluent.core as pyfluent
+
+
+def test_set_console_logging_level(caplog):
+    settings_logger = logging.getLogger("pyfluent.settings_api")
+    settings_logger.warning("ABC")
+    assert len(caplog.records) == 1
+    caplog.clear()
+    pyfluent.set_console_logging_level("ERROR")
+    settings_logger.warning("ABC")
+    assert len(caplog.records) == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,7 @@ import logging
 import ansys.fluent.core as pyfluent
 
 
+@pytest.mark.standalone
 def test_set_console_logging_level(caplog):
     settings_logger = logging.getLogger("pyfluent.settings_api")
     settings_logger.warning("ABC")


### PR DESCRIPTION
Please see the new FAQ entry to hide all PyFluent warnings from console.