### PR TITLE
refactor: update error message for Dimension enum.

### DIFF
--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -137,7 +137,7 @@ class Dimension(FluentEnum):
                 return member
         raise ValueError(
             f"The specified value '{value}' is not a supported value of {cls.__name__}."
-            f""" The supported values are: '{"', '".join((member.value[0][0]) for member in cls)}'."""
+            f""" The supported values are: {", ".join((member.value[0][0]) for member in cls)}."""
         )
 
 

--- a/tests/test_cad_to_post_wtm.py
+++ b/tests/test_cad_to_post_wtm.py
@@ -5,7 +5,7 @@ This test covers the setup and solution of a three-dimensional
 turbulent fluid flow and heat transfer problem in a mixing elbow. The mixing
 elbow configuration is encountered in piping systems in power plants and
 process industries. It is often important to predict the flow field and
-temperature field in the area of the mixing region in order to properly design
+temperature field in the area of the mixing region to properly design
 the junction.
 
 This test queries the following using PyTest:

--- a/tests/test_cad_to_post_wtm.py
+++ b/tests/test_cad_to_post_wtm.py
@@ -4,8 +4,8 @@ End-to-end Fluent Solver Workflow using Watertight Meshing
 This test covers the setup and solution of a three-dimensional
 turbulent fluid flow and heat transfer problem in a mixing elbow. The mixing
 elbow configuration is encountered in piping systems in power plants and
-processindustries. It is often important to predict the flow field and
-temperature field in the area of the mixing regionin order to properly design
+process industries. It is often important to predict the flow field and
+temperature field in the area of the mixing region in order to properly design
 the junction.
 
 This test queries the following using PyTest:

--- a/tests/test_cad_to_post_wtm.py
+++ b/tests/test_cad_to_post_wtm.py
@@ -1,7 +1,7 @@
 """
 End-to-end Fluent Solver Workflow using Watertight Meshing
 -----------------------------------------------------------------------------
-This test covers the setup and solution of a three-dimensional
+This test covers the setup and solution of a 3D
 turbulent fluid flow and heat transfer problem in a mixing elbow. The mixing
 elbow configuration is encountered in piping systems in power plants and
 process industries. It is often important to predict the flow field and


### PR DESCRIPTION
![image](https://github.com/ansys/pyfluent/assets/109645853/8f369ad6-0376-43c0-9515-c562cd493d31)

@seanpearsonuk, we can have a discussion whether we want to support "2" or "2d" as well. I think that dimension=2 (as an integer) or enum is clean and without any confusion. version="2d" is still supported, with a deprecation warning. dimension="2d" seems a bit redundant. dimension="2" as string can be supported but with a warning??
What do you think?