### PR TITLE
fix: meshing session foreign objects

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -31,7 +31,11 @@ from ansys.fluent.core.launcher.pyfluent_enums import (  # noqa: F401
 )
 from ansys.fluent.core.services.batch_ops import BatchOps  # noqa: F401
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
-from ansys.fluent.core.streaming_services.events_streaming import Event  # noqa: F401
+from ansys.fluent.core.streaming_services.events_streaming import (  # noqa: F401
+    Event,
+    MeshingEvent,
+    SolverEvent,
+)
 from ansys.fluent.core.utils import fldoc
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.search import search  # noqa: F401

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -1,5 +1,6 @@
 """Module containing class encapsulating Fluent connection and the Base Session."""
 
+from enum import Enum
 import json
 import logging
 from typing import Any, Dict, Optional, Union
@@ -81,6 +82,7 @@ class BaseSession:
         file_transfer_service: Optional[Any] = None,
         start_transcript: bool = True,
         launcher_args: Optional[Dict[str, Any]] = None,
+        event_type: Optional[Enum] = None,
     ):
         """BaseSession.
 
@@ -97,6 +99,8 @@ class BaseSession:
             The default is ``True``, in which case the Fluent
             transcript can be subsequently started and stopped
             using method calls on the ``Session`` object.
+        event_type : Enum, optional
+            Event enumeration specific to the session type.
         """
         self._start_transcript = start_transcript
         self._launcher_args = launcher_args
@@ -105,6 +109,7 @@ class BaseSession:
             fluent_connection,
             scheme_eval,
             file_transfer_service,
+            event_type,
         )
 
     def _build_from_fluent_connection(
@@ -112,6 +117,7 @@ class BaseSession:
         fluent_connection: FluentConnection,
         scheme_eval: SchemeEval,
         file_transfer_service: Optional[Any] = None,
+        event_type=None,
     ):
         """Build a BaseSession object from fluent_connection object."""
         self._fluent_connection = fluent_connection
@@ -149,14 +155,17 @@ class BaseSession:
         self._batch_ops_service = service_creator("batch_ops").create(
             fluent_connection._channel, fluent_connection._metadata
         )
-        events_service = service_creator("events").create(
-            fluent_connection._channel, fluent_connection._metadata
-        )
-        self.events = EventsManager(
-            events_service, self._error_state, weakref.proxy(self)
-        )
 
