### PR TITLE
fix: override __dir__ method of SolverIcing

### DIFF
--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -66,4 +66,4 @@ class SolverIcing(Solver):
         return self._flserver.Case.App
 
     def __dir__(self):
-        super().__dir__(self)
+        return super(SolverIcing, self).__dir__()

--- a/src/ansys/fluent/core/session_solver_icing.py
+++ b/src/ansys/fluent/core/session_solver_icing.py
@@ -64,3 +64,6 @@ class SolverIcing(Solver):
     def icing(self):
         """Instance of icing (Case.App) -> root datamodel object."""
         return self._flserver.Case.App
+
+    def __dir__(self):
+        super().__dir__(self)


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/2986

1. override `__dir__` of `SolverIcing`

```
>>> dir(solver_icing)
['__call__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__'
, '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_batch_ops_service', '_build_from_fluent_connection', '_create_fro
m_server_info_file', '_datamodel_events', '_datamodel_service_se', '_datamodel_service_tui', '_error_state', '_events_service', '_field_data_service', '_file_transfer_api_warning', '_file_transfer_service', '_flserver', '_flserver_r
oot', '_fluent_connection', '_fluent_version', '_interrupt', '_launcher_args', '_lck', '_monitors_service', '_populate_settings_api_root', '_preferences', '_reduction_service', '_se_service', '_settings_api_root', '_settings_root', 
'_settings_service', '_solution_variable_data', '_solution_variable_service', '_start_transcript', '_sync_from_future', '_system_coupling', '_transcript_service', '_tui', '_tui_service', '_version', '_workflow', 'connection_properti
es', 'download', 'events', 'execute_tui', 'exit', 'fields', 'file_exists_on_remote', 'force_exit', 'get_fluent_version', 'get_state', 'health_check', 'icing', 'id', 'journal', 'monitors', 'preferences', 'read_case_lightweight', 'rp_vars', 'scheme_eval', 'set_state', 'settings', 'system_coupling', 'transcript', 'tui', 'upload', 'workflow']
>>>
```