### PR TITLE
fix: Convert protobuf Point to python Vector.

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -13,6 +13,7 @@ import grpc
 
 from ansys.api.fluent.v0 import datamodel_se_pb2 as DataModelProtoModule
 from ansys.api.fluent.v0 import datamodel_se_pb2_grpc as DataModelGrpcModule
+from ansys.api.fluent.v0.common_api_pb2 import Point
 from ansys.api.fluent.v0.variant_pb2 import Variant
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.data_model_cache import DataModelCache, NameKey
@@ -327,6 +328,33 @@ def _convert_variant_to_value(var: Variant) -> _TValue:
         for k, v in var.variant_map_state.item.items():
             val[k] = _convert_variant_to_value(v)
         return val
+
+
+class Vector:
+    """Wrap Fluent's Point type into a Python class."""
+
+    def __init__(self, point: Point):
+        """__init__ of Vector class."""
+        self._val = point
+
+    @property
+    def x(self) -> float:
+        """Returns vector point x."""
+        return self._val.x
+
+    @property
+    def y(self) -> float:
+        """Returns vector point y."""
+        return self._val.y
+
+    @property
+    def z(self) -> float:
+        """Returns vector point z."""
+        return self._val.z
+
+    def __call__(self):
+        """Returns vector as [x, y, z]."""
+        return [self.x, self.y, self.z]
 
 
 class EventSubscription:

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -13,7 +13,6 @@ import grpc
 
 from ansys.api.fluent.v0 import datamodel_se_pb2 as DataModelProtoModule
 from ansys.api.fluent.v0 import datamodel_se_pb2_grpc as DataModelGrpcModule
-from ansys.api.fluent.v0.common_api_pb2 import Point
 from ansys.api.fluent.v0.variant_pb2 import Variant
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.data_model_cache import DataModelCache, NameKey
@@ -328,33 +327,6 @@ def _convert_variant_to_value(var: Variant) -> _TValue:
         for k, v in var.variant_map_state.item.items():
             val[k] = _convert_variant_to_value(v)
         return val
-
-
-class Vector:
-    """Wrap Fluent's Point type into a Python class."""
-
-    def __init__(self, point: Point):
-        """__init__ of Vector class."""
-        self._val = point
-
-    @property
-    def x(self) -> float:
-        """Returns vector point x."""
-        return self._val.x
-
-    @property
-    def y(self) -> float:
-        """Returns vector point y."""
-        return self._val.y
-
-    @property
-    def z(self) -> float:
-        """Returns vector point z."""
-        return self._val.z
-
-    def __call__(self):
-        """Returns vector as [x, y, z]."""
-        return [self.x, self.y, self.z]
 
 
 class EventSubscription:

--- a/src/ansys/fluent/core/services/reduction.py
+++ b/src/ansys/fluent/core/services/reduction.py
@@ -7,7 +7,7 @@ import grpc
 
 from ansys.api.fluent.v0 import reduction_pb2 as ReductionProtoModule
 from ansys.api.fluent.v0 import reduction_pb2_grpc as ReductionGrpcModule
-from ansys.fluent.core.services.datamodel_se import _convert_variant_to_value
+from ansys.fluent.core.services.datamodel_se import Vector, _convert_variant_to_value
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
@@ -300,7 +300,7 @@ class Reduction:
         request = ReductionProtoModule.CentroidRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.centroid(request)
-        return response.value
+        return Vector(response.value)
 
     def count(self, locations, ctxt=None) -> Any:
         """Get count."""
@@ -322,7 +322,7 @@ class Reduction:
         request = ReductionProtoModule.ForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.force(request)
-        return response.value
+        return Vector(response.value)
 
     def mass_average(self, expression, locations, ctxt=None) -> Any:
         """Get mass average."""
@@ -385,14 +385,14 @@ class Reduction:
         request = ReductionProtoModule.PressureForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.pressure_force(request)
-        return response.value
+        return Vector(response.value)
 
     def viscous_force(self, locations, ctxt=None) -> Any:
         """Get viscous force."""
         request = ReductionProtoModule.ViscousForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.viscous_force(request)
-        return response.value
+        return Vector(response.value)
 
     def volume(self, locations, ctxt=None) -> Any:
         """Get volume."""
@@ -423,7 +423,7 @@ class Reduction:
         request.expression = expression
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.moment(request)
-        return response.value
+        return Vector(response.value)
 
     def sum(self, expression, locations, weight, ctxt=None) -> Any:
         """Get sum."""

--- a/src/ansys/fluent/core/services/reduction.py
+++ b/src/ansys/fluent/core/services/reduction.py
@@ -7,7 +7,7 @@ import grpc
 
 from ansys.api.fluent.v0 import reduction_pb2 as ReductionProtoModule
 from ansys.api.fluent.v0 import reduction_pb2_grpc as ReductionGrpcModule
-from ansys.fluent.core.services.datamodel_se import Vector, _convert_variant_to_value
+from ansys.fluent.core.services.datamodel_se import _convert_variant_to_value
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
@@ -300,7 +300,7 @@ class Reduction:
         request = ReductionProtoModule.CentroidRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.centroid(request)
-        return Vector(response.value)
+        return (response.value.x, response.value.y, response.value.z)
 
     def count(self, locations, ctxt=None) -> Any:
         """Get count."""
