### PR TITLE
docs: Remove reference to example that doesn't exist anymore

### DIFF
--- a/doc/source/user_guide/legacy/tui.rst
+++ b/doc/source/user_guide/legacy/tui.rst
@@ -163,5 +163,3 @@ The following rules are implied in the preceding examples:
     ``"Pa"`` in the preceding example) must be wrapped in single quotation marks
     so that the original quotation marks are preserved.
   - The contents of string arguments are preserved.
-
-For more examples of TUI command usage, see :ref:`ref_mixing_elbow_tui_api`.


### PR DESCRIPTION
Example was removed in https://github.com/ansys/pyfluent/pull/3048, but this reference to it remains