### PR TITLE
fix: Update examples download path

### DIFF
--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -62,7 +62,12 @@ def _retrieve_file(
     """Download specified file from specified URL."""
     file_name = os.path.basename(file_name)
     if save_path is None:
-        save_path = pyfluent.EXAMPLES_PATH
+        if os.getenv("PYFLUENT_HOST_MOUNT_PATH", None):
+            save_path = pyfluent.EXAMPLES_PATH
+        elif pyfluent.CONTAINER_MOUNT_PATH:
+            save_path = pyfluent.CONTAINER_MOUNT_PATH
+        else:
+            save_path = os.getcwd()
     else:
         save_path = os.path.abspath(save_path)
     local_path = os.path.join(save_path, file_name)


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2978

1. Update examples download file path.
2. Handle examples download path based on all scenarios of `host_mount_path`.

Current working directory is the default location to download files.

```
>>> from ansys.fluent.core.examples import download_file 
>>> import_file_name = download_file("mixing_elbow.msh.h5", "pyfluent/mixing_elbow")
Download successful. File path:
D:\pyfluent\mixing_elbow.msh.h5   # File downloaded to current working directory.
>>>
```
