### PR TITLE
docs: monitor

### DIFF
--- a/doc/source/user_guide/monitors.rst
+++ b/doc/source/user_guide/monitors.rst
@@ -3,8 +3,10 @@
 Using monitors
 ==============
 
-Monitors allow you to observe the convergence of your solution dynamically
-by checking the values of solution variables and residuals.
+Monitors in PyFluent allow you to dynamically observe the convergence of your 
+solution by tracking the values of solution variables and residuals. They enable
+you to visualize the progress of the solver, helping you ensure that the solution
+is progressing as expected and allowing you to diagnose issues early on.
 
 The following example queries what monitors exist and then registers a callback
 function which tabulates monitored values per iteration:

--- a/doc/source/user_guide/monitors.rst
+++ b/doc/source/user_guide/monitors.rst
@@ -3,61 +3,74 @@
 Using monitors
 ==============
 
-Monitors in PyFluent allow you to dynamically observe the convergence of your 
-solution by tracking the values of solution variables and residuals. They enable
-you to visualize the progress of the solver, helping you ensure that the solution
-is progressing as expected and allowing you to diagnose issues early on.
+Monitors in PyFluent allow you to dynamically observe the convergence of
+your solution by tracking the values of solution variables and residuals.
+They enable you to visualize the progress of the solver, helping ensure that
+the solution is progressing as expected and allowing you to diagnose issues 
+early on.
 
-The following example queries what monitors exist and then registers a callback
-function which tabulates monitored values per iteration:
+You can integrate PyFluent's monitor callback mechanism with visualization
+tools from the Python ecosystem, making it easy to visualize the data of interest.
+
+The following example queries the existing monitors and then uses the monitor
+callback mechanism to perform a simple tabulation of monitored values per iteration:
 
 .. code-block:: python
 
-    import ansys.fluent.core as pyfluent
-    from ansys.fluent.core import examples
-    import pandas as pd
-    from tabulate import tabulate
-    solver = pyfluent.launch_fluent(start_transcript=False)
-    import_case = examples.download_file(
-        file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
-    )
-    import_data = examples.download_file(
-        file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
-    )
-    solver.file.read_case_data(file_name=import_case)
-    sorted(solver.settings.solution.monitor.report_plots())
-    [
-        "mass-bal-rplot",
-        "mass-in-rplot",
-        "mass-tot-rplot",
-        "point-vel-rplot",
-    ]
-    solver.solution.initialization.hybrid_initialize()
-    sorted(solver.monitors.get_monitor_set_names())
-    [
-        "mass-bal-rplot",
-        "mass-in-rplot",
-        "mass-tot-rplot",
-        "point-vel-rplot",
-        "residual"
-    ]
-
-    def display_monitor_table(monitor_set_name="mass-bal-rplot"):
-        def display_table():
-            data = solver.monitors.get_monitor_set_data(monitor_set_name=monitor_set_name)
-            iterations = data[0]
-            if len(iterations) > display_table.iter_count:
-                display_table.iter_count = len(iterations)
-                results = data[1]
-                df = pd.DataFrame(results, index=iterations)
-                df.index.name = 'Iteration'
-                df.reset_index(inplace=True)
-                df = df.drop_duplicates(subset='Iteration')
-                print(tabulate(df, headers='keys', tablefmt='psql'))
-        display_table.iter_count = 0
-        return display_table
-    
-
-    register_id = solver.monitors.register_callback(display_monitor_table())
-
-    solver.solution.run_calculation.iterate(iter_count=10)
+  >>> # get started with case and data loaded
+  >>> import ansys.fluent.core as pyfluent
+  >>> from ansys.fluent.core import examples
+  >>> import pandas as pd
+  >>> from tabulate import tabulate
+  >>> solver = pyfluent.launch_fluent(start_transcript=False)
+  >>> import_case = examples.download_file(
+  >>>     file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
+  >>> )
+  >>> import_data = examples.download_file(
+  >>>     file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
+  >>> )
+  >>> solver.file.read_case_data(file_name=import_case)
+  >>> # check the active report plot monitors using the settings relevant object
+  >>> sorted(solver.settings.solution.monitor.report_plots())
+  >>> [
+  >>>     "mass-bal-rplot",
+  >>>     "mass-in-rplot",
+  >>>     "mass-tot-rplot",
+  >>>     "point-vel-rplot",
+  >>> ]
+  >>> # initialize so that monitors object is usable
+  >>> solver.solution.initialization.hybrid_initialize()
+  >>> # check which monitors are available
+  >>> sorted(solver.monitors.get_monitor_set_names())
+  >>> [
+  >>>    "mass-bal-rplot",
+  >>>    "mass-in-rplot",
+  >>>    "mass-tot-rplot",
+  >>>    "point-vel-rplot",
+  >>>    "residual"
+  >>> ]
+  >>> # create and register a callback function that will 
+  >>> def display_monitor_table(monitor_set_name="mass-bal-rplot"):
+  >>>     def display_table():
+  >>>         data = solver.monitors.get_monitor_set_data(monitor_set_name=monitor_set_name)
+  >>>         # extract iteration numbers
+  >>>         iterations = data[0]
+  >>>         # filter out additional callbacks
+  >>>         if len(iterations) > display_table.iter_count:
+  >>>             display_table.iter_count = len(iterations)
+  >>>             # extract results
+  >>>             results = data[1]
+  >>>             # create a DataFrame
+  >>>             df = pd.DataFrame(results, index=iterations)
+  >>>             df.index.name = 'Iteration'
+  >>>             df.reset_index(inplace=True)
+  >>>             # The streamed data contains duplicates, so eliminate them
+  >>>             df = df.drop_duplicates(subset='Iteration')
+  >>>             print(tabulate(df, headers='keys', tablefmt='psql'))
+  >>>         display_table.iter_count = 0
+  >>>     return display_table
+  >>>
+  >>>
+  >>> register_id = solver.monitors.register_callback(display_monitor_table())
+  >>> # run the solver and see the full tabulated monitor data on each iteration
+  >>> solver.solution.run_calculation.iterate(iter_count=10)

