### PR TITLE
fix: Localize imports in search.py

### DIFF
--- a/src/ansys/fluent/core/utils/search.py
+++ b/src/ansys/fluent/core/utils/search.py
@@ -12,11 +12,7 @@ import sys
 from typing import Any, Optional
 import warnings
 
-from nltk.corpus import wordnet as wn
-
-from ansys.fluent.core.services.datamodel_se import PyMenu, PyNamedObjectContainer
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
-from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.solver.error_message import closest_allowed_names
@@ -69,6 +65,9 @@ _meshing_rules = ["workflow", "meshing", "PartManagement", "PMFileManagement"]
 
 
 def _get_version_path_prefix_from_obj(obj: Any):
+    from ansys.fluent.core.services.datamodel_se import PyMenu, PyNamedObjectContainer
+    from ansys.fluent.core.session_pure_meshing import PureMeshing
+
     path = None
     version = None
     prefix = None
@@ -270,6 +269,8 @@ def _search(
     api_tree_data["api_tui_objects"] = sorted(api_tui_objects)
 
     def _write_api_tree_file(api_tree_data: dict, api_object_names: list):
+        from nltk.corpus import wordnet as wn
+
         _download_nltk_data()
         from ansys.fluent.core import CODEGEN_OUTDIR
 
@@ -565,6 +566,8 @@ def _search_semantic(search_string: str, language: str, api_tree_data: dict):
     queries: list
         List of search string matches.
     """
+    from nltk.corpus import wordnet as wn
+
     api_tree_data = api_tree_data if api_tree_data else _get_api_tree_data()
     similar_keys = set()
     search_string_synsets = (


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3002

Localize following imports.

```
from nltk.corpus import wordnet as wn
from ansys.fluent.core.services.datamodel_se import PyMenu, PyNamedObjectContainer
from ansys.fluent.core.session_pure_meshing import PureMeshing
```