@@ -322,7 +322,7 @@ class Reduction:
         request = ReductionProtoModule.ForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.force(request)
-        return Vector(response.value)
+        return (response.value.x, response.value.y, response.value.z)
 
     def mass_average(self, expression, locations, ctxt=None) -> Any:
         """Get mass average."""
@@ -385,14 +385,14 @@ class Reduction:
         request = ReductionProtoModule.PressureForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.pressure_force(request)
-        return Vector(response.value)
+        return (response.value.x, response.value.y, response.value.z)
 
     def viscous_force(self, locations, ctxt=None) -> Any:
         """Get viscous force."""
         request = ReductionProtoModule.ViscousForceRequest()
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.viscous_force(request)
-        return Vector(response.value)
+        return (response.value.x, response.value.y, response.value.z)
 
     def volume(self, locations, ctxt=None) -> Any:
         """Get volume."""
@@ -423,7 +423,7 @@ class Reduction:
         request.expression = expression
         request.locations.extend(self._get_location_string(locations, ctxt))
         response = self.service.moment(request)
-        return Vector(response.value)
+        return (response.value.x, response.value.y, response.value.z)
 
     def sum(self, expression, locations, weight, ctxt=None) -> Any:
         """Get sum."""

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -368,7 +368,7 @@ def _test_sum_if(solver):
 static_mixer_case_session2 = static_mixer_case_session
 
 
-# @pytest.mark.nightly
+@pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_reductions(static_mixer_case_session, static_mixer_case_session2) -> None:
     solver1 = static_mixer_case_session

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -163,9 +163,9 @@ def _test_centroid(solver):
     red_val_1 = solver.fields.reduction.centroid(locations=[velocity_inlet["inlet1"]])
     red_val_2 = solver.fields.reduction.centroid(locations=[velocity_inlet["inlet2"]])
     red_val_3 = solver.fields.reduction.centroid(locations=[velocity_inlet])
-    assert [red_val_1.x, red_val_1.y, red_val_1.z] == expr_val_1
-    assert [red_val_2.x, red_val_2.y, red_val_2.z] == expr_val_2
-    assert [red_val_3.x, red_val_3.y, red_val_3.z] == expr_val_3
+    assert [red_val_1[0], red_val_1[1], red_val_1[2]] == expr_val_1
+    assert [red_val_2[0], red_val_2[1], red_val_2[2]] == expr_val_2
+    assert [red_val_3[0], red_val_3[1], red_val_3[2]] == expr_val_3
     solver_named_expressions.pop(key="test_expr_1")
 
 
@@ -284,13 +284,13 @@ def _test_force(solver):
         locations=[solver.setup.boundary_conditions.wall]
     )
 
-    assert [red_total_force.x, red_total_force.y, red_total_force.z] == expr_val_1
+    assert [red_total_force[0], red_total_force[1], red_total_force[2]] == expr_val_1
 
-    assert red_pressure_force.x + red_viscous_force.x == red_total_force.x
+    assert red_pressure_force[0] + red_viscous_force[0] == red_total_force[0]
 
-    assert red_pressure_force.y + red_viscous_force.y == red_total_force.y
+    assert red_pressure_force[1] + red_viscous_force[1] == red_total_force[1]
 
-    assert red_pressure_force.z + red_viscous_force.z == red_total_force.z
+    assert red_pressure_force[2] + red_viscous_force[2] == red_total_force[2]
 
     solver_named_expressions.pop(key="test_expr_1")
 
@@ -316,11 +316,11 @@ def _test_moment(solver):
         expression="['inlet1']", locations=[location]
     )
 
-    assert [red_moment_force.x, red_moment_force.y, red_moment_force.z] == expr_val_1
+    assert [red_moment_force[0], red_moment_force[1], red_moment_force[2]] == expr_val_1
     assert [
-        red_moment_location.x,
-        red_moment_location.y,
-        red_moment_location.z,
+        red_moment_location[0],
+        red_moment_location[1],
+        red_moment_location[2],
     ] == expr_val_2
 
     solver_named_expressions.pop(key="test_expr_1")
@@ -368,7 +368,7 @@ def _test_sum_if(solver):
 static_mixer_case_session2 = static_mixer_case_session
 
 
-@pytest.mark.nightly
+# @pytest.mark.nightly
 @pytest.mark.fluent_version(">=23.1")
 def test_reductions(static_mixer_case_session, static_mixer_case_session2) -> None:
     solver1 = static_mixer_case_session


### PR DESCRIPTION
Earlier solver.fields.reduction.<any Point type> was returning a protobuf message. Currently they are wrapped as a python class.

For instance:

Earlier behavior:
```Python
>>> x = solver.fields.reduction.force(locations=["wall"])
>>> x
x: 2.862068334485282
y: -2.5299803741481259
z: -0.0014375438414745349

>>> type(x)
<class 'ansys.api.fluent.v0.common_api_pb2.Point'>
```

Current behavior:

```Python
>>> x = s.fields.reduction.force(locations=["wall"])
>>> x                                                
(2.600005424922768e-31, -1.080374020897745e-24, 3.302743550728087e-17)
>>> type(x) 
<class 'tuple'>
>>> type(x[0]) 
<class 'float'>
```