### PR TITLE
refactor: Clean-up post segregation of classic and enhanced meshing w…

### DIFF
--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1184,7 +1184,7 @@ class CompoundTask(CommandTask):
         return self._last_child()
 
     def _last_child(self) -> BaseTask:
-        """Get the last child of this CompoundTask and formulate their python name.
+        """Get the last child of this CompoundTask and set their Python name.
 
         Returns
         -------

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -204,7 +204,6 @@ class BaseTask:
                 _ordered_children=[],
                 _task_list=[],
                 _task_objects={},
-                _dynamic_interface=command_source._dynamic_interface,
                 _fluent_version=command_source._fluent_version,
             )
         )
@@ -386,20 +385,17 @@ class BaseTask:
         return self._python_name
 
     def _set_python_name(self, compound=False):
-        if self._dynamic_interface:
-            this_command = self._command()
-            if compound:
-                p_name = (
-                    self._command_source._compound_parent_task_python_name_id[0]
-                    + f"_child_{self._command_source._compound_parent_task_python_name_id[1]}"
-                )
-                self._python_name = p_name
-                self._command_source._compound_task_map[self.name()] = p_name
-            else:
-                self._python_name = camel_to_snake_case(
-                    this_command.get_attr("helpString")
-                )
-            self._cache_data(this_command)
+        this_command = self._command()
+        if compound:
+            p_name = (
+                self._command_source._compound_parent_task_python_name_id[0]
+                + f"_child_{self._command_source._compound_parent_task_python_name_id[1]}"
+            )
+            self._python_name = p_name
+            self._command_source._compound_task_map[self.name()] = p_name
+        else:
+            self._python_name = camel_to_snake_case(this_command.get_attr("helpString"))
+        self._cache_data(this_command)
 
     def _cache_data(self, command):
         disp_text = command.get_attr("displayText")
@@ -428,20 +424,19 @@ class BaseTask:
         result = getattr(self._task, attr, None)
         if result:
             return result
