### PR TITLE
fix: user can input enum, str, float or int for product_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,7 @@ jobs:
         id: cache-api-code
         with:
           path: |
-            src/ansys/fluent/core/generated/datamodel_231
-            src/ansys/fluent/core/generated/fluent_version_231.py
-            src/ansys/fluent/core/generated/meshing/tui_231.py
-            src/ansys/fluent/core/generated/solver/settings_231
-            src/ansys/fluent/core/generated/solver/tui_231.py
+            src/ansys/fluent/core/generated
             doc/source/api/meshing/tui
             doc/source/api/meshing/datamodel
             doc/source/api/solver/tui
@@ -255,12 +251,7 @@ jobs:
         id: cache-222-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_222
-            src/ansys/fluent/core/generated/fluent_version_222.py
-            src/ansys/fluent/core/generated/meshing/tui_222.py
-            src/ansys/fluent/core/generated/solver/settings_222
-            src/ansys/fluent/core/generated/solver/tui_222.py
-            src/ansys/fluent/core/generated/data/api_tree_222.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
@@ -297,12 +288,7 @@ jobs:
         id: cache-231-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_231
-            src/ansys/fluent/core/generated/fluent_version_231.py
-            src/ansys/fluent/core/generated/meshing/tui_231.py
-            src/ansys/fluent/core/generated/solver/settings_231
-            src/ansys/fluent/core/generated/solver/tui_231.py
-            src/ansys/fluent/core/generated/data/api_tree_231.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
@@ -332,12 +318,7 @@ jobs:
         id: cache-232-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_232
-            src/ansys/fluent/core/generated/fluent_version_232.py
-            src/ansys/fluent/core/generated/meshing/tui_232.py
-            src/ansys/fluent/core/generated/solver/settings_232
-            src/ansys/fluent/core/generated/solver/tui_232.py
-            src/ansys/fluent/core/generated/data/api_tree_232.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
@@ -367,12 +348,7 @@ jobs:
         id: cache-241-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_241
-            src/ansys/fluent/core/generated/fluent_version_241.py
-            src/ansys/fluent/core/generated/meshing/tui_241.py
-            src/ansys/fluent/core/generated/solver/settings_241
-            src/ansys/fluent/core/generated/solver/tui_241.py
-            src/ansys/fluent/core/generated/data/api_tree_241.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
@@ -402,12 +378,7 @@ jobs:
         id: cache-242-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_242
-            src/ansys/fluent/core/generated/fluent_version_242.py
-            src/ansys/fluent/core/generated/meshing/tui_242.py
-            src/ansys/fluent/core/generated/solver/settings_242
-            src/ansys/fluent/core/generated/solver/tui_242.py
-            src/ansys/fluent/core/generated/data/api_tree_242.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
@@ -437,18 +408,13 @@ jobs:
         id: cache-251-api-code
         with:
           path:
-            src/ansys/fluent/core/generated/datamodel_251
-            src/ansys/fluent/core/generated/fluent_version_251.py
-            src/ansys/fluent/core/generated/meshing/tui_251.py
-            src/ansys/fluent/core/generated/solver/settings_251
-            src/ansys/fluent/core/generated/solver/tui_251.py
-            src/ansys/fluent/core/generated/data/api_tree_251.pickle
+            src/ansys/fluent/core/generated
             doc/source/api/core/meshing/tui
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
             doc/source/api/core/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Pull 25.1 Fluent docker image
         if: steps.cache-251-api-code.outputs.cache-hit != 'true'

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -50,7 +50,7 @@ class DockerLauncher:
         graphics_driver: Union[
             FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
         ] = None,
-        product_version: Optional[FluentVersion] = None,
+        product_version: Union[FluentVersion, str, float, int] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
         processor_count: Optional[int] = None,
