### PR TITLE
PyFluent changes for Fluent integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ include = [
     { path = "src/ansys/fluent/core/generated/datamodel_*/*.py", format = ["sdist", "wheel"] },
     { path = "src/ansys/fluent/core/generated/solver/settings_*/*.py", format = ["sdist", "wheel"] },
     { path = "src/ansys/fluent/core/generated/solver/settings_*/*.pyi", format = ["sdist", "wheel"] },
+    { path = "src/ansys/fluent/core/generated/solver/settings_*.zip", format = ["sdist", "wheel"] },
     { path = "src/ansys/fluent/core/generated/*.pickle", format = ["sdist", "wheel"] },
     { path = "src/ansys/fluent/core/generated/api_tree/*.json", format = ["sdist", "wheel"] },
 ]

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -99,7 +99,7 @@ USE_FILE_TRANSFER_SERVICE = False
 CODEGEN_OUTDIR = (Path(__file__) / ".." / "generated").resolve()
 
 # Whether to zip settings API files during codegen
-CODEGEN_ZIP_SETTINGS = False
+CODEGEN_ZIP_SETTINGS = os.getenv("PYFLUENT_CODEGEN_ZIP_SETTINGS", False)
 
 # Whether to show mesh after case read
 SHOW_MESH_AFTER_CASE_READ = False

--- a/src/ansys/fluent/core/utils/file_transfer_service.py
+++ b/src/ansys/fluent/core/utils/file_transfer_service.py
@@ -8,12 +8,9 @@ import shutil
 from typing import Any, Callable, List, Optional, Protocol, Union  # noqa: F401
 import warnings
 
-from alive_progress import alive_bar
-
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.warnings import PyFluentUserWarning
 import ansys.platform.instancemanagement as pypim
-import ansys.tools.filetransfer as ft
 import docker
 
 logger = logging.getLogger("pyfluent.file_transfer_service")
@@ -176,6 +173,8 @@ class RemoteFileTransferStrategy(FileTransferStrategy):
                 detach=True,
                 volumes=[f"{self.host_mount_path}:{self.container_mount_path}"],
             )
+        import ansys.tools.filetransfer as ft
+
         self.client = ft.Client.from_server_address(f"localhost:{self.host_port}")
 
     def file_exists_on_remote(self, file_name: str) -> bool:
@@ -379,6 +378,8 @@ class PimFileTransferService:
         """
         files = [file_name] if isinstance(file_name, str) else file_name
         if self.is_configured():
+            from alive_progress import alive_bar
+
             with alive_bar(len(files), title="Uploading...") as bar:
                 for file in files:
                     if os.path.isfile(file):
@@ -434,6 +435,8 @@ class PimFileTransferService:
         """
         files = [file_name] if isinstance(file_name, str) else file_name
         if self.is_configured():
+            from alive_progress import alive_bar
+
             with alive_bar(len(files), title="Downloading...") as bar:
                 for file in files:
                     if os.path.isfile(file):


### PR DESCRIPTION
1. Move some imports to method level.
2. Add zipped settings API in the package. The zipping option will be needed for Fluent integration, it is not the default in PyFluent.