### PR TITLE
feat: Reduce size of the copied files to Fluent.

### DIFF
--- a/devel/scripts/copy_to_fluent.py
+++ b/devel/scripts/copy_to_fluent.py
@@ -48,6 +48,10 @@ for root, dirs, files in os.walk(pyfluent_core_dst):
         if dir == "__pycache__":
             shutil.rmtree(Path(root) / dir)
 
+# Remove some unnecessary data files
+(pyfluent_core_dst / "codegen" / "data" / "static_info_222_meshing.pickle").unlink()
+(pyfluent_core_dst / "codegen" / "data" / "static_info_222_solver.pickle").unlink()
+
 # Finally, print the Fluent manifest code of the copied files.
 # Copy and replace this output in the following section in packageManifest/cortex/manifest.pkg in Fluent repository
 # # PyFluent sources START


### PR DESCRIPTION
1. Do not create type-stub files when we create zip archive for settings API.
2. Remove some unnecessary data files.

This reduced the total size of the copied files by ~4 MB, down to 16.3 MB.