### PR TITLE
chore: Revising `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,2 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a pull request.
-*       @mkundu1 @seanpearsonuk @prmukherj @hpohekar
+# Core PyFluent development team
+* @mkundu1 @seanpearsonuk @prmukherj @hpohekar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @mkundu1 @seanpearsonuk @ajain-work @dnwillia-work @prmukherj @hpohekar @h-krishnan @raph-luc
+*       @mkundu1 @seanpearsonuk @prmukherj @hpohekar


### PR DESCRIPTION
No issue tracker for this, as this suggestion is based on my anecdotal experience with codeowners and notifications. 

I believe we should only have the core and most active PyFluent developers, that can actually keep track of all the notifications, listed as `CODEOWNERS` with general ownership of the codebase.

For others like myself, and I believe @ajain-work, @dnwillia-work and @h-krishnan, we only want notifications to be sent to them when their attention is actually needed here. I do not believe we want to spam their emails with notifications from code ownership, which will drown out notifications that may be actually important and would then be missed.

In the future, if considered worthwhile, we can add ownership for specific files or folders in the codebase, so that review from these specified owners is needed when PRs touch the files assigned to them in the repo. There are more details [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), otherwise let me know as I can provide examples and/or make a suggestion of what this could look like for PyFluent if desired (we did this for another repo and it has been working well). 