### PR TITLE
feat: Remove print statement

### DIFF
--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -102,7 +102,6 @@ def _retrieve_file(
         _decompress(local_path)
         local_path = local_path_no_zip
         file_name = file_name_no_zip
-    print(f"Download successful. File path:\n{local_path}")
     logger.info("Download successful.")
     if return_without_path:
         return file_name


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3102

 Remove print statement from `examples.download_file()`.