-        if self._dynamic_interface:
-            if not attr.islower() and attr != "Arguments":
-                raise AttributeError(
-                    "Camel case attribute access is not supported. "
-                    f"Try using '{camel_to_snake_case(attr)}' instead."
-                )
-            camel_attr = (
-                snake_to_camel_case(
-                    str(attr), [*self._get_camel_case_arg_keys(), *dir(self._task)]
-                )
-                if attr.islower()
-                else attr
+        if not attr.islower() and attr != "Arguments":
+            raise AttributeError(
+                "Camel case attribute access is not supported. "
+                f"Try using '{camel_to_snake_case(attr)}' instead."
             )
-            attr = camel_attr or attr
+        camel_attr = (
+            snake_to_camel_case(
+                str(attr), [*self._get_camel_case_arg_keys(), *dir(self._task)]
+            )
+            if attr.islower()
+            else attr
+        )
+        attr = camel_attr or attr
         result = getattr(self._task, attr, None)
         if result:
             return result
@@ -462,12 +457,8 @@ class BaseTask:
 
     def __dir__(self):
         arg_list = []
-        if self._dynamic_interface:
-            for arg in [*self._get_camel_case_arg_keys(), *dir(self._task)]:
-                arg_list.append(camel_to_snake_case(arg))
-        else:
-            for arg in [*self.arguments().keys(), *dir(self._task)]:
-                arg_list.append(arg)
+        for arg in [*self._get_camel_case_arg_keys(), *dir(self._task)]:
+            arg_list.append(camel_to_snake_case(arg))
 
         return sorted(set(list(self.__dict__.keys()) + dir(type(self)) + arg_list))
 
@@ -477,44 +468,43 @@ class BaseTask:
 
     def rename(self, new_name: str):
         """Rename the current task to a given name."""
-        if self._dynamic_interface:
-            self._command_source._dynamic_python_names = True
-            if (
-                self.python_name()
-                in self._command_source._repeated_task_python_name_display_text_map
-            ):
-                self._command_source._python_name_command_id_map[new_name] = (
-                    self._command_source._python_name_command_id_map.pop(
-                        self.python_name(), None
-                    )
-                )
-                self._command_source._python_name_display_id_map[new_name] = (
-                    self._command_source._python_name_display_id_map.pop(
-                        self.python_name(), None
-                    )
-                )
-                self._command_source._python_name_display_text_map.pop(
+        self._command_source._dynamic_python_names = True
+        if (
+            self.python_name()
+            in self._command_source._repeated_task_python_name_display_text_map
+        ):
+            self._command_source._python_name_command_id_map[new_name] = (
+                self._command_source._python_name_command_id_map.pop(
                     self.python_name(), None
                 )
-                self._command_source._repeated_task_python_name_display_text_map.pop(
+            )
+            self._command_source._python_name_display_id_map[new_name] = (
+                self._command_source._python_name_display_id_map.pop(
                     self.python_name(), None
                 )
-            else:
-                self._command_source._python_name_command_id_map[new_name] = (
-                    self._command_source._python_name_command_id_map[self.python_name()]
-                )
-                self._command_source._python_name_display_id_map[new_name] = (
-                    self._command_source._python_name_display_id_map[self.python_name()]
-                )
-                self._command_source._python_name_display_text_map.pop(
-                    self.python_name(), None
-                )
+            )
+            self._command_source._python_name_display_text_map.pop(
+                self.python_name(), None
+            )
+            self._command_source._repeated_task_python_name_display_text_map.pop(
+                self.python_name(), None
+            )
+        else:
+            self._command_source._python_name_command_id_map[new_name] = (
+                self._command_source._python_name_command_id_map[self.python_name()]
+            )
+            self._command_source._python_name_display_id_map[new_name] = (
+                self._command_source._python_name_display_id_map[self.python_name()]
+            )
+            self._command_source._python_name_display_text_map.pop(
+                self.python_name(), None
+            )
 
-            self._command_source._python_name_display_text_map[new_name] = new_name
-            self._command_source._repeated_task_python_name_display_text_map[
-                new_name
-            ] = new_name
-            self._python_name = new_name
+        self._command_source._python_name_display_text_map[new_name] = new_name
+        self._command_source._repeated_task_python_name_display_text_map[new_name] = (
+            new_name
+        )
+        self._python_name = new_name
         return self._task.Rename(NewName=new_name)
 
     def add_child_to_task(self):
@@ -703,7 +693,6 @@ class ArgumentsWrapper(PyCallableStateObject):
         self.__dict__.update(
             dict(
                 _task=task,
-                _dynamic_interface=task._dynamic_interface,
                 _snake_to_camel_map={},
             )
         )
@@ -767,10 +756,7 @@ class ArgumentsWrapper(PyCallableStateObject):
             self._task.Arguments() if explicit_only else self._task._command_arguments()
         )
 
-        if self._dynamic_interface:
-            return self._camel_snake_arguments_map(state_dict)
-
-        return state_dict
+        return self._camel_snake_arguments_map(state_dict)
 
     def _assign(self, args: dict, fn) -> None:
         # This function sets the task arguments' state, either via update_dict()
@@ -792,15 +778,10 @@ class ArgumentsWrapper(PyCallableStateObject):
             old_state = self.get_state()
         except Exception:
             old_state = None
-        if self._dynamic_interface:
-            camel_args = {}
-            for key, val in args.items():
-                camel_args[self._snake_to_camel_map[key] if key.islower() else key] = (
-                    val
-                )
-            getattr(self._task.Arguments, fn)(camel_args)
-        else:
-            getattr(self._task.Arguments, fn)(args)
+        camel_args = {}
+        for key, val in args.items():
+            camel_args[self._snake_to_camel_map[key] if key.islower() else key] = val
+        getattr(self._task.Arguments, fn)(camel_args)
         try:
             self._refresh_command_after_changing_args(old_state)
         except Exception as ex:
@@ -820,19 +801,14 @@ class ArgumentsWrapper(PyCallableStateObject):
             raise ex
 
     def _just_set_state(self, args):
-        if self._dynamic_interface:
-            camel_args = {}
-            if isinstance(args, dict):
-                for key, val in args.items():
-                    camel_args[self._snake_to_camel_map[key]] = val
-            self._task.Arguments.set_state(camel_args)
-        else:
-            self._task.Arguments.set_state(args)
+        camel_args = {}
+        if isinstance(args, dict):
+            for key, val in args.items():
+                camel_args[self._snake_to_camel_map[key]] = val
+        self._task.Arguments.set_state(camel_args)
 
     def __getattr__(self, attr):
-        if self._dynamic_interface:
-            return getattr(self._task, attr)
-        return getattr(self._task._command_arguments, attr)
+        return getattr(self._task, attr)
 
     def __setattr__(self, key, value):
         try:
@@ -843,15 +819,10 @@ class ArgumentsWrapper(PyCallableStateObject):
             )
 
     def __setitem__(self, key, value):
-        if self._dynamic_interface:
-            getattr(self._task, key).set_state(value)
-        else:
-            self._task._command_arguments.__setitem__(key, value)
+        getattr(self._task, key).set_state(value)
 
     def __getitem__(self, item):
-        if self._dynamic_interface:
-            return getattr(self._task, item).get_state()
-        return self._task._command_arguments.__getitem__(item)
+        return getattr(self._task, item).get_state()
 
 
 class ArgumentWrapper(PyCallableStateObject):
@@ -872,7 +843,6 @@ class ArgumentWrapper(PyCallableStateObject):
                 _task=task,
                 _arg_name=arg,
                 _arg=getattr(task._command_arguments, arg),
-                _dynamic_interface=task._dynamic_interface,
                 _snake_to_camel_map={},
             )
         )
