### PR TITLE
feat: override `__dir__` method

### DIFF
--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -393,4 +393,4 @@ class BaseSession:
             "start_journal",
             "stop_journal",
         }
-        return sorted(dir_list)
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -202,3 +202,7 @@ class BaseMeshing:
         if self._preferences is None:
             self._preferences = _make_datamodel_module(self, "preferences")
         return self._preferences
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -95,3 +95,7 @@ class Meshing(PureMeshing):
     def preferences(self):
         """Datamodel root of preferences."""
         return super(Meshing, self).preferences if not self.switched else None
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -203,3 +203,7 @@ class PureMeshing(BaseSession):
             clean_up_mesh_file,
             overwrite_previous,
         )
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -307,4 +307,4 @@ class Solver(BaseSession):
             "start_journal",
             "stop_journal",
         }
-        return sorted(dir_list)
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -64,3 +64,7 @@ class SolverIcing(Solver):
     def icing(self):
         """Instance of icing (Case.App) -> root datamodel object."""
         return self._flserver.Case.App
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]

--- a/src/ansys/fluent/core/session_solver_lite.py
+++ b/src/ansys/fluent/core/session_solver_lite.py
@@ -50,3 +50,7 @@ class SolverLite(Solver):
             fluent_connection=self._fluent_connection, scheme_eval=self.scheme_eval
         )
         return solver_session
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        return [attr for attr in sorted(dir_list) if not attr.startswith("_")]


### PR DESCRIPTION
1. override `__dir__` method.

**Meshing**

**Now**

```
>>> dir(meshing)
['PMFileManagement', 'PartManagement', 'connection_properties', 'create_workflow', 'datamodel_streams', 'download', 'events', 'execute_tui', 'exit', 'fault_tolerant', 'field_data', 'field_data_streaming', 'field_info', 'fields', 'fi
le_exists_on_remote', 'force_exit', 'get_fluent_version', 'health_check', 'id', 'journal', 'load_workflow', 'meshing', 'meshing_utilities', 'monitors', 'preferences', 'rp_vars', 'scheme_eval', 'start_journal', 'stop_journal', 'switch_to_solver', 'switched', 'topology_based', 'transcript', 'transfer_mesh_to_solvers', 'tui', 'two_dimensional_meshing', 'upload', 'watertight', 'workflow']
```

**Earlier**

```
>>> dir(meshing)
['PMFileManagement', 'PartManagement', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__
', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_base_meshing', '_batch_ops_service', '_build_from_flue
nt_connection', '_create_from_server_info_file', '_datamodel_events', '_datamodel_service_se', '_datamodel_service_tui', '_error_state', '_events_service', '_field_data_service', '_file_transfer_api_warning', '_file_transfer_service
', '_fluent_connection', '_launcher_args', '_monitors_service', '_preferences', '_rules', '_settings_service', '_start_transcript', '_switch_to_solver', '_transcript_service', 'connection_properties', 'create_workflow', 'datamodel_s
treams', 'download', 'events', 'execute_tui', 'exit', 'fault_tolerant', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'health_check', 'id', 'journal', 'load_workflow', 'meshing', 'meshing_utilities', 'monitors', 'preferences', 'rp_vars', 'scheme_eval', 'switch_to_solver', 'switched', 'topology_based', 'transcript', 'transfer_mesh_to_solvers', 'tui', 'two_dimensional_meshing', 'upload', 'watertight', 'workflow']
```

`--------------------------------------------------------------------------------------------------`

**Pure Meshing**

**Now**

```
>>> dir(pure_meshing)
['PMFileManagement', 'PartManagement', 'connection_properties', 'create_workflow', 'datamodel_streams', 'download', 'events', 'execute_tui', 'exit', 'fault_tolerant', 'field_data', 'field_data_streaming', 'field_info', 'fields', 'fi
le_exists_on_remote', 'force_exit', 'get_fluent_version', 'health_check', 'id', 'journal', 'load_workflow', 'meshing', 'meshing_utilities', 'monitors', 'preferences', 'rp_vars', 'scheme_eval', 'start_journal', 'stop_journal', 'topology_based', 'transcript', 'transfer_mesh_to_solvers', 'tui', 'two_dimensional_meshing', 'upload', 'watertight', 'workflow']

```

**Earlier**

