### PR TITLE
fix: Correct error message for Fluent versions

### DIFF
--- a/src/ansys/fluent/core/solver/settings_external.py
+++ b/src/ansys/fluent/core/solver/settings_external.py
@@ -1,5 +1,8 @@
 """Miscellaneous utility functions."""
 
+import os
+import re
+
 
 def expand_api_file_argument(command_name, value, kwargs):
     """Expand API file argument."""
@@ -11,3 +14,29 @@ def expand_api_file_argument(command_name, value, kwargs):
         return [value, data_file]
     else:
         return [value]
+
+
+def use_search(codegen_outdir: str, version: str):
+    """Whether to use ``_search()`` in the error handling.
+
+    Parameters
+    ----------
+    codegen_outdir: str
+        Codegen directory.
+    version: str
+        Fluent version.
+    """
+    fluent_version_str = version
+    fluent_version_int = int(fluent_version_str.replace(".", "")[0:3])
+    api_tree_files = [
+        file for file in os.listdir(codegen_outdir) if file.endswith("pickle")
+    ]
+    api_tree_file_count = len(api_tree_files)
+    api_tree_file_versions = [
+        int(re.findall(r"\d+", file)[0]) for file in api_tree_files
+    ]
+    latest_api_tree_version = max(api_tree_file_versions)
+    if api_tree_file_count == 1 or fluent_version_int == latest_api_tree_version:
+        return True
+    else:
+        return False

--- a/src/ansys/fluent/core/solver/settings_external.py
+++ b/src/ansys/fluent/core/solver/settings_external.py
@@ -31,12 +31,11 @@ def use_search(codegen_outdir: str, version: str):
     api_tree_files = [
         file for file in os.listdir(codegen_outdir) if file.endswith("pickle")
     ]
-    api_tree_file_count = len(api_tree_files)
     api_tree_file_versions = [
         int(re.findall(r"\d+", file)[0]) for file in api_tree_files
     ]
     latest_api_tree_version = max(api_tree_file_versions)
-    if api_tree_file_count == 1 or fluent_version_int == latest_api_tree_version:
+    if fluent_version_int == latest_api_tree_version:
         return True
     else:
         return False


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3116

Handle the error message according to Fluent version.

1. Use `_search` if Fluent version and latest api_tree pickle file version is same.

Earlier -

```
>>> import os
>>> os.environ["PYFLUENT_FLUENT_ROOT"] = r"D:\Installations\Ansys\v222_07082024\ANSYS Inc\v222\fluent"
>>> import ansys.fluent.core as pf
>>> solver = pf.launch_fluent(ui_mode="gui")
>>> solver.file.read_case
 AttributeError: 'file' object has no attribute 'read_case'.

The most similar API names are:
file.read_case (Command)
file.read_case_data (Command)
file.read_case_setting (Command)
```


Now - 

![image](https://github.com/user-attachments/assets/af47f96d-a318-409f-9dae-23de57fb46a4)