--- a/doc/source/user_guide/monitors.rst
+++ b/doc/source/user_guide/monitors.rst
@@ -3,4 +3,60 @@
 Using monitors
 ==============
 
-Check back soon for full details.
+Monitors allow you to observe the convergence of your solution dynamically
+by checking residuals, statistics, force values, surface integrals, and volume
+integrals.
+
+The following example queries what monitors exist and then registers a callback
+function which tabulates monitored values per iteration:
+
+.. code-block:: python
+
+    import ansys.fluent.core as pyfluent
+    from ansys.fluent.core import examples
+    import pandas as pd
+    from tabulate import tabulate
+    solver = pyfluent.launch_fluent(start_transcript=False)
+    import_case = examples.download_file(
+        file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
+    )
+    import_data = examples.download_file(
+        file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
+    )
+    solver.file.read_case_data(file_name=import_case)
+    sorted(solver.settings.solution.monitor.report_plots())
+    [
+        "mass-bal-rplot",
+        "mass-in-rplot",
+        "mass-tot-rplot",
+        "point-vel-rplot",
+    ]
+    solver.solution.initialization.hybrid_initialize()
+    sorted(solver.monitors.get_monitor_set_names())
+    [
+        "mass-bal-rplot",
+        "mass-in-rplot",
+        "mass-tot-rplot",
+        "point-vel-rplot",
+        "residual"
+    ]
+
+    def display_monitor_table(monitor_set_name="mass-bal-rplot"):
+        def display_table():
+            data = solver.monitors.get_monitor_set_data(monitor_set_name=monitor_set_name)
+            iterations = data[0]
+            if len(iterations) > display_table.iter_count:
+                display_table.iter_count = len(iterations)
+                results = data[1]
+                df = pd.DataFrame(results, index=iterations)
+                df.index.name = 'Iteration'
+                df.reset_index(inplace=True)
+                df = df.drop_duplicates(subset='Iteration')
+                print(tabulate(df, headers='keys', tablefmt='psql'))
+        display_table.iter_count = 0
+        return display_table
+    
+
+    register_id = solver.monitors.register_callback(display_monitor_table())
+
+    solver.solution.run_calculation.iterate(iter_count=10)

--- a/doc/source/user_guide/monitors.rst
+++ b/doc/source/user_guide/monitors.rst
@@ -4,8 +4,7 @@ Using monitors
 ==============
 
 Monitors allow you to observe the convergence of your solution dynamically
-by checking residuals, statistics, force values, surface integrals, and volume
-integrals.
+by checking the values of solution variables and residuals.
 
 The following example queries what monitors exist and then registers a callback
 function which tabulates monitored values per iteration:

--- a/tests/test_solver_monitors.py
+++ b/tests/test_solver_monitors.py
@@ -37,6 +37,7 @@ def test_solver_monitors(new_solver_session):
 
     # monitor set names becomes available after initializing
     solver.solution.initialization.hybrid_initialize()
+
     monitor_set_names = ordered_report_plot_names + ["residual"]
     assert sorted(solver.monitors.get_monitor_set_names()) == sorted(monitor_set_names)
 

--- a/tests/test_solver_monitors.py
+++ b/tests/test_solver_monitors.py
@@ -1,6 +1,9 @@
+import pytest
+
 from ansys.fluent.core import examples
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_solver_monitors(new_solver_session):
 
     solver = new_solver_session
@@ -9,10 +12,7 @@ def test_solver_monitors(new_solver_session):
         file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
     )
 
-    try:
-        solver.file.read_case(file_name=import_case)
-    except AttributeError:
-        solver.tui.file.read_case(import_case)
+    solver.file.read_case(file_name=import_case)
 
     ordered_report_plot_names = [
         "mass-bal-rplot",
@@ -33,10 +33,7 @@ def test_solver_monitors(new_solver_session):
         file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
     )
 
