### PR TITLE
fix: Compound child creation and naming.

### DIFF
--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -716,7 +716,7 @@ def test_watertight_workflow_children(
     assert added_sizing.name() == "facesize_1"
     assert len(added_sizing.arguments())
     added_sizing_by_name = add_local_sizing.compound_child("facesize_1")
-    added_sizing_by_pos = add_local_sizing.tasks()[-1]
+    added_sizing_by_pos = add_local_sizing.last_child()
     assert added_sizing.arguments() == added_sizing_by_name.arguments()
     assert added_sizing.arguments() == added_sizing_by_pos.arguments()
     assert added_sizing.python_name() == "add_local_sizing_child_1"


### PR DESCRIPTION
Fix for both PyConsole and PyFluent.

Please refer to test for more details: "tests/test_new_meshing_workflow\test_duplicate_children_of_compound_task"