@@ -903,9 +873,7 @@ class ArgumentWrapper(PyCallableStateObject):
             self._task.Arguments()[self._arg_name] if explicit_only else self._arg()
         )
 
-        if self._dynamic_interface and isinstance(
-            self._arg, PySingletonCommandArgumentsSubItem
-        ):
+        if isinstance(self._arg, PySingletonCommandArgumentsSubItem):
             snake_case_state_dict = {}
             for key, val in state_dict.items():
                 self._snake_to_camel_map[camel_to_snake_case(key)] = key
@@ -928,35 +896,31 @@ class ArgumentWrapper(PyCallableStateObject):
         return _camel_args
 
     def __getattr__(self, attr):
-        if self._dynamic_interface:
-            if not attr.islower():
-                raise AttributeError(
-                    "Camel case attribute access is not supported. "
-                    f"Try using '{camel_to_snake_case(attr)}' instead."
-                )
-            camel_attr = snake_to_camel_case(
-                str(attr), self._get_camel_case_arg_keys() or []
+        if not attr.islower():
+            raise AttributeError(
+                "Camel case attribute access is not supported. "
+                f"Try using '{camel_to_snake_case(attr)}' instead."
             )
-            attr = camel_attr or attr
+        camel_attr = snake_to_camel_case(
+            str(attr), self._get_camel_case_arg_keys() or []
+        )
+        attr = camel_attr or attr
         return getattr(self._arg, attr)
 
     def __setattr__(self, attr, value):
         if attr in self.__dict__:
             self.__dict__[attr] = value
         else:
-            if self._dynamic_interface:
-                camel_attr = snake_to_camel_case(
-                    str(attr), self._get_camel_case_arg_keys() or []
-                )
-                attr = camel_attr or attr
+            camel_attr = snake_to_camel_case(
+                str(attr), self._get_camel_case_arg_keys() or []
+            )
+            attr = camel_attr or attr
             self.set_state({attr: value})
 
     def __dir__(self):
         arg_list = []
         for arg in self():
-            arg_list.append(
-                camel_to_snake_case(arg) if self._dynamic_interface else arg
-            )
+            arg_list.append(camel_to_snake_case(arg))
         return sorted(set(list(self.__dict__.keys()) + dir(type(self)) + arg_list))
 
 
@@ -1198,12 +1162,8 @@ class CompoundTask(CommandTask):
             Optional state.
         """
         state = state or {}
-        if self._dynamic_interface:
-            state.update({"add_child": "yes"})
-            self.arguments.update_dict(state)
-        else:
-            state.update({"AddChild": "yes"})
-            self._task.Arguments.update_dict(state)
+        state.update({"add_child": "yes"})
+        self.arguments.update_dict(state)
 
     def add_child_and_update(self, state=None, defer_update=None):
         """Add a child to this CompoundTask and update.
@@ -1341,7 +1301,6 @@ class Workflow:
                 _getattr_recurse_depth=0,
                 _main_thread_ident=None,
                 _task_objects={},
-                _dynamic_interface=False,
                 _python_name_command_id_map={},
                 _python_name_display_id_map={},
                 _python_name_display_text_map={},
@@ -1507,7 +1466,6 @@ class Workflow:
         return self._task_by_id_impl(task_id, workflow_state)
 
     def _activate_dynamic_interface(self, dynamic_interface: bool):
-        self._dynamic_interface = dynamic_interface
         self._initialize_methods(dynamic_interface=dynamic_interface)
 
     def _unsubscribe_root_affected_callback(self):
@@ -1687,7 +1645,6 @@ class ClassicWorkflow:
         self._lock = (
             threading.RLock()
         )  # TODO: sort out issues with these un-used variables.
-        self._dynamic_interface = False
         self._fluent_version = fluent_version
 
     @property

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -454,36 +454,26 @@ class BaseTask:
     def rename(self, new_name: str):
         """Rename the current task to a given name."""
         self._command_source._dynamic_python_names = True
-        if (
-            self.python_name()
-            in self._command_source._repeated_task_python_name_display_text_map
-        ):
+        py_name = self.python_name()
+        if py_name in self._command_source._repeated_task_python_name_display_text_map:
             self._command_source._python_name_command_id_map[new_name] = (
-                self._command_source._python_name_command_id_map.pop(
-                    self.python_name(), None
-                )
+                self._command_source._python_name_command_id_map.pop(py_name, None)
             )
             self._command_source._python_name_display_id_map[new_name] = (
-                self._command_source._python_name_display_id_map.pop(
-                    self.python_name(), None
-                )
+                self._command_source._python_name_display_id_map.pop(py_name, None)
             )
-            self._command_source._python_name_display_text_map.pop(
-                self.python_name(), None
-            )
+            self._command_source._python_name_display_text_map.pop(py_name, None)
             self._command_source._repeated_task_python_name_display_text_map.pop(
-                self.python_name(), None
+                py_name, None
             )
         else:
             self._command_source._python_name_command_id_map[new_name] = (
-                self._command_source._python_name_command_id_map[self.python_name()]
+                self._command_source._python_name_command_id_map[py_name]
             )
             self._command_source._python_name_display_id_map[new_name] = (
-                self._command_source._python_name_display_id_map[self.python_name()]
+                self._command_source._python_name_display_id_map[py_name]
             )
-            self._command_source._python_name_display_text_map.pop(
-                self.python_name(), None
-            )
+            self._command_source._python_name_display_text_map.pop(py_name, None)
 
         self._command_source._python_name_display_text_map[new_name] = new_name
         self._command_source._repeated_task_python_name_display_text_map[new_name] = (

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -716,7 +716,7 @@ def test_watertight_workflow_children(
     assert added_sizing.name() == "facesize_1"
     assert len(added_sizing.arguments())
     added_sizing_by_name = add_local_sizing.compound_child("facesize_1")
-    added_sizing_by_pos = add_local_sizing.last_child()
+    added_sizing_by_pos = add_local_sizing.tasks()[-1]
     assert added_sizing.arguments() == added_sizing_by_name.arguments()
     assert added_sizing.arguments() == added_sizing_by_pos.arguments()
     assert added_sizing.python_name() == "add_local_sizing_child_1"


### PR DESCRIPTION
Clean-up the Enhanced meshing workflow post segregation from the Classic one. The "_dynamic_interface" flag is no longer to be required.

The "time.sleep(1)" is no longer needed as well now.