### PR TITLE
test: fix test_fluent_freeze_kill

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -667,7 +667,7 @@ class FluentConnection:
             if wait is not False:
                 self.wait_process_finished(wait=wait)
         else:
-            if not self.health_check.is_serving:
+            if not timeout_exec(lambda: self.health_check.is_serving, 5):
                 logger.debug("gRPC service not working, cancelling soft exit call.")
             else:
                 logger.info("Attempting to send exit request to Fluent...")

--- a/src/ansys/fluent/core/launcher/watchdog_exec
+++ b/src/ansys/fluent/core/launcher/watchdog_exec
@@ -128,7 +128,7 @@ if __name__ == "__main__":
                 "Fluent processes remain. Checking if Fluent gRPC service is healthy..."
             )
             is_serving = timeout_exec(
-                fluent.health_check.is_serving, timeout=IDLE_PERIOD * 3
+                lambda: fluent.health_check.is_serving, timeout=IDLE_PERIOD * 3
             )
 
             if is_serving:

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -192,7 +192,6 @@ def test_fluent_connection_properties(
     assert isinstance(connection_properties.fluent_host_pid, int)
 
 
-@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/2899")
 def test_fluent_freeze_kill(
     new_solver_session,
 ) -> None:


### PR DESCRIPTION
As the health-check service is now executed on main thread in FLuent, calling `session.health_check.is_serving` when Fluent's main thread is frozen will hang in client . Calling `session.health_check.is_serving` in `timeout_exec` to resolve the client hang.