### PR TITLE
fix: Update contributing doc

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -36,10 +36,10 @@ repository, run:
     make html
 
 After the build completes, the HTML documentation is located in the
-``_builds/html`` directory. You can load the ``index.html`` file in
+``_build/html`` directory. You can load the ``index.html`` file in
 this directory into a web browser.
 
-You can clear all HTML files from the ``_builds/html`` directory with:
+You can clear all HTML files from the ``_build/html`` directory with:
 
 .. code::
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -31,7 +31,7 @@ repository, run:
 
 .. code:: 
 
-    pip install -r requirements/requirements_doc.txt
+    poetry install --with docs
     cd doc
     make html
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2883, https://github.com/ansys/pyfluent/issues/2894

1. Updated `Build documentation` instructions.
2. Renamed `_builds` -> `_build`