### PR TITLE
fix: name for compound child tasks

### DIFF
--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1213,7 +1213,6 @@ class CompoundTask(CommandTask):
             c += 1
         task_name = self.tasks()[-1].name()
         self.tasks()[-1]._set_python_name(py_name=py_name)
-        self._command_source.task(task_name)._set_python_name(py_name=py_name)
         self._command_source.tasks()[-1]._set_python_name(py_name=py_name)
         self._command_source._python_name_display_text_map[py_name] = task_name
 

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import threading
-from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Iterable, Iterator, Optional, Tuple, Union
 import warnings
 
 from ansys.fluent.core.services.datamodel_se import (
@@ -307,16 +307,6 @@ class BaseTask:
             Inactive ordered children.
         """
         return []
-
-    def child_task_python_names(self) -> List[str]:
-        """Get the Pythonic names of the child tasks.
-
-        Returns
-        -------
-        List[str]
-            Pythonic names of the child tasks.
-        """
-        return self._python_task_names
 
     def get_id(self) -> str:
         """Get the unique string identifier of this task, as it is in the application.
@@ -1395,17 +1385,6 @@ class Workflow:
                 self._task_list = task_list
         return self._ordered_children
 
-    def child_task_python_names(self) -> List[str]:
-        """Get the Pythonic names of the child tasks.
-
-        Returns
-        -------
-        List[str]
-            Pythonic names of the child tasks.
-        """
-        with self._lock:
-            return self._python_task_names
-
     @staticmethod
     def inactive_tasks() -> list:
         """Get the inactive ordered task list held by this task.
@@ -1453,7 +1432,7 @@ class Workflow:
             list(self.__dict__)
             + dir(type(self))
             + arg_list
-            + self.child_task_python_names()
+            + self.task_names()
             + list(self._repeated_task_python_name_display_text_map)
         )
         dir_set = dir_set - self._unwanted_attrs

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import threading
+import time
 from typing import Any, Iterable, Iterator, Optional, Tuple, Union
 import warnings
 
@@ -358,7 +359,13 @@ class BaseTask:
         str
             Pythonic name of the task.
         """
-        if not self._python_name:
+        if self._python_name in self._command_source._compound_task_names_with_children:
+            if (
+                self.task_type() == "Compound Child"
+                and self.name() in self._command_source._compound_task_map
+            ):
+                self._python_name = self._command_source._compound_task_map[self.name()]
+        elif not self._python_name:
             if self._command_source._dynamic_python_names:
                 display_name_map = self._command_source._python_name_display_text_map
                 if self.display_name() not in display_name_map.values():
@@ -374,12 +381,13 @@ class BaseTask:
 
     def _set_python_name(self, compound=False):
         this_command = self._command()
-        if self.task_type() == "Compound Child" or compound:
+        if compound:
             p_name = (
                 f"child_{self._command_source._compound_parent_task_python_name_id[1]}_of_"
                 + self._command_source._compound_parent_task_python_name_id[0]
             )
             self._python_name = p_name
+            self._command_source._compound_task_map[self.name()] = p_name
         else:
             self._python_name = camel_to_snake_case(this_command.get_attr("helpString"))
         self._cache_data(this_command)
@@ -1047,6 +1055,7 @@ class CompoundChild(SimpleTask):
             The name of this task.
         """
         super().__init__(command_source, task)
+        self._set_python_name(compound=True)
 
 
 class CompositeTask(BaseTask):
@@ -1189,6 +1198,9 @@ class CompoundTask(CommandTask):
             self._command_source._compound_parent_task_python_name_id[0] = (
                 self.python_name()
             )
+            self._command_source._compound_task_names_with_children.append(
+                self.python_name()
+            )
             self._command_source._compound_parent_task_python_name_id[1] = 0
 
         self._command_source._compound_parent_task_python_name_id[1] = (
@@ -1206,6 +1218,7 @@ class CompoundTask(CommandTask):
                     PyFluentUserWarning,
                 )
             self._task.AddChildAndUpdate()
+        time.sleep(1)
         self.tasks()[-1]._set_python_name(compound=True)
         return self.last_child()
 
@@ -1311,6 +1324,8 @@ class Workflow:
                 _repeated_task_python_name_display_text_map={},
                 _initial_task_python_names_map={},
                 _compound_parent_task_python_name_id=[None, 0],
+                _compound_task_map={},
+                _compound_task_names_with_children=[],
                 _unwanted_attrs={
                     "reset_workflow",
                     "initialize_workflow",

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1200,12 +1200,8 @@ class CompoundTask(CommandTask):
                     PyFluentUserWarning,
                 )
             self._task.AddChildAndUpdate()
-        self._update_python_name()
-        return self.last_child()
-
-    def _update_python_name(self):
         self.tasks()[-1]._set_python_name(compound=True)
-        self._command_source.tasks()[-1]._set_python_name(compound=True)
+        return self.last_child()
 
     def last_child(self) -> BaseTask:
         """Get the last child of this CompoundTask.

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1182,9 +1182,15 @@ class CompoundTask(CommandTask):
         defer_update : bool, default: False
             Whether to defer the update.
         """
-        self._command_source._compound_parent_task_python_name_id[0] = (
+        if (
             self.python_name()
-        )
+            != self._command_source._compound_parent_task_python_name_id[0]
+        ):
+            self._command_source._compound_parent_task_python_name_id[0] = (
+                self.python_name()
+            )
+            self._command_source._compound_parent_task_python_name_id[1] = 0
+
         self._command_source._compound_parent_task_python_name_id[1] = (
             self._command_source._compound_parent_task_python_name_id[1] + 1
         )

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -383,8 +383,8 @@ class BaseTask:
         this_command = self._command()
         if compound:
             p_name = (
-                f"child_{self._command_source._compound_parent_task_python_name_id[1]}_of_"
-                + self._command_source._compound_parent_task_python_name_id[0]
+                self._command_source._compound_parent_task_python_name_id[0]
+                + f"_child_{self._command_source._compound_parent_task_python_name_id[1]}"
             )
             self._python_name = p_name
             self._command_source._compound_task_map[self.name()] = p_name

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -727,9 +727,7 @@ def test_watertight_workflow_children(mixing_elbow_geometry, new_mesh_session):
     describe_geometry = watertight.describe_geometry
     describe_geometry_children = describe_geometry.tasks()
     assert len(describe_geometry_children) == 2
-    describe_geometry_child_task_python_names = (
-        describe_geometry.child_task_python_names()
-    )
+    describe_geometry_child_task_python_names = describe_geometry.task_names()
     assert describe_geometry_child_task_python_names == [
         "enclose_fluid_regions",
         "create_regions",

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1507,3 +1507,47 @@ def test_switching_workflow_interface(new_mesh_session):
     lw = new_mesh_session.load_workflow(file_path=saved_workflow_path)
     wt2 = new_mesh_session.watertight()
     del wt1, ft, tw, cw, lw, wt2
+
+
+@pytest.mark.codegen_required
+@pytest.mark.fluent_version(">=24.1")
+def test_duplicate_children_of_compound_task(new_mesh_session, mixing_elbow_geometry):
+    watertight = new_mesh_session.watertight()
+    watertight.import_geometry.file_name = mixing_elbow_geometry
+    watertight.import_geometry()
+    watertight.add_local_sizing.add_child_and_update(
+        state={
+            "boi_control_name": "wall",
+            "boi_face_label_list": ["wall-elbow", "wall-inlet"],
+            "boi_size": 10,
+        }
+    )
+    watertight.add_local_sizing.add_child_and_update(
+        state={
+            "boi_control_name": "inlet",
+            "boi_face_label_list": ["wall-inlet", "cold-inlet", "hot-inlet"],
+            "boi_size": 10,
+        }
+    )
+    watertight.add_local_sizing.add_child_and_update(
+        state={
+            "boi_control_name": "outlet",
+            "boi_face_label_list": ["outlet"],
+            "boi_size": 10,
+        }
+    )
+
+    assert {
+        "child_of_add_local_sizing",
+        "child_1_of_add_local_sizing",
+        "child_2_of_add_local_sizing",
+    }.issubset(set(watertight.task_names()))
+
+    assert watertight.add_local_sizing.task_names() == [
+        "child_of_add_local_sizing",
+        "child_1_of_add_local_sizing",
+        "child_2_of_add_local_sizing",
+    ]
+
+    assert watertight.tasks()[-2].name() == "inlet"
+    assert watertight.tasks()[-2].python_name() == "child_1_of_add_local_sizing"

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1551,3 +1551,4 @@ def test_duplicate_children_of_compound_task(new_mesh_session, mixing_elbow_geom
 
     assert watertight.tasks()[-2].name() == "inlet"
     assert watertight.tasks()[-2].python_name() == "child_1_of_add_local_sizing"
+    assert watertight.task("inlet").python_name() == "child_1_of_add_local_sizing"

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1538,17 +1538,16 @@ def test_duplicate_children_of_compound_task(new_mesh_session, mixing_elbow_geom
     )
 
     assert {
-        "child_of_add_local_sizing",
         "child_1_of_add_local_sizing",
         "child_2_of_add_local_sizing",
+        "child_3_of_add_local_sizing",
     }.issubset(set(watertight.task_names()))
 
     assert watertight.add_local_sizing.task_names() == [
-        "child_of_add_local_sizing",
         "child_1_of_add_local_sizing",
         "child_2_of_add_local_sizing",
+        "child_3_of_add_local_sizing",
     ]
 
     assert watertight.tasks()[-2].name() == "inlet"
-    assert watertight.tasks()[-2].python_name() == "child_1_of_add_local_sizing"
-    assert watertight.task("inlet").python_name() == "child_1_of_add_local_sizing"
+    assert watertight.tasks()[-2].python_name() == "child_2_of_add_local_sizing"

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -723,7 +723,7 @@ def test_watertight_workflow_children(mixing_elbow_geometry, new_mesh_session):
     added_sizing_by_pos = add_local_sizing.last_child()
     assert added_sizing.arguments() == added_sizing_by_name.arguments()
     assert added_sizing.arguments() == added_sizing_by_pos.arguments()
-    assert not added_sizing.python_name()
+    assert added_sizing.python_name() == "child_1_of_add_local_sizing"
     describe_geometry = watertight.describe_geometry
     describe_geometry_children = describe_geometry.tasks()
     assert len(describe_geometry_children) == 2

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -723,7 +723,7 @@ def test_watertight_workflow_children(mixing_elbow_geometry, new_mesh_session):
     added_sizing_by_pos = add_local_sizing.last_child()
     assert added_sizing.arguments() == added_sizing_by_name.arguments()
     assert added_sizing.arguments() == added_sizing_by_pos.arguments()
-    assert added_sizing.python_name() == "child_1_of_add_local_sizing"
+    assert added_sizing.python_name() == "add_local_sizing_child_1"
     describe_geometry = watertight.describe_geometry
     describe_geometry_children = describe_geometry.tasks()
     assert len(describe_geometry_children) == 2

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1549,3 +1549,9 @@ def test_duplicate_children_of_compound_task(new_mesh_session, mixing_elbow_geom
 
     assert watertight.tasks()[-2].name() == "inlet"
     assert watertight.tasks()[-2].python_name() == "add_local_sizing_child_2"
+
+    assert watertight.add_local_sizing.tasks()[-1].name() == "outlet"
+    assert (
+        watertight.add_local_sizing.tasks()[-1].python_name()
+        == "add_local_sizing_child_3"
+    )

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1536,16 +1536,16 @@ def test_duplicate_children_of_compound_task(new_mesh_session, mixing_elbow_geom
     )
 
     assert {
-        "child_1_of_add_local_sizing",
-        "child_2_of_add_local_sizing",
-        "child_3_of_add_local_sizing",
+        "add_local_sizing_child_1",
+        "add_local_sizing_child_2",
+        "add_local_sizing_child_3",
     }.issubset(set(watertight.task_names()))
 
     assert watertight.add_local_sizing.task_names() == [
-        "child_1_of_add_local_sizing",
-        "child_2_of_add_local_sizing",
-        "child_3_of_add_local_sizing",
+        "add_local_sizing_child_1",
+        "add_local_sizing_child_2",
+        "add_local_sizing_child_3",
     ]
 
     assert watertight.tasks()[-2].name() == "inlet"
-    assert watertight.tasks()[-2].python_name() == "child_2_of_add_local_sizing"
+    assert watertight.tasks()[-2].python_name() == "add_local_sizing_child_2"


### PR DESCRIPTION
Compound child task_names() should have a format of the parent name followed by child number. Please see the test for details.