### PR TITLE
fix: Update field_name error allowed values

### DIFF
--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -262,7 +262,7 @@ class _AllowedFieldNames(_AllowedNames):
                     allowed_name_error_message(
                         context="field",
                         trial_name=field_name,
-                        allowed_values=names(respect_data_valid=False),
+                        allowed_values=list(names(respect_data_valid=False).keys()),
                     )
                 )
             if not names.is_valid(field_name, respect_data_valid=True):

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -20,7 +20,6 @@ from ansys.fluent.core.services.interceptors import (
     TracingInterceptor,
 )
 from ansys.fluent.core.services.streaming import StreamingService
-from ansys.fluent.core.solver.error_message import allowed_name_error_message
 
 
 def override_help_text(func, func_to_be_wrapped):
@@ -259,11 +258,9 @@ class _AllowedFieldNames(_AllowedNames):
             names = self
             if not names.is_valid(field_name, respect_data_valid=False):
                 raise self._field_name_error(
-                    allowed_name_error_message(
-                        context="field",
-                        trial_name=field_name,
-                        allowed_values=list(names(respect_data_valid=False).keys()),
-                    )
+                    context="field",
+                    name=field_name,
+                    allowed_values=list(names(respect_data_valid=False).keys()),
                 )
             if not names.is_valid(field_name, respect_data_valid=True):
                 raise self._field_unavailable_error(


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2976

Update `field_name` error allowed values.

**Now** 

```
>>> add_scalar_fields(field_name='absolute-pressur', surface_names=add_scalar_fields.surface_names.allowed_values())
Traceback (most recent call last):
  File "D:\pyfluent\tests\debug.py", line 145, in <module>
    add_scalar_fields(field_name='absolute-pressur', surface_names=add_scalar_fields.surface_names.allowed_values())
  File "D:\pyfluent\src\ansys\fluent\core\services\field_data.py", line 355, in __call__
    return self._field_data_accessor(*args, **kwargs)
  File "D:\pyfluent\src\ansys\fluent\core\services\field_data.py", line 509, in add_scalar_fields_request
    [
  File "D:\pyfluent\src\ansys\fluent\core\services\field_data.py", line 512, in <listcomp>
    scalarFieldName=self._allowed_scalar_field_names.valid_name(
  File "D:\pyfluent\src\ansys\fluent\core\services\field_data.py", line 261, in valid_name
    raise self._field_name_error(
ansys.fluent.core.exceptions.DisallowedValuesError: 'field' has no attribute 'absolute-pressur'.
The most similar names are: absolute-pressure, total-pressure.

>>>
```

**`----------------------------------------------------------------------------------------`**

**Earlier**

```
>>> add_scalar_fields(field_name='absolute-pressur', surface_names=add_scalar_fields.surface_names.allowed_values())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\Repos\pyfluent\src\ansys\fluent\core\services\field_data.py", line 357, in __call__
    return self._field_data_accessor(*args, **kwargs)
  File "D:\Repos\pyfluent\src\ansys\fluent\core\services\field_data.py", line 511, in add_scalar_fields_request
    [
  File "D:\Repos\pyfluent\src\ansys\fluent\core\services\field_data.py", line 514, in <listcomp>
    scalarFieldName=self._allowed_scalar_field_names.valid_name(
  File "D:\Repos\pyfluent\src\ansys\fluent\core\services\field_data.py", line 261, in valid_name
    raise self._field_name_error(
ansys.fluent.core.exceptions.DisallowedValuesError: ''field' has no attribute 'absolute-pressur'.
The allowed values are: {'pressure': {'display_name': 'Static Pressure', 'section': 'Pressure...', 'domain': 'mixture'}, 'pressure-coefficient': {'display_name': 'Pressure Coefficient', 'section': 'Pressure...', 'domain': 'mixture'}
, 'dynamic-pressure': {'display_name': 'Dynamic Pressure', 'section': 'Pressure...', 'domain': 'mixture'}, 'absolute-pressure': {'display_name': 'Absolute Pressure', 'section': 'Pressure...', 'domain': 'mixture'}, 'total-pressure': 
{'display_name': 'Total Pressure', 'section': 'Pressure...', 'domain': 'mixture'}, 'rel-total-pressure': {'display_name': 'Relative Total Pressure', 'section': 'Pressure...', 'domain': 'mixture'}, 'density': {'display_name': 'Densit
y', 'section': 'Density...', 'domain': 'mixture'}, 'density-all': {'display_name': 'Density All', 'section': 'Density...', 'domain': 'mixture'}, 'velocity-magnitude': {'display_name': 'Velocity Magnitude', 'section': 'Velocity...', 
'domain': 'mixture'}, 'x-velocity': {'display_name': 'X Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'y-velocity': {'display_name': 'Y Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'z-velocity': {'display_
name': 'Z Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'axial-velocity': {'display_name': 'Axial Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'radial-velocity': {'display_name': 'Radial Velocity', 'sectio
n': 'Velocity...', 'domain': 'mixture'}, 'tangential-velocity': {'display_name': 'Tangential Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'rel-velocity-magnitude': {'display_name': 'Relative Velocity Magnitude', 'secti
on': 'Velocity...', 'domain': 'mixture'}, 'relative-x-velocity': {'display_name': 'Relative X Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'relative-y-velocity': {'display_name': 'Relative Y Velocity', 'section': 'Velo
city...', 'domain': 'mixture'}, 'relative-z-velocity': {'display_name': 'Relative Z Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'rel-axial-velocity': {'display_name': 'Relative Axial Velocity', 'section': 'Velocity...
', 'domain': 'mixture'}, 'rel-radial-velocity': {'display_name': 'Relative Radial Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'rel-tangential-velocity': {'display_name': 'Relative Tangential Velocity', 'section': 'Vel
ocity...', 'domain': 'mixture'}, 'mesh-x-velocity': {'display_name': 'Mesh X-Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'mesh-y-velocity': {'display_name': 'Mesh Y-Velocity', 'section': 'Velocity...', 'domain': 'mixt
ure'}, 'mesh-z-velocity': {'display_name': 'Mesh Z-Velocity', 'section': 'Velocity...', 'domain': 'mixture'}, 'velocity-angle': {'display_name': 'Velocity Angle', 'section': 'Velocity...', 'domain': 'mixture'}, 'relative-velocity-an
gle': {'display_name': 'Relative Velocity Angle', 'section': 'Velocity...', 'domain': 'mixture'}, 'vorticity-mag': {'display_name': 'Vorticity Magnitude', 'section': 'Velocity...', 'domain': 'mixture'}, 'helicity': {'display_name': 
'Helicity', 'section': 'Velocity...', 'domain': 'mixture'}, 'x-vorticity': {'display_name': 'X-Vorticity', 'section': 'Velocity...', 'domain': 'mixture'}, 'y-vorticity': {'display_name': 'Y-Vorticity', 'section': 'Velocity...', 'dom
ain': 'mixture'}, 'z-vorticity': {'display_name': 'Z-Vorticity', 'section': 'Velocity...', 'domain': 'mixture'}, 'cell-reynolds-number': {'display_name': 'Cell Reynolds Number', 'section': 'Velocity...', 'domain': 'mixture'}, 'cell-
convective-courant-number': {'display_name': 'Cell Convective Courant Number', 'section': 'Velocity...', 'domain': 'mixture'}, 'q-criterion': {'display_name': 'Q Criterion Normalized', 'section': 'Velocity...', 'domain': 'mixture'},
 'raw-q-criterion': {'display_name': 'Q Criterion Raw', 'section': 'Velocity...', 'domain': 'mixture'}, 'lambda2-criterion': {'display_name': 'Lambda 2 Criterion', 'section': 'Velocity...', 'domain': 'mixture'}, 'temperature': {'dis
play_name': 'Static Temperature', 'section': 'Temperature...', 'domain': 'mixture'}, 'total-temperature': {'display_name': 'Total Temperature', 'section': 'Temperature...', 'domain': 'mixture'}, 'enthalpy': {'display_name': 'Enthalp
y', 'section': 'Temperature...', 'domain': 'mixture'}, 'rel-total-temperature': {'display_name': 'Relative Total Temperature', 'section': 'Temperature...', 'domain': 'mixture'}, 'rothalpy': {'display_name': 'Rothalpy', 'section': 'T
emperature...', 'domain': 'mixture'}, 'wall-temperature': {'display_name': 'Wall Temperature', 'section': 'Temperature...', 'domain': 'mixture'}, 'wall-adjacent-temperature': {'display_name': 'Wall Adjacent Temperature', 'section': 
'Temperature...', 'domain': 'mixture'}, 'reference-temperature-at-y+': {'display_name': 'Yplus Based Heat Tran. Ref. Temperature', 'section': 'Temperature...', 'domain': 'mixture'}, 'wall-temp-thin': {'display_name': 'Wall Temperatu
re (Thin)', 'section': 'Temperature...', 'domain': 'mixture'}, 'total-enthalpy': {'display_name': 'Total Enthalpy', 'section': 'Temperature...', 'domain': 'mixture'}, 'rel-total-enthalpy': {'display_name': 'Relative Total Enthalpy',
 'section': 'Temperature...', 'domain': 'mixture'}, 'total-enthalpy-deviation': {'display_name': 'Total Enthalpy Deviation', 'section': 'Temperature...', 'domain': 'mixture'}, 'entropy': {'display_name': 'Entropy', 'section': 'Tempe
rature...', 'domain': 'mixture'}, 'total-energy': {'display_name': 'Total Energy', 'section': 'Temperature...', 'domain': 'mixture'}, 'internal-energy': {'display_name': 'Internal Energy', 'section': 'Temperature...', 'domain': 'mix
ture'}, 'turb-kinetic-energy': {'display_name': 'Turbulent Kinetic Energy (k)', 'section': 'Turbulence...', 'domain': 'mixture'}, 'turb-intensity': {'display_name': 'Turbulent Intensity', 'section': 'Turbulence...', 'domain': 'mixtu
re'}, 'turb-diss-rate': {'display_name': 'Turbulent Dissipation Rate (Epsilon)', 'section': 'Turbulence...', 'domain': 'mixture'}, 'specific-diss-rate': {'display_name': 'Specific Dissipation Rate (Omega)', 'section': 'Turbulence...
', 'domain': 'mixture'}, 'production-of-k': {'display_name': 'Production of k', 'section': 'Turbulence...', 'domain': 'mixture'}, 'viscosity-turb': {'display_name': 'Turbulent Viscosity', 'section': 'Turbulence...', 'domain': 'mixtu
re'}, 'viscosity-eff': {'display_name': 'Effective Viscosity', 'section': 'Turbulence...', 'domain': 'mixture'}, 'viscosity-ratio': {'display_name': 'Turbulent Viscosity Ratio', 'section': 'Turbulence...', 'domain': 'mixture'}, 'the
rmal-conductivity-eff': {'display_name': 'Effective Thermal Conductivity', 'section': 'Turbulence...', 'domain': 'mixture'}, 'prandtl-number-eff': {'display_name': 'Effective Prandtl Number', 'section': 'Turbulence...', 'domain': 'm
ixture'}, 'y-star': {'display_name': 'Wall Ystar', 'section': 'Turbulence...', 'domain': 'mixture'}, 'y-plus': {'display_name': 'Wall Yplus', 'section': 'Turbulence...', 'domain': 'mixture'}, 'turb-reynolds-number-rey': {'display_na
me': 'Turbulent Reynolds Number (Re_y)', 'section': 'Turbulence...', 'domain': 'mixture'}, 'viscosity-lam': {'display_name': 'Molecular Viscosity', 'section': 'Properties...', 'domain': 'mixture'}, 'thermal-conductivity-lam': {'disp
lay_name': 'Thermal Conductivity', 'section': 'Properties...', 'domain': 'mixture'}, 'specific-heat-cp': {'display_name': 'Specific Heat (Cp)', 'section': 'Properties...', 'domain': 'mixture'}, 'prandtl-number-lam': {'display_name':
 'Molecular Prandtl Number', 'section': 'Properties...', 'domain': 'mixture'}, 'wall-shear': {'display_name': 'Wall Shear Stress', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'x-wall-shear': {'display_name': 'X-Wall Shear Str
ess', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'y-wall-shear': {'display_name': 'Y-Wall Shear Stress', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'z-wall-shear': {'display_name': 'Z-Wall Shear Stress', 'section': '
Wall Fluxes...', 'domain': 'mixture'}, 'skin-friction-coef': {'display_name': 'Skin Friction Coefficient', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'heat-flux': {'display_name': 'Total Surface Heat Flux', 'section': 'Wall 
Fluxes...', 'domain': 'mixture'}, 'heat-transfer-coef': {'display_name': 'Surface Heat Transfer Coef.', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'heat-transfer-coef-wall-adj': {'display_name': 'Wall Adjacent Heat Transfer 
Coef.', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'heat-transfer-coef-yplus': {'display_name': 'Yplus Based Heat Tran. Coef.', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'heat-transfer-coef-wall': {'display_name': '
Wall Func. Heat Tran. Coef.', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'nusselt-number': {'display_name': 'Surface Nusselt Number', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'stanton-number': {'display_name': 'Sur
face Stanton Number', 'section': 'Wall Fluxes...', 'domain': 'mixture'}, 'cell-partition-active': {'display_name': 'Active Cell Partition', 'section': 'Cell Info...', 'domain': 'mixture'}, 'cell-partition-stored': {'display_name': '
Stored Cell Partition', 'section': 'Cell Info...', 'domain': 'mixture'}, 'cell-id': {'display_name': 'Cell Id', 'section': 'Cell Info...', 'domain': 'mixture'}, 'cell-element-type': {'display_name': 'Cell Element Type', 'section': '
Cell Info...', 'domain': 'mixture'}, 'cell-type': {'display_name': 'Cell Zone Type', 'section': 'Cell Info...', 'domain': 'mixture'}, 'cell-zone': {'display_name': 'Cell Zone Index', 'section': 'Cell Info...', 'domain': 'mixture'}, 
'partition-neighbors': {'display_name': 'Partition Neighbors', 'section': 'Cell Info...', 'domain': 'mixture'}, 'cell-weight': {'display_name': 'Cell Weight', 'section': 'Cell Info...', 'domain': 'mixture'}, 'x-coordinate': {'displa
y_name': 'X-Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'y-coordinate': {'display_name': 'Y-Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'z-coordinate': {'display_name': 'Z-Coordinate', 'section': 'Mesh...',
 'domain': 'mixture'}, 'axial-coordinate': {'display_name': 'Axial Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'angular-coordinate': {'display_name': 'Angular Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'ab
s-angular-coordinate': {'display_name': 'Abs. Angular Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'radial-coordinate': {'display_name': 'Radial Coordinate', 'section': 'Mesh...', 'domain': 'mixture'}, 'face-area-magnitu
de': {'display_name': 'Face Area Magnitude', 'section': 'Mesh...', 'domain': 'mixture'}, 'x-face-area': {'display_name': 'X Face Area', 'section': 'Mesh...', 'domain': 'mixture'}, 'y-face-area': {'display_name': 'Y Face Area', 'sect
ion': 'Mesh...', 'domain': 'mixture'}, 'z-face-area': {'display_name': 'Z Face Area', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-volume': {'display_name': 'Cell Volume', 'section': 'Mesh...', 'domain': 'mixture'}, 'orthogonal
-quality': {'display_name': 'Orthogonal Quality', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-equiangle-skew': {'display_name': 'Cell Equiangle Skew', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-equivolume-skew': {'displ
ay_name': 'Cell Equivolume Skew', 'section': 'Mesh...', 'domain': 'mixture'}, 'face-handedness': {'display_name': 'Face Handedness', 'section': 'Mesh...', 'domain': 'mixture'}, 'mark-poor-elements': {'display_name': 'Mark Poor Eleme
nts', 'section': 'Mesh...', 'domain': 'mixture'}, 'interface-overlap-fraction': {'display_name': 'Interface Overlap Fraction', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-wall-distance': {'display_name': 'Cell Wall Distance', 
'section': 'Mesh...', 'domain': 'mixture'}, 'aspect-ratio': {'display_name': 'Aspect Ratio', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-refine-level': {'display_name': 'Cell Refine Level', 'section': 'Mesh...', 'domain': 'mix
ture'}, 'smoothed-cell-refine-level': {'display_name': 'Smoothed Cell Refine Level', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-parent-index': {'display_name': 'Cell Parent Index', 'section': 'Mesh...', 'domain': 'mixture'}, 
'anisotropic-adaption-cells': {'display_name': 'Anisotropic Adaption Cells', 'section': 'Mesh...', 'domain': 'mixture'}, 'boundary-layer-cells': {'display_name': 'Boundary Layer Cells', 'section': 'Mesh...', 'domain': 'mixture'}, 'b
oundary-cell-dist': {'display_name': 'Boundary Cell Distance', 'section': 'Mesh...', 'domain': 'mixture'}, 'boundary-normal-dist': {'display_name': 'Boundary Normal Distance', 'section': 'Mesh...', 'domain': 'mixture'}, 'boundary-vo
lume-dist': {'display_name': 'Boundary Volume Distance', 'section': 'Mesh...', 'domain': 'mixture'}, 'cell-volume-change': {'display_name': 'Cell Volume Change', 'section': 'Mesh...', 'domain': 'mixture'}, 'mass-imbalance': {'displa
y_name': 'Mass Imbalance', 'section': 'Residuals...', 'domain': 'mixture'}, 'strain-rate-mag': {'display_name': 'Strain Rate', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dx-velocity-dx': {'display_name': 'dX-Velocity/dx', '
section': 'Derivatives...', 'domain': 'mixture'}, 'dy-velocity-dx': {'display_name': 'dY-Velocity/dx', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dz-velocity-dx': {'display_name': 'dZ-Velocity/dx', 'section': 'Derivatives..
.', 'domain': 'mixture'}, 'dx-velocity-dy': {'display_name': 'dX-Velocity/dy', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dy-velocity-dy': {'display_name': 'dY-Velocity/dy', 'section': 'Derivatives...', 'domain': 'mixture'}
, 'dz-velocity-dy': {'display_name': 'dZ-Velocity/dy', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dx-velocity-dz': {'display_name': 'dX-Velocity/dz', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dy-velocity-dz': {'di
splay_name': 'dY-Velocity/dz', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dz-velocity-dz': {'display_name': 'dZ-Velocity/dz', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dp-dx': {'display_name': 'dp-dX', 'section': 
'Derivatives...', 'domain': 'mixture'}, 'dp-dy': {'display_name': 'dp-dY', 'section': 'Derivatives...', 'domain': 'mixture'}, 'dp-dz': {'display_name': 'dp-dZ', 'section': 'Derivatives...', 'domain': 'mixture'}, 'pressure-hessian-indicator': {'display_name': 'Pressure Hessian Indicator', 'section': 'Derivatives...', 'domain': 'mixture'}}.' has no attribute 'None'.

>>> solver.exit()
```


`sudo docker run -it --name ansys-inc -e ANSYSLMD_LICENSE_FILE=<license>.ansys.com ansys_inc 3ddp -gu`



`sudo docker run -it --name ansys-inc -e ANSYSLMD_LICENSE_FILE=<license>.ansys.com ansys_inc 3ddp -gu -meshing`
