### PR TITLE
feat: Check valid Slurm queues

### DIFF
--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -192,7 +192,8 @@ def _get_fluent_launch_mode(start_container, container_dict, scheduler_options):
         and (container_dict or os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1")
     ):
         fluent_launch_mode = LaunchMode.CONTAINER
-    elif scheduler_options and scheduler_options["scheduler"] == "slurm":
+    # Currently, only Slurm scheduler is supported and within SlurmLauncher we check the value of the scheduler
+    elif scheduler_options:
         fluent_launch_mode = LaunchMode.SLURM
     else:
         fluent_launch_mode = LaunchMode.STANDALONE

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -392,7 +392,7 @@ class SlurmLauncher:
                 queues = _SlurmWrapper.list_queues()
                 if queue not in queues:
                     raise InvalidArgument(
-                        f"Slurm queue is not valid. Valid queues are {', '.join(queues)}."
+                        f"""Slurm queue is not valid. Valid queues are "{'", "'.join(queues)}"."""
                     )
 
     def _prepare(self):


### PR DESCRIPTION
```
>>> import ansys.fluent.core as pyfluent
>>> slurm = pyfluent.launch_fluent(scheduler_options={"scheduler": "slurm", "scheduler_queue": "xyz"})  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mkundu/devel/pyfluent/src/ansys/fluent/core/utils/deprecate.py", line 49, in wrapper
    return func(*args, **kwargs)
  File "/home/mkundu/devel/pyfluent/src/ansys/fluent/core/utils/deprecate.py", line 49, in wrapper
    return func(*args, **kwargs)
  File "/home/mkundu/devel/pyfluent/src/ansys/fluent/core/launcher/launcher.py", line 284, in launch_fluent
    launcher = launcher_type(**launcher_argvals)
  File "/home/mkundu/devel/pyfluent/src/ansys/fluent/core/launcher/slurm_launcher.py", line 394, in __init__
    raise InvalidArgument(
ansys.fluent.core.exceptions.InvalidArgument: Slurm queue is not valid. Valid queues are "cdc01lm", "acepri", "cdc01", "apdl", "cdc02lm", "cdc02fbu", "cdc02gen", "naacegpu", "dynaimp", "quadl40", "cdc03gen", "cdc03vlm", "cdc03lm", "cdc03xlm".
```
Also throwing error when Slurm is not available.