### PR TITLE
ci: Avoid dynamic status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,9 +467,11 @@ jobs:
             version: 241
           - image-tag: v24.2.0
             version: 242
-          - image-tag: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          - image-tag: v25.1.0
             version: 251
     timeout-minutes: 120
+    env:
+        FLUENT_IMAGE_TAG: ${{ matrix.version == 251 && vars.FLUENT_STABLE_IMAGE_DEV || matrix.image-tag }}
 
     steps:
 
@@ -510,16 +512,12 @@ jobs:
       - name: Pull Fluent docker image
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Unit Testing
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
           make install-test
           make unittest-dev-${{ matrix.version }}
-        env:
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Cleanup previous docker containers
         if: always()


### PR DESCRIPTION
In the previous code, the matrix parameter was dynamic turning the status checks for branch protection dynamic.