### PR TITLE
fix: Install and display all Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,13 @@ jobs:
           - should-release: false
             os: macos-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
       - name: Build wheelhouse and perform smoke test
         uses: ansys/actions/build-wheelhouse@v6
         with:


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2106

Install and test all supported Python versions as a part of smoke test.

Now - 

![image](https://github.com/ansys/pyfluent/assets/106588300/c991a1ab-80da-47b1-9f0f-2d251f235946)

before - 

![image](https://github.com/ansys/pyfluent/assets/106588300/0cc62bd6-864a-40b0-99ff-78608efd9d67)
