### PR TITLE
fix: Correct rst file generation path

### DIFF
--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -16,7 +16,7 @@ def _get_folder_path(folder_name: str):
     -------
         Path of the folder.
     """
-    return (Path(__file__) / ".." / "api" / folder_name).resolve()
+    return (Path(__file__) / ".." / "source" / "api" / folder_name).resolve()
 
 
 def _get_file_path(folder_name: str, file_name: str):
@@ -34,7 +34,9 @@ def _get_file_path(folder_name: str, file_name: str):
     -------
         Path of the file.
     """
-    return (Path(__file__) / ".." / "api" / folder_name / f"{file_name}.rst").resolve()
+    return (
+        Path(__file__) / ".." / "source" / "api" / folder_name / f"{file_name}.rst"
+    ).resolve()
 
 
 hierarchy = {


### PR DESCRIPTION
Correct rst file generation path

![image](https://github.com/user-attachments/assets/a1c12dd8-c826-46a4-9196-30d5d54b6a1a)

@prmukherj This change should be part of patch release if 0.24.0 tag pushed already. I will create patch release if needed.

Tracking nightly doc build[ here](https://github.com/ansys/pyfluent/actions/runs/10440697186).

Correct API docs -

![image](https://github.com/user-attachments/assets/6b81c6ec-3f43-4ce5-96f3-371df7756b0d)
