### PR TITLE
feat: Create as command in Fluent 25.1

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1764,7 +1764,7 @@ class CreatableNamedObjectMixin(collections.abc.MutableMapping, Generic[ChildTyp
 
 
 class CreatableNamedObjectMixinOld(CreatableNamedObjectMixin):
-    """Provides creatable named objects for Fluent 24.2 and earlier."""
+    """Provides creatable named objects for Fluent 2024 R2 and earlier."""
 
     # In Fluent 2025 R1, the ``create()`` method is available as commands in the ``NamedObject`` class.
     def create(self, name: str = "") -> ChildTypeT:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1749,7 +1749,7 @@ class _ChildNamedObjectAccessorMixin(collections.abc.MutableMapping):
 
 
 class CreatableNamedObjectMixin(collections.abc.MutableMapping, Generic[ChildTypeT]):
-    """Provides creatable named objects for Fluent 25.1 and later."""
+    """Provides creatable named objects for Fluent 2025 R1 and later."""
 
     def __setitem__(self, name: str, value):
         if name not in self.get_object_names():

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1766,7 +1766,7 @@ class CreatableNamedObjectMixin(collections.abc.MutableMapping, Generic[ChildTyp
 class CreatableNamedObjectMixinOld(CreatableNamedObjectMixin):
     """Provides creatable named objects for Fluent 24.2 and earlier."""
 
-    # In Fluent 25.1, create method is available as commands in NamedObject class.
+    # In Fluent 2025 R1, the ``create()`` method is available as commands in the ``NamedObject`` class.
     def create(self, name: str = "") -> ChildTypeT:
         """Create a named object.
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1577,6 +1577,8 @@ class BaseCommand(Action):
             kwds[arg] = argument.after_execute(
                 command_name=self.python_name, value=value, kwargs=kwds
             )
+        if self.obj_name == "create" and isinstance(self._parent, NamedObject):
+            return self._parent[ret]
         return_t = getattr(self, "return_type", None)
         if return_t:
             base_t = _baseTypes.get(return_t)
@@ -1819,7 +1821,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             pname = to_python_name(name)
         obj_type = info["type"]
         base = _baseTypes.get(obj_type)
-        if obj_type == "command" and name in ["rename", "delete", "resize"]:
+        if obj_type == "command" and name in ["rename", "delete", "resize", "create"]:
             base = CommandWithPositionalArgs
         if base is None:
             settings_logger.warning(

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1821,7 +1821,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             pname = to_python_name(name)
         obj_type = info["type"]
         base = _baseTypes.get(obj_type)
-        if obj_type == "command" and name in ["rename", "delete", "resize", "create"]:
+        if obj_type == "command" and name in ["create", "rename", "delete", "resize"]:
             base = CommandWithPositionalArgs
         if base is None:
             settings_logger.warning(

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1178,7 +1178,8 @@ def test_static_info_hash_identity(new_solver_session):
 def test_default_argument_names_for_commands(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 
-    assert solver.results.graphics.contour.command_names == [
+    assert set(solver.results.graphics.contour.command_names) == {
+        "create",
         "delete",
         "rename",
         "list",
@@ -1188,7 +1189,7 @@ def test_default_argument_names_for_commands(load_static_mixer_settings_only):
         "copy",
         "add_to_graphics",
         "clear_history",
-    ]
+    }
 
     assert solver.results.graphics.contour.rename.argument_names == ["new", "old"]
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1173,23 +1173,35 @@ def test_static_info_hash_identity(new_solver_session):
     assert hash1 == hash2
 
 
-@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/2997")
 @pytest.mark.fluent_version(">=24.2")
 def test_default_argument_names_for_commands(load_static_mixer_settings_only):
     solver = load_static_mixer_settings_only
 
-    assert set(solver.results.graphics.contour.command_names) == {
-        "create",
-        "delete",
-        "rename",
-        "list",
-        "list_properties",
-        "make_a_copy",
-        "display",
-        "copy",
-        "add_to_graphics",
-        "clear_history",
-    }
+    if solver.get_fluent_version() >= FluentVersion.v251:
+        assert set(solver.results.graphics.contour.command_names) == {
+            "create",
+            "delete",
+            "rename",
+            "list",
+            "list_properties",
+            "make_a_copy",
+            "display",
+            "copy",
+            "add_to_graphics",
+            "clear_history",
+        }
+    else:
+        assert set(solver.results.graphics.contour.command_names) == {
+            "delete",
+            "rename",
+            "list",
+            "list_properties",
+            "make_a_copy",
+            "display",
+            "copy",
+            "add_to_graphics",
+            "clear_history",
+        }
 
     assert solver.results.graphics.contour.rename.argument_names == ["new", "old"]
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -108,10 +108,14 @@ def test_wildcard_fnmatch(new_solver_session):
     solver.solution.initialization.hybrid_initialize()
 
     mesh = solver.results.graphics.mesh
-    assert mesh.create(name="mesh-2").name() == "mesh-2"
     assert mesh.create("mesh-a").name() == "mesh-a"
     mesh.create("mesh-bc")
-    assert mesh.create().name() == "mesh-3"
+    if solver.get_fluent_version() >= FluentVersion.v251:
+        assert mesh.create(name="mesh-2").name() == "mesh-2"
+        assert mesh.create().name() == "mesh-3"
+    else:
+        assert mesh.create("mesh-2").name() == "mesh-2"
+        assert mesh.create("mesh-3").name() == "mesh-3"
 
     assert sorted(mesh["mesh-*"]()) == sorted(
         ["mesh-1", "mesh-2", "mesh-3", "mesh-a", "mesh-bc"]

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -108,15 +108,18 @@ def test_wildcard_fnmatch(new_solver_session):
     solver.solution.initialization.hybrid_initialize()
 
     mesh = solver.results.graphics.mesh
-    mesh.create("mesh-2")
-    mesh.create("mesh-a")
+    assert mesh.create(name="mesh-2").name() == "mesh-2"
+    assert mesh.create("mesh-a").name() == "mesh-a"
     mesh.create("mesh-bc")
+    assert mesh.create().name() == "mesh-3"
 
-    assert sorted(mesh["mesh-*"]()) == sorted(["mesh-1", "mesh-2", "mesh-a", "mesh-bc"])
+    assert sorted(mesh["mesh-*"]()) == sorted(
+        ["mesh-1", "mesh-2", "mesh-3", "mesh-a", "mesh-bc"]
+    )
 
     assert list(mesh["mesh-?c"]().keys()) == ["mesh-bc"]
 
-    assert list(mesh["mesh-[2-5]"]().keys()) == ["mesh-2"]
+    assert list(mesh["mesh-[2-5]"]().keys()) == ["mesh-2", "mesh-3"]
 
     assert sorted(mesh["mesh-[!2-5]"]()) == sorted(["mesh-1", "mesh-a"])
 


### PR DESCRIPTION
`create()` is available as a command in Fluent 25.1. This PR contains PyFluent side change.

`CreatableNamedObjectMixinOld` - mixin with create method for Fluent < 25.1.
`CreatableNamedObjectMixin` - mixin without create method for Fluent >= 25.1 as create is available as a command.

Please see the changed test_wildcard_fnmatch for the currently supported usage (backward compatibility is provided).