### PR TITLE
docs: Add events manager example to user guide section and add comments in examples scripts

### DIFF
--- a/doc/source/user_guide/events_manager.rst
+++ b/doc/source/user_guide/events_manager.rst
@@ -1,0 +1,13 @@
+.. _ref_user_guide_events_manager:
+
+Use events manager
+==================
+
+The following code triggers a callback at the end of every iteration.
+
+.. code-block:: python
+
+    def callback_executed_at_end_of_iteration(session_id, event_info):
+        print("Iteration ended index", event_info.index)
+
+    cb_itr_id = session.events_manager.register_callback('IterationEndedEvent', callback_executed_at_end_of_iteration)

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -24,6 +24,7 @@ Python code to control and monitor Ansys Fluent.
    materials
    boundary_conditions
    solution
+   events_manager
 
 
 Overview

--- a/examples/00-fluent/exhaust_system.py
+++ b/examples/00-fluent/exhaust_system.py
@@ -84,7 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
-# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
+# Execute meshing.upload(import_file_name) if Fluent is running in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/exhaust_system.py
+++ b/examples/00-fluent/exhaust_system.py
@@ -84,7 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
-# Execute meshing.upload(import_file_name) if Fluent is running in Ansys Lab.
+# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/exhaust_system.py
+++ b/examples/00-fluent/exhaust_system.py
@@ -48,6 +48,8 @@ to demonstrate the automatic leakage detection aspects of the meshing workflow.
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 import_file_name = examples.download_file(
     "exhaust_system.fmd", "pyfluent/exhaust_system"
@@ -82,6 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
+# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/exhaust_system_settings_api.py
+++ b/examples/00-fluent/exhaust_system_settings_api.py
@@ -84,7 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
-# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
+# Execute meshing.upload(import_file_name) if Fluent is running in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/exhaust_system_settings_api.py
+++ b/examples/00-fluent/exhaust_system_settings_api.py
@@ -84,7 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
-# Execute meshing.upload(import_file_name) if Fluent is running in Ansys Lab.
+# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/exhaust_system_settings_api.py
+++ b/examples/00-fluent/exhaust_system_settings_api.py
@@ -48,6 +48,8 @@ to demonstrate the automatic leakage detection aspects of the meshing workflow.
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 import_file_name = examples.download_file(
     "exhaust_system.fmd", "pyfluent/exhaust_system"
@@ -82,6 +84,7 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry file (``exhaust_system.fmd``) and selectively manage some
 # parts.
+# Execute meshing.upload(import_file_name) if Fluent is running in container mode or in Ansys Lab.
 
 meshing.PartManagement.InputFileChanged(
     FilePath=import_file_name, IgnoreSolidNames=False, PartPerBody=False

--- a/examples/00-fluent/external_compressible_flow.py
+++ b/examples/00-fluent/external_compressible_flow.py
@@ -48,6 +48,8 @@ an aspect ratio of 3.8, and a taper ratio of 0.562.
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 wing_spaceclaim_file, wing_intermediary_file = [
     examples.download_file(CAD_file, "pyfluent/external_compressible")
@@ -88,6 +90,8 @@ geo_import.Arguments.set_state(
         "FileName": wing_intermediary_file,
     }
 )
+
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/external_compressible_flow.py
+++ b/examples/00-fluent/external_compressible_flow.py
@@ -91,7 +91,7 @@ geo_import.Arguments.set_state(
     }
 )
 
-# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/external_compressible_flow.py
+++ b/examples/00-fluent/external_compressible_flow.py
@@ -91,7 +91,7 @@ geo_import.Arguments.set_state(
     }
 )
 
-# Execute meshing.upload(wing_intermediary_file) if Fluent is running in Ansys Lab.
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/mixing_elbow.py
+++ b/examples/00-fluent/mixing_elbow.py
@@ -90,7 +90,7 @@ geo_import.Arguments = {
 # ~~~~~~~~~~~~~~~
 # Import the geometry.
 
-# Execute meshing.upload(wing_intermediary_file) if Fluent is running in Ansys Lab.
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/mixing_elbow.py
+++ b/examples/00-fluent/mixing_elbow.py
@@ -45,6 +45,8 @@ flow at the larger inlet is ``50, 800``, a turbulent flow model is required.
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 import_file_name = examples.download_file("mixing_elbow.pmdb", "pyfluent/mixing_elbow")
 
@@ -87,6 +89,8 @@ geo_import.Arguments = {
 # Import geometry
 # ~~~~~~~~~~~~~~~
 # Import the geometry.
+
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/mixing_elbow.py
+++ b/examples/00-fluent/mixing_elbow.py
@@ -90,7 +90,7 @@ geo_import.Arguments = {
 # ~~~~~~~~~~~~~~~
 # Import the geometry.
 
-# Execute meshing.upload(wing_intermediary_file) if Fluent is running in container mode or in Ansys Lab.
+# Execute meshing.upload(wing_intermediary_file) if Fluent is running in Ansys Lab.
 
 geo_import.Execute()
 

--- a/examples/00-fluent/mixing_elbow_settings_api.py
+++ b/examples/00-fluent/mixing_elbow_settings_api.py
@@ -29,6 +29,8 @@ flow at the larger inlet is ``50, 800``, a turbulent flow model is required.
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 import_file_name = examples.download_file(
     "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"

--- a/examples/00-fluent/modeling_cavitation.py
+++ b/examples/00-fluent/modeling_cavitation.py
@@ -48,6 +48,8 @@ os.environ["AWP_ROOT251"] = r"C:\Program Files\ANSYS Inc\v241"
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 
+# Do not set pyfluent.CONTAINER_MOUNT_PATH. It has set to run this example in GitHub container only.
+
 pyfluent.CONTAINER_MOUNT_PATH = pyfluent.EXAMPLES_PATH
 cav_file = examples.download_file("cav.msh.gz", "pyfluent/cavitation")
 
@@ -266,11 +268,11 @@ initialization.hybrid_initialize()
 # Save the case file 'cav.cas.h5'. Then, start the calculation by requesting
 # 500 iterations. Save the final case file and the data.
 
-solver.file.write_case(file_name="cav")
+solver.file.write_case(file_name="cav.cas.h5")
 
 solver.solution.run_calculation.iterate(iter_count=500)
 
-solver.file.write_case_data(file_name="cav")
+solver.file.write_case_data(file_name="cav.cas.h5")
 
 ###############################################################################
 # Post Processing


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2921, https://github.com/ansys/pyfluent/issues/2949

Add events manager example to user guide section. We have added single example for now.

Add following comments - 
        1. Do not set pyfluent.pyfluent.CONTAINER_MOUNT_PATH and
         2. Execute <session>.upload() wherever necessary. (Thanks a lot @answillgm for reporting this.)

![image](https://github.com/ansys/pyfluent/assets/106588300/36952558-456e-41f8-acda-b990aef38d84)