-    try:
-        solver.file.read_data(file_name=import_data)
-    except AttributeError:
-        solver.tui.file.read_data(import_data)
+    solver.file.read_data(file_name=import_data)
 
     # monitor set names remains unavailable after loading data
     assert len(solver.monitors.get_monitor_set_names()) == 0

--- a/tests/test_solver_monitors.py
+++ b/tests/test_solver_monitors.py
@@ -1,0 +1,77 @@
+from ansys.fluent.core import examples
+
+
+def test_solver_monitors(new_solver_session):
+
+    solver = new_solver_session
+
+    import_case = examples.download_file(
+        file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
+    )
+
+    solver.file.read_case(file_name=import_case)
+
+    ordered_report_plot_names = [
+        "mass-bal-rplot",
+        "mass-in-rplot",
+        "mass-tot-rplot",
+        "point-vel-rplot",
+    ]
+
+    assert (
+        sorted(solver.settings.solution.monitor.report_plots().keys())
+        == ordered_report_plot_names
+    )
+
+    # monitor set names unavailable without data
+    assert len(solver.monitors.get_monitor_set_names()) == 0
+
+    import_data = examples.download_file(
+        file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
+    )
+
+    solver.file.read_data(file_name=import_data)
+
+    # monitor set names remains unavailable after loading data
+    assert len(solver.monitors.get_monitor_set_names()) == 0
+
+    # monitor set names becomes available after initializing
+    solver.solution.initialization.hybrid_initialize()
+    monitor_set_names = ordered_report_plot_names + ["residual"]
+    assert sorted(solver.monitors.get_monitor_set_names()) == sorted(monitor_set_names)
+
+    # no data in monitors at this point
+    assert all(
+        all(
+            len(elem) == 0
+            for elem in solver.monitors.get_monitor_set_data(monitor_set_name=name)
+        )
+        for name in monitor_set_names
+    ), "One or more monitor sets contain non-empty elements."
+
+    # run the solver...
+    solver.solution.run_calculation.iterate(iter_count=1)
+
+    # ...data is in monitors
+    assert all(
+        all(
+            len(elem) != 0
+            for elem in solver.monitors.get_monitor_set_data(monitor_set_name=name)
+        )
+        for name in monitor_set_names
+    ), "One or more monitor sets contain empty elements."
+
+    def monitor_callback():
+        monitor_callback.called = True
+
+    monitor_callback.called = False
+
+    # n.b. there is no checking of the callback signature at registration. Instead
+    # we would get a TypeError at callback time if the signatire is wrong. The correct
+    # signature is undocumented.
+    register_id = solver.monitors.register_callback(monitor_callback)
+
+    # trigger callback by running the solver
+    assert not monitor_callback.called
+    solver.solution.run_calculation.iterate(iter_count=1)
+    assert monitor_callback.called

--- a/tests/test_solver_monitors.py
+++ b/tests/test_solver_monitors.py
@@ -19,7 +19,7 @@ def test_solver_monitors(new_solver_session):
     ]
 
     assert (
-        sorted(solver.settings.solution.monitor.report_plots().keys())
+        sorted(solver.settings.solution.monitor.report_plots())
         == ordered_report_plot_names
     )
 
@@ -68,7 +68,7 @@ def test_solver_monitors(new_solver_session):
     monitor_callback.called = False
 
     # n.b. there is no checking of the callback signature at registration. Instead
-    # we would get a TypeError at callback time if the signatire is wrong. The correct
+    # we would get a TypeError at callback time if the signature is wrong. The correct
     # signature is undocumented.
     register_id = solver.monitors.register_callback(monitor_callback)
 

--- a/tests/test_solver_monitors.py
+++ b/tests/test_solver_monitors.py
@@ -9,7 +9,10 @@ def test_solver_monitors(new_solver_session):
         file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system"
     )
 
-    solver.file.read_case(file_name=import_case)
+    try:
+        solver.file.read_case(file_name=import_case)
+    except AttributeError:
+        solver.tui.file.read_case(import_case)
 
     ordered_report_plot_names = [
         "mass-bal-rplot",
@@ -30,7 +33,10 @@ def test_solver_monitors(new_solver_session):
         file_name="exhaust_system.dat.h5", directory="pyfluent/exhaust_system"
     )
 
-    solver.file.read_data(file_name=import_data)
+    try:
+        solver.file.read_data(file_name=import_data)
+    except AttributeError:
+        solver.tui.file.read_data(import_data)
 
     # monitor set names remains unavailable after loading data
     assert len(solver.monitors.get_monitor_set_names()) == 0


### PR DESCRIPTION
- Test and doc for monitors.
- Met a few issues in usage.
- Maybe they are surmountable but it's hard to tell because of the documentation.

1. Have to load data **AND** initialize to get monitor set info through `monitors` service. The same info is in settings API after case read.
2. Cannot see how to register callback for a specific monitor set name. Get `N` callback calls per iteration for `N` monitor sets in the case.
3. The signature of the callback is not checked at registration. This signature is undocumented.
4. The callback interface could be extended to contain more contextual information, similar to the event callbacks.