### PR TITLE
refactor: Skip meshing utilities test.

### DIFF
--- a/tests/test_meshing_utilities.py
+++ b/tests/test_meshing_utilities.py
@@ -9,9 +9,10 @@ def pytest_approx(expected):
     return pytest.approx(expected=expected, rel=PYTEST_RELATIVE_TOLERANCE)
 
 
+@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/3183")
 @pytest.mark.codegen_required
 @pytest.mark.nightly
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version(">=25.1")
 def test_meshing_utilities(new_meshing_session):
     meshing_session = new_meshing_session
     import_filename = examples.download_file(


### PR DESCRIPTION
Activate this test once the fluent side changes are available.