### PR TITLE
fix: Temporary fix for parameter list() method

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1608,6 +1608,27 @@ class BaseCommand(Action):
         return self.execute_command(*args, **kwds)
 
 
+# TODO: Remove this after paremater list() method is fixed from Fluent side
+def _fix_parameter_list_return(val):
+    if isinstance(val, dict):
+        new_val = {}
+        for name, v in val.items():
+            value, units = v
+            if len(units) > 0:
+                unit_labels = _fix_parameter_list_return.scheme_eval(
+                    f"(units/inquire-available-label-strings-for-quantity '{units[0]})"
+                )
+                unit_label = unit_labels[0] if len(unit_labels) > 0 else ""
+            else:
+                unit_label = ""
+            new_val[name] = [value, unit_label]
+        return new_val
+    return val
+
+
+_fix_parameter_list_return.scheme_eval = None
+
+
 class Command(BaseCommand):
     """Command object."""
 
@@ -1628,7 +1649,14 @@ class Command(BaseCommand):
                 if response in ["n", "N", "no"]:
                     return
         with self._while_executing_command():
-            return self.flproxy.execute_cmd(self._parent.path, self.obj_name, **newkwds)
+            ret = self.flproxy.execute_cmd(self._parent.path, self.obj_name, **newkwds)
+            if os.getenv("PYFLUENT_NO_FIX_PARAMETER_LIST_RETURN") != "1":
+                if (self._parent.path, self.obj_name) in [
+                    ("parameters/input-parameters", "list"),
+                    ("parameters/output-parameters", "list"),
+                ]:
+                    ret = _fix_parameter_list_return(ret)
+            return ret
 
     def __call__(self, **kwds):
         """Call a command with the specified keyword arguments."""
@@ -2099,6 +2127,7 @@ def get_root(
     root._set_on_interrupt(interrupt)
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
+    _fix_parameter_list_return.scheme_eval = scheme_eval
     root._setattr("_static_info", obj_info)
     root._setattr("_file_transfer_service", file_transfer_service)
     return root

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -228,7 +228,6 @@ def test_parametric_workflow():
     solver_session.exit()
 
 
-@pytest.mark.nightly
 @pytest.mark.fluent_version(">=24.2")
 def test_parameters_list_function(static_mixer_settings_session):
     solver = static_mixer_settings_session
@@ -256,5 +255,15 @@ def test_parameters_list_function(static_mixer_settings_session):
     create_output_param("report-definition", "outlet-temp-avg")
     create_output_param("report-definition", "outlet-vel-avg")
 
-    assert len(solver.parameters.input_parameters.list()) == 4
-    assert len(solver.parameters.output_parameters.list()) == 2
+    input_parameters_list = solver.parameters.input_parameters.list()
+    output_parameters_list = solver.parameters.output_parameters.list()
+    assert input_parameters_list == {
+        "inlet1_temp": [300.0, "K"],
+        "inlet1_vel": [1.0, "m/s"],
+        "inlet2_temp": [350.0, "K"],
+        "inlet2_vel": [1.0, "m/s"],
+    }
+    assert output_parameters_list == {
+        "outlet-temp-avg-op": [0.0, "K"],
+        "outlet-vel-avg-op": [0.0, "m/s"],
+    }


### PR DESCRIPTION
Adding this temporary fix in PyFluent side, till Fluent code is fixed. The fix can be disabled by setting the env var `PYFLUENT_NO_FIX_PARAMETER_LIST_RETURN` to `1`.