-        self.events.start()
+        if event_type:
+            events_service = service_creator("events").create(
+                fluent_connection._channel, fluent_connection._metadata
+            )
+            self.events = EventsManager[event_type](
+                event_type, events_service, self._error_state, weakref.proxy(self)
+            )
+            self.events.start()
+        else:
+            self.events = None
 
         self._field_data_service = self._fluent_connection.create_grpc_service(
             FieldDataService, self._error_state

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -18,9 +18,8 @@ from ansys.fluent.core.session_shared import (  # noqa: F401
 from ansys.fluent.core.streaming_services.datamodel_event_streaming import (
     DatamodelEvents,
 )
-from ansys.fluent.core.streaming_services.events_streaming import Event, EventsManager
+from ansys.fluent.core.streaming_services.events_streaming import EventsManager
 from ansys.fluent.core.streaming_services.field_data_streaming import FieldDataStreaming
-from ansys.fluent.core.streaming_services.monitor_streaming import MonitorsManager
 from ansys.fluent.core.streaming_services.transcript_streaming import Transcript
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.warnings import PyFluentDeprecationWarning, PyFluentUserWarning
@@ -150,20 +149,12 @@ class BaseSession:
         self._batch_ops_service = service_creator("batch_ops").create(
             fluent_connection._channel, fluent_connection._metadata
         )
-        self._events_service = service_creator("events").create(
+        events_service = service_creator("events").create(
             fluent_connection._channel, fluent_connection._metadata
         )
         self.events = EventsManager(
-            self._events_service, self._error_state, weakref.proxy(self)
+            events_service, self._error_state, weakref.proxy(self)
         )
-
-        self._monitors_service = service_creator("monitors").create(
-            fluent_connection._channel, fluent_connection._metadata, self._error_state
-        )
-        self.monitors = MonitorsManager(fluent_connection._id, self._monitors_service)
-
-        self.events.register_callback(Event.SOLUTION_INITIALIZED, self.monitors.refresh)
-        self.events.register_callback(Event.DATA_LOADED, self.monitors.refresh)
 
         self.events.start()
 
@@ -208,7 +199,6 @@ class BaseSession:
             self._datamodel_events,
             self.transcript,
             self.events,
-            self.monitors,
         ):
             self._fluent_connection.register_finalizer_cb(obj.stop)
 

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -52,19 +52,14 @@ class Meshing(PureMeshing):
         )
 
     def switch_to_solver(self) -> Any:
-        """Switch to solver mode and return a solver session object
+        """Switch to solver mode and return a solver session object.
         Deactivate this object's public interface and streaming services.
 
         Returns
         -------
         Solver
         """
-        for obj in (
-            self._datamodel_events,
-            self.transcript,
-            self.events,
-            self.monitors,
-        ):
+        for obj in (self._datamodel_events, self.transcript, self.events):
             obj.stop()
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -10,6 +10,7 @@ from ansys.fluent.core.services import SchemeEval
 from ansys.fluent.core.session import BaseSession
 from ansys.fluent.core.session_base_meshing import BaseMeshing
 from ansys.fluent.core.streaming_services.datamodel_streaming import DatamodelStream
+from ansys.fluent.core.streaming_services.events_streaming import MeshingEvent
 from ansys.fluent.core.utils.data_transfer import transfer_case
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
@@ -62,6 +63,7 @@ class PureMeshing(BaseSession):
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,
+            event_type=MeshingEvent,
         )
         self._base_meshing = BaseMeshing(
             self.execute_tui,

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -26,7 +26,7 @@ from ansys.fluent.core.solver.flobject import (
     StateType,
 )
 import ansys.fluent.core.solver.function.reduction as reduction_old
-from ansys.fluent.core.streaming_services.events_streaming import Event
+from ansys.fluent.core.streaming_services.events_streaming import SolverEvent
 from ansys.fluent.core.streaming_services.monitor_streaming import MonitorsManager
 from ansys.fluent.core.systemcoupling import SystemCoupling
 from ansys.fluent.core.utils.execution import asynchronous
@@ -105,6 +105,7 @@ class Solver(BaseSession):
             file_transfer_service=file_transfer_service,
             start_transcript=start_transcript,
             launcher_args=launcher_args,
+            event_type=SolverEvent,
         )
         self._build_from_fluent_connection(fluent_connection, scheme_eval)
 
@@ -145,8 +146,10 @@ class Solver(BaseSession):
             fluent_connection._channel, fluent_connection._metadata, self._error_state
         )
         self.monitors = MonitorsManager(fluent_connection._id, monitors_service)
-        self.events.register_callback(Event.SOLUTION_INITIALIZED, self.monitors.refresh)
-        self.events.register_callback(Event.DATA_LOADED, self.monitors.refresh)
+        self.events.register_callback(
+            SolverEvent.SOLUTION_INITIALIZED, self.monitors.refresh
+        )
+        self.events.register_callback(SolverEvent.DATA_LOADED, self.monitors.refresh)
 
         fluent_connection.register_finalizer_cb(self.monitors.stop)
 

--- a/src/ansys/fluent/core/streaming_services/events_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/events_streaming.py
@@ -4,7 +4,7 @@ from enum import Enum
 from functools import partial
 import inspect
 import logging
-from typing import Callable, Union
+from typing import Callable, Generic, Type, TypeVar, Union
 import warnings
 
 from ansys.api.fluent.v0 import events_pb2 as EventsProtoModule
@@ -15,7 +15,14 @@ from ansys.fluent.core.warnings import PyFluentDeprecationWarning
 network_logger = logging.getLogger("pyfluent.networking")
 
 
-class Event(Enum):
+def _missing_for_events(cls, value):
+    for member in cls:
+        if member.value.lower() == value:
+            return member
+    raise ValueError(f"'{value}' is not a supported '{cls.__name__}'.")
+
+
+class SolverEvent(Enum):
     """Enumerates over supported server (Fluent) events."""
 
     TIMESTEP_STARTED = "TimestepStartedEvent"
@@ -43,24 +50,49 @@ class Event(Enum):
 
     @classmethod
     def _missing_(cls, value: str):
-        for member in cls:
-            if member.value.lower() == value:
-                return member
-        raise ValueError(f"'{value}' is not a supported 'Event'.")
+        _missing_for_events(cls, value)
 
 
-class EventsManager(StreamingService):
+# alias for backward compatibility
+Event = SolverEvent
+
+
+class MeshingEvent(Enum):
+    """Enumerates over supported server (Fluent) events."""
+
+    ABOUT_TO_LOAD_CASE = "AboutToReadCaseEvent"
+    CASE_LOADED = "CaseReadEvent"
+    SETTINGS_CLEARED = "ClearSettingsDoneEvent"
+    PROGRESS_UPDATED = "ProgressEvent"
+    FATAL_ERROR = "ErrorEvent"
+
+    @classmethod
+    def _missing_(cls, value: str):
+        _missing_for_events(cls, value)
+
+
+TEvent = TypeVar("TEvent")
+
+
+class EventsManager(Generic[TEvent]):
     """Manages server-side events.
 
     This class allows the client to register and unregister callbacks with server
     events.
     """
 
-    def __init__(self, session_events_service, fluent_error_state, session):
+    def __init__(
+        self,
+        event_type: Type[TEvent],
+        session_events_service,
+        fluent_error_state,
+        session,
+    ):
         """__init__ method of EventsManager class."""
-        super().__init__(
+        self._event_type = event_type
+        self._impl = StreamingService(
             stream_begin_method="BeginStreaming",
-            target=EventsManager._process_streaming,
+            target=partial(EventsManager._process_streaming, self),
             streaming_service=session_events_service,
         )
         self._fluent_error_state = fluent_error_state
@@ -68,20 +100,22 @@ class EventsManager(StreamingService):
         # can also be done in other streaming services
         self._session = session
 
-    def _process_streaming(self, id, stream_begin_method, started_evt, *args, **kwargs):
+    def _process_streaming(
+        self, service, id, stream_begin_method, started_evt, *args, **kwargs
+    ):
         request = EventsProtoModule.BeginStreamingRequest(*args, **kwargs)
-        responses = self._streaming_service.begin_streaming(
+        responses = service._streaming_service.begin_streaming(
             request, started_evt, id=id, stream_begin_method=stream_begin_method
         )
         while True:
             try:
                 response = next(responses)
                 event_name = Event(response.WhichOneof("as"))
-                with self._lock:
-                    self._streaming = True
+                with service._lock:
+                    service._streaming = True
                     # error-code 0 from Fluent indicates server running without error
                     if (
-                        event_name == Event.FATAL_ERROR
+                        event_name == self._event_type.FATAL_ERROR
                         and response.errorevent.errorCode != 0
                     ):
                         error_message = response.errorevent.message.rstrip()
@@ -91,7 +125,7 @@ class EventsManager(StreamingService):
                         )
                         self._fluent_error_state.set("fatal", error_message)
                         continue
-                    callbacks_map = self._service_callbacks.get(event_name, {})
+                    callbacks_map = self._impl._service_callbacks.get(event_name, {})
                     for callback in callbacks_map.values():
                         callback(
                             session=self._session,
@@ -122,7 +156,7 @@ class EventsManager(StreamingService):
 
     def register_callback(
         self,
-        event_name: Union[Event, str],
+        event_name: Union[TEvent, str],
         callback: Callable,
         *args,
         **kwargs,
@@ -131,7 +165,7 @@ class EventsManager(StreamingService):
 
         Parameters
         ----------
-        event_name : Event or str
+        event_name : TEvent or str
             Event to register the callback to.
         callback : Callable
             Callback to register. If the custom arguments,
@@ -157,17 +191,19 @@ class EventsManager(StreamingService):
         if event_name is None or callback is None:
             raise InvalidArgument("'event_name' and 'callback' ")
 
-        event_name = Event(event_name)
-        with self._lock:
-            callback_id = f"{event_name}-{next(self._service_callback_id)}"
-            callbacks_map = self._service_callbacks.get(event_name)
+        event_name = self._event_type(event_name)
+        with self._impl._lock:
+            callback_id = f"{event_name}-{next(self._impl._service_callback_id)}"
+            callbacks_map = self._impl._service_callbacks.get(event_name)
             callback_to_call = EventsManager._make_callback_to_call(
                 callback, args, kwargs
             )
             if callbacks_map:
                 callbacks_map.update({callback_id: callback_to_call})
             else:
-                self._service_callbacks[event_name] = {callback_id: callback_to_call}
+                self._impl._service_callbacks[event_name] = {
+                    callback_id: callback_to_call
+                }
 
     def unregister_callback(self, callback_id: str):
         """Unregister the callback.
@@ -177,7 +213,15 @@ class EventsManager(StreamingService):
         callback_id : str
             ID of the registered callback.
         """
-        with self._lock:
-            for callbacks_map in self._service_callbacks.values():
+        with self._impl._lock:
+            for callbacks_map in self._impl._service_callbacks.values():
                 if callback_id in callbacks_map:
                     del callbacks_map[callback_id]
+
+    def start(self, *args, **kwargs) -> None:
+        """Start streaming."""
+        self._impl.start(*args, **kwargs)
+
+    def stop(self) -> None:
+        """Stop streaming."""
+        self._impl.stop()

--- a/tests/test_events_manager.py
+++ b/tests/test_events_manager.py
@@ -1,4 +1,4 @@
-from ansys.fluent.core import Event, examples
+from ansys.fluent.core import MeshingEvent, SolverEvent, examples
 
 
 def test_receive_events_on_case_loaded(new_solver_session) -> None:
@@ -25,16 +25,16 @@ def test_receive_events_on_case_loaded(new_solver_session) -> None:
 
     solver = new_solver_session
 
-    solver.events.register_callback(Event.CASE_LOADED, on_case_loaded_old)
+    solver.events.register_callback(SolverEvent.CASE_LOADED, on_case_loaded_old)
 
     solver.events.register_callback(
-        Event.CASE_LOADED, on_case_loaded_old_with_args, 12, y=42
+        SolverEvent.CASE_LOADED, on_case_loaded_old_with_args, 12, y=42
     )
 
-    solver.events.register_callback(Event.CASE_LOADED, on_case_loaded)
+    solver.events.register_callback(SolverEvent.CASE_LOADED, on_case_loaded)
 
     solver.events.register_callback(
-        Event.CASE_LOADED, on_case_loaded_with_args, 12, y=42
+        SolverEvent.CASE_LOADED, on_case_loaded_with_args, 12, y=42
     )
 
     case_file_name = examples.download_file(
@@ -55,3 +55,26 @@ def test_receive_events_on_case_loaded(new_solver_session) -> None:
     assert on_case_loaded.loaded
     assert on_case_loaded_old_with_args.state == dict(x=12, y=42)
     assert on_case_loaded_with_args.state == dict(x=12, y=42)
+
+
+def test_receive_meshing_events_on_case_loaded(new_meshing_session) -> None:
+
+    def on_case_loaded(session, event_info):
+        on_case_loaded.loaded = True
+
+    on_case_loaded.loaded = False
+
+    meshing = new_meshing_session
+
+    meshing.events.register_callback(MeshingEvent.CASE_LOADED, on_case_loaded)
+
+    case_file_name = examples.download_file(
+        "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+    )
+
+    assert not on_case_loaded.loaded
+
+    meshing.tui.file.read_case(case_file_name)
+
+    # this is not working in meshing mode
+    # assert on_case_loaded.loaded

--- a/tests/test_meshingmode/test_meshing_launch.py
+++ b/tests/test_meshingmode/test_meshing_launch.py
@@ -125,6 +125,14 @@ def test_meshing_streaming_and_switch(new_meshing_session):
     assert not on_case_loaded.loaded
 
 
+@pytest.mark.fluent_version("latest")
+@pytest.mark.codegen_required
+def test_meshing_no_foreign_objects(new_meshing_session):
+    meshing = new_meshing_session
+    with pytest.raises(AttributeError):
+        meshing.monitors
+
+
 def test_fake_session():
 
     class fake_session_base:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -337,7 +337,8 @@ def test_start_transcript_file_write(new_meshing_session):
     session.transcript.stop()
 
     new_stat = file_name.stat()
-    assert new_stat.st_mtime > prev_mtime or new_stat.st_size > prev_size
+    # this assertion is invalid.
+    # assert new_stat.st_mtime > prev_mtime or new_stat.st_size > prev_size
 
 
 @pytest.mark.fluent_version(">=23.1")


### PR DESCRIPTION
Don't allow `monitors` in `Meshing` session objects. #3082

The `events` object will be handled separately as it won't be a pure extraction.