### PR TITLE
build: Bump version to 0.21.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-fluent-core"
-version = "0.21.dev1"
+version = "0.21.0"
 description = "PyFluent provides Pythonic access to Ansys Fluent"
 license = "MIT"
 authors = ["ANSYS, Inc. <ansys.support@ansys.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ ansys-tools-filetransfer = ">=0.1,<0.3"
 ansys-units = "^0.3.2"
 alive-progress = "^3.1.5"
 beartype = ">=0.17,<0.19"
-docker = "^6.1.3"
+docker = "^7.1.0"
 grpcio = "^1.30.0"
 grpcio-health-checking = "^1.30.0"
 h5py = { version = "==3.11.0", optional = true }
@@ -56,7 +56,7 @@ pandas = "^2.0.3"
 platformdirs = "^3.5.1"
 psutil = "^5.9.5"
 pyyaml = "^6.0"
-requests = "==2.31.0"
+requests = "^2.32.3"
 
 [tool.poetry.group.docs]
 optional = true

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 21, "dev1"
+version_info = 0, 21, 0
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3007

Patch release for bump version 0.21.0

Update following versions.

```
docker = "^7.1.0"
requests = "^2.32.3"
```