### PR TITLE
fix: command return type for old Fluent version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ compare-flobject:
 
 cleanup-previous-docker-containers:
 	@if [ -n "$(docker ps -a -q)" ]; then \
+		echo "Found running containers"; \
 		docker inspect --format='{{.Config.Labels.test_name}}' $(docker ps -a -q); \
 		docker stop $(docker ps -a -q); \
 	fi

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1948,9 +1948,12 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             _process_cls_names(arguments, cls.argument_names, write_doc=True)
             cls.__doc__ = doc
 
-        return_type = info.get("return-type") or info.get("return_type")
-        if return_type:
-            cls.return_type = return_type
+        if version < "242":
+            cls.return_type = object()
+        else:
+            return_type = info.get("return-type") or info.get("return_type")
+            if return_type:
+                cls.return_type = return_type
 
         object_type = info.get("object-type", False) or info.get("object_type", False)
         if object_type:

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -298,13 +298,13 @@ def test_deprecated_settings(new_solver_session):
     }
 
 
-@pytest.mark.fluent_version(">=24.2")
 def test_command_return_type(new_solver_session):
     solver = new_solver_session
+    version = solver.get_fluent_version()
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
     download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
     ret = solver.file.read_case_data(file_name=case_path)
-    assert ret is None
+    assert ret is None if version >= FluentVersion.v242 else not None
     solver.solution.report_definitions.surface["surface-1"] = dict(
         surface_names=["cold-inlet"]
     )

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -298,6 +298,7 @@ def test_deprecated_settings(new_solver_session):
     }
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_command_return_type(new_solver_session):
     solver = new_solver_session
     version = solver.get_fluent_version()


### PR DESCRIPTION
For Fluent version < 24.2, commands will return the value of the settings API function call as before. For later Fluent versions, commands will return value only if the `return_type` attribute is specified for the command in settings API.