```
>>> dir(pure_meshing)
['PMFileManagement', 'PartManagement', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__
', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_base_meshing', '_batch_ops_service', '_build_from_flue
nt_connection', '_create_from_server_info_file', '_datamodel_events', '_datamodel_service_se', '_datamodel_service_tui', '_error_state', '_events_service', '_field_data_service', '_file_transfer_api_warning', '_file_transfer_service
', '_fluent_connection', '_launcher_args', '_monitors_service', '_preferences', '_rules', '_settings_service', '_start_transcript', '_switch_to_solver', '_transcript_service', 'connection_properties', 'create_workflow', 'datamodel_s
treams', 'download', 'events', 'execute_tui', 'exit', 'fault_tolerant', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'health_check', 'id', 'journal', 'load_workflow', 'meshing', 'meshing_utilities', 'monitors', 'preferences', 'rp_vars', 'scheme_eval', 'switch_to_solver', 'switched', 'topology_based', 'transcript', 'transfer_mesh_to_solvers', 'tui', 'two_dimensional_meshing', 'upload', 'watertight', 'workflow']
```

`--------------------------------------------------------------------------------------------------`

**Solver**

**Now**

```
>>> dir(solver)
['connection_properties', 'download', 'events', 'execute_tui', 'exit', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'get_state', 'health_check', 'id', 'journal', 'monitors', 'preferences', 'read_case_lightweight', 'rp_vars', 'scheme_eval', 'set_state', 'settings', 'system_coupling', 'transcript', 'tui', 'upload', 'workflow']
```

**Earlier**

```
>>> dir(solver)
['__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__'
, '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_batch_ops_service', '_build_from_fluent_connection', '_create_fro
m_server_info_file', '_datamodel_events', '_datamodel_service_se', '_datamodel_service_tui', '_error_state', '_events_service', '_field_data_service', '_file_transfer_api_warning', '_file_transfer_service', '_fluent_connection', '_f
luent_version', '_interrupt', '_launcher_args', '_lck', '_monitors_service', '_populate_settings_api_root', '_preferences', '_reduction_service', '_se_service', '_settings_api_root', '_settings_root', '_settings_service', '_solution
_variable_data', '_solution_variable_service', '_start_transcript', '_sync_from_future', '_system_coupling', '_transcript_service', '_tui', '_tui_service', '_version', '_workflow', 'connection_properties', 'download', 'events', 'exe
cute_tui', 'exit', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'get_state', 'health_check', 'id', 'journal', 'monitors', 'preferences', 'read_case_lightweight', 'rp_vars', 'scheme_eval', 'set_state', 'settings', 'system_coupling', 'transcript', 'tui', 'upload', 'workflow']
```

`--------------------------------------------------------------------------------------------------`

**Solver Icing**

**Now**

```
>>> dir(solver_icing)
['connection_properties', 'download', 'events', 'execute_tui', 'exit', 'field_data', 'field_data_streaming', 'field_info', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'get_state', 'health_check', 'icing', 
'id', 'journal', 'monitors', 'preferences', 'read_case_lightweight', 'reduction', 'rp_vars', 'scheme_eval', 'set_state', 'settings', 'start_journal', 'stop_journal', 'svar_data', 'svar_info', 'system_coupling', 'transcript', 'tui', 'upload', 'workflow']
```

**Earlier**

```
>>> dir(solver_icing)
['__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__'
, '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_batch_ops_service', '_build_from_fluent_connection', '_create_fro
m_server_info_file', '_datamodel_events', '_datamodel_service_se', '_datamodel_service_tui', '_error_state', '_events_service', '_field_data_service', '_file_transfer_api_warning', '_file_transfer_service', '_flserver', '_flserver_r
oot', '_fluent_connection', '_fluent_version', '_interrupt', '_launcher_args', '_lck', '_monitors_service', '_populate_settings_api_root', '_preferences', '_reduction_service', '_se_service', '_settings_api_root', '_settings_root', 
'_settings_service', '_solution_variable_data', '_solution_variable_service', '_start_transcript', '_sync_from_future', '_system_coupling', '_transcript_service', '_tui', '_tui_service', '_version', '_workflow', 'connection_properti
es', 'download', 'events', 'execute_tui', 'exit', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'get_state', 'health_check', 'icing', 'id', 'journal', 'monitors', 'preferences', 'read_case_lightweight', 'rp_vars', 'scheme_eval', 'set_state', 'settings', 'system_coupling', 'transcript', 'tui', 'upload', 'workflow']
```