@@ -77,8 +77,9 @@ class DockerLauncher:
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
-        product_version : FluentVersion, optional
-            Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+        product_version : FluentVersion or str or float or int, optional
+            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
+            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,
@@ -157,7 +158,7 @@ class DockerLauncher:
         if self.argvals["product_version"]:
             self.argvals["container_dict"][
                 "image_tag"
-            ] = f"v{self.argvals['product_version'].value}"
+            ] = f"v{FluentVersion(self.argvals['product_version']).value}"
 
         self._args = _build_fluent_launch_args_string(**self.argvals).split()
         if FluentMode.is_meshing(self.argvals["mode"]):

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -79,7 +79,7 @@ class DockerLauncher:
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
             Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
+            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -76,7 +76,7 @@ def create_launcher(fluent_launch_mode: LaunchMode = None, **kwargs):
     deprecation_class=PyFluentDeprecationWarning,
 )
 def launch_fluent(
-    product_version: Optional[FluentVersion] = None,
+    product_version: Union[FluentVersion, str, float, int, None] = None,
     version: Optional[str] = None,
     precision: Optional[str] = None,
     processor_count: Optional[int] = None,
@@ -110,8 +110,9 @@ def launch_fluent(
 
     Parameters
     ----------
-    product_version : FluentVersion, optional
-        Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+    product_version : FluentVersion or str or float or int, optional
+        Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
+        any of  ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
         The default is ``None``, in which case the newest installed version is used.
     version : str, optional
         Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -75,7 +75,7 @@ class PIMLauncher:
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
             Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
+           ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -48,7 +48,7 @@ class PIMLauncher:
         graphics_driver: Union[
             FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
         ] = None,
-        product_version: Optional[FluentVersion] = None,
+        product_version: Union[FluentVersion, str, float, int] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
         processor_count: Optional[int] = None,
@@ -73,8 +73,9 @@ class PIMLauncher:
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
-        product_version : FluentVersion, optional
-            Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+        product_version : FluentVersion or str or float or int, optional
+            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
+            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,
@@ -153,7 +154,9 @@ class PIMLauncher:
     def __call__(self):
         logger.info("Starting Fluent remotely. The startup configuration is ignored.")
         if self.argvals["product_version"]:
-            fluent_product_version = str(self.argvals["product_version"].number)
+            fluent_product_version = str(
+                FluentVersion(self.argvals["product_version"]).number
+            )
         else:
             fluent_product_version = None
 
@@ -172,7 +175,7 @@ class PIMLauncher:
 def launch_remote_fluent(
     session_cls,
     start_transcript: bool,
-    product_version: Optional[FluentVersion] = None,
+    product_version: Optional[str] = None,
     cleanup_on_exit: bool = True,
     mode: FluentMode = FluentMode.SOLVER,
     dimensionality: Optional[str] = None,
@@ -194,8 +197,8 @@ def launch_remote_fluent(
         Whether to start streaming the Fluent transcript in the client. The
         default is ``True``. You can stop and start the streaming of the
         Fluent transcript subsequently via method calls on the session object.
-    product_version : FluentVersion, optional
-        Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+    product_version : str, optional
+        Version of Ansys Fluent to launch. Use ``"242"`` for 2024 R2.
         The default is ``None``, in which case the newest installed version is used.
     cleanup_on_exit : bool, optional
         Whether to clean up and exit Fluent when Python exits or when garbage

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -127,16 +127,16 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
         else:
             return fluent_root / "bin" / "fluent"
 
-    # (DEV) "PYFLUENT_FLUENT_ROOT" environment variable
-    fluent_root = os.getenv("PYFLUENT_FLUENT_ROOT")
-    if fluent_root:
-        return get_exe_path(Path(fluent_root))
-
     # Look for Fluent exe path in the following order:
     # 1. product_version parameter passed with launch_fluent
     product_version = launch_argvals.get("product_version")
     if product_version:
         return get_exe_path(get_fluent_root(FluentVersion(product_version)))
+
+    # (DEV) "PYFLUENT_FLUENT_ROOT" environment variable
+    fluent_root = os.getenv("PYFLUENT_FLUENT_ROOT")
+    if fluent_root:
+        return get_exe_path(Path(fluent_root))
 
     # 2. the latest ANSYS version from AWP_ROOT environment variables
     return get_exe_path(get_fluent_root(FluentVersion.get_latest_installed()))

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -219,7 +219,7 @@ def _get_running_session_mode(
 
 
 def _get_standalone_launch_fluent_version(
-    product_version: Union[FluentVersion, None]
+    product_version: Union[FluentVersion, str, float, int, None]
 ) -> Optional[FluentVersion]:
     """Determine the Fluent version during the execution of the ``launch_fluent()``
     method in standalone mode.
@@ -235,15 +235,15 @@ def _get_standalone_launch_fluent_version(
         Fluent version or ``None``
     """
 
-    # (DEV) if "PYFLUENT_FLUENT_ROOT" environment variable is defined, we cannot
-    # determine the Fluent version, so returning None.
-    if os.getenv("PYFLUENT_FLUENT_ROOT"):
-        return None
-
     # Look for Fluent version in the following order:
     # 1. product_version parameter passed with launch_fluent
     if product_version:
         return FluentVersion(product_version)
+
+    # (DEV) if "PYFLUENT_FLUENT_ROOT" environment variable is defined, we cannot
+    # determine the Fluent version, so returning None.
+    if os.getenv("PYFLUENT_FLUENT_ROOT"):
+        return None
 
     # 2. the latest ANSYS version from AWP_ROOT environment variables
     return FluentVersion.get_latest_installed()

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -208,7 +208,7 @@ class SlurmLauncher:
         graphics_driver: Union[
             FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
         ] = None,
-        product_version: Optional[FluentVersion] = None,
+        product_version: Union[FluentVersion, str, float, int, None] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
         processor_count: Optional[int] = None,
@@ -241,8 +241,9 @@ class SlurmLauncher:
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
-        product_version : FluentVersion, optional
-            Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+        product_version : FluentVersion or str or float or int, optional
+            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
+            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -243,7 +243,7 @@ class SlurmLauncher:
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
             Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
+            ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -60,7 +60,7 @@ class StandaloneLauncher:
         graphics_driver: Union[
             FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver, str, None
         ] = None,
-        product_version: Optional[FluentVersion] = None,
+        product_version: Union[FluentVersion, str, float, int, None] = None,
         version: Optional[str] = None,
         precision: Optional[str] = None,
         processor_count: Optional[int] = None,
@@ -92,8 +92,9 @@ class StandaloneLauncher:
             Graphics driver of Fluent. Options are the values of the
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
-        product_version : FluentVersion, optional
-            Version of Ansys Fluent to launch. Use ``FluentVersion.v241`` for 2024 R1.
+        product_version : FluentVersion or str or float or int, optional
+            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
+            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -94,7 +94,7 @@ class StandaloneLauncher:
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
             Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
+           ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
             The default is ``None``, in which case the newest installed version is used.
         version : str, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -279,7 +279,7 @@ def test_get_fluent_exe_path_from_product_version_launcher_arg(helpers):
         expected_path = Path("ansys_inc/v231/fluent") / "ntbin" / "win64" / "fluent.exe"
     else:
         expected_path = Path("ansys_inc/v231/fluent") / "bin" / "fluent"
-    assert get_fluent_exe_path(product_version=FluentVersion.v231) == expected_path
+    assert get_fluent_exe_path(product_version=231) == expected_path
 
 
 def test_get_fluent_exe_path_from_pyfluent_fluent_root(helpers, monkeypatch):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -289,7 +289,7 @@ def test_get_fluent_exe_path_from_pyfluent_fluent_root(helpers, monkeypatch):
         expected_path = Path("dev/vNNN/fluent") / "ntbin" / "win64" / "fluent.exe"
     else:
         expected_path = Path("dev/vNNN/fluent") / "bin" / "fluent"
-    assert get_fluent_exe_path(product_version=FluentVersion.v231) == expected_path
+    assert get_fluent_exe_path() == expected_path
 
 
 def test_watchdog_launch(monkeypatch):


### PR DESCRIPTION
`FluentVersion` can be constructed as:
```
FluentVersion.v242
FluentVersion("24.2.0")
FluentVersion("24.2")
FluentVersion(24.2)
FluentVersion(242)
```
Supporting all of them in `product_version`.

Also, `product_version` is given higher priority over the env var `PYFLUENT_FLUENT_ROOT`.