### PR TITLE
refactor: Clean-up PyFluent Enums.

### DIFF
--- a/src/ansys/fluent/core/launcher/error_handler.py
+++ b/src/ansys/fluent/core/launcher/error_handler.py
@@ -50,7 +50,7 @@ def _raise_non_gui_exception_in_windows(
 
     if (
         launcher_utils.is_windows()
-        and ui_mode < UIMode.HIDDEN_GUI
+        and UIMode(ui_mode) not in [UIMode.GUI and UIMode.HIDDEN_GUI]
         and product_version < FluentVersion.v241
     ):
         raise InvalidArgument(

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -1,7 +1,6 @@
 """Provides a module for enums used in the PyFluent."""
 
 from enum import Enum
-from functools import total_ordering
 import os
 from typing import Optional, Union
 
@@ -17,7 +16,6 @@ from ansys.fluent.core.utils.fluent_version import FluentVersion
 import ansys.platform.instancemanagement as pypim
 
 
-@total_ordering
 class FluentEnum(Enum):
     """Provides the base class for Fluent-related enums.
 
@@ -57,19 +55,6 @@ class FluentEnum(Enum):
             f"""is not a supported value of {cls.__name__}."""
             f""" The supported values are: {msg}."""
         )
-
-    def __lt__(self, other):
-        if not isinstance(other, type(self)):
-            raise TypeError(
-                f"Cannot compare between {type(self).__name__} and {type(other).__name__}"
-            )
-        if self == other:
-            return False
-        for member in type(self):
-            if self == member:
-                return True
-            if other == member:
-                return False
 
 
 class LaunchMode(FluentEnum):

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -134,6 +134,19 @@ class UIMode(FluentEnum):
             self.GUI: ("",),
         }
 
+    def __lt__(self, other):
+        if not isinstance(other, type(self)):
+            raise TypeError(
+                f"Cannot compare between {type(self).__name__} and {type(other).__name__}"
+            )
+        if self == other:
+            return False
+        for member in type(self):
+            if self == member:
+                return True
+            if other == member:
+                return False
+
 
 class Dimension(FluentEnum):
     """Geometric dimensionality of the Fluent simulation."""

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -78,9 +78,9 @@ class FluentMode(FluentEnum):
     """Enumerates over supported Fluent modes."""
 
     MESHING = "meshing"
-    PURE_MESHING = "pure-meshing"
+    PURE_MESHING = "pure_meshing"
     SOLVER = "solver"
-    SOLVER_ICING = "solver-icing"
+    SOLVER_ICING = "solver_icing"
 
     def _default(self):
         return self.SOLVER
@@ -114,10 +114,10 @@ class FluentMode(FluentEnum):
 class UIMode(FluentEnum):
     """Provides supported user interface mode of Fluent."""
 
-    NO_GUI_OR_GRAPHICS = "no-gui-or-graphics"
-    NO_GRAPHICS = "no-graphics"
-    NO_GUI = "no-gui"
-    HIDDEN_GUI = "hidden-gui"
+    NO_GUI_OR_GRAPHICS = "no_gui_or_graphics"
+    NO_GRAPHICS = "no_graphics"
+    NO_GUI = "no_gui"
+    HIDDEN_GUI = "hidden_gui"
     GUI = "gui"
 
     def _default(self):

--- a/src/ansys/fluent/core/launcher/pyfluent_enums.py
+++ b/src/ansys/fluent/core/launcher/pyfluent_enums.py
@@ -134,19 +134,6 @@ class UIMode(FluentEnum):
             self.GUI: ("",),
         }
 
-    def __lt__(self, other):
-        if not isinstance(other, type(self)):
-            raise TypeError(
-                f"Cannot compare between {type(self).__name__} and {type(other).__name__}"
-            )
-        if self == other:
-            return False
-        for member in type(self):
-            if self == member:
-                return True
-            if other == member:
-                return False
-
 
 class Dimension(FluentEnum):
     """Geometric dimensionality of the Fluent simulation."""

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -418,7 +418,6 @@ def test_fluent_enums():
     assert UIMode("gui") == UIMode.GUI
     with pytest.raises(ValueError):
         UIMode("")
-    assert UIMode.NO_GUI < UIMode.GUI
     with pytest.raises(TypeError):
         UIMode.NO_GUI < FluentWindowsGraphicsDriver.AUTO
 


### PR DESCRIPTION
We don't need to compare 'FluentEnums' for greater than or less than the other now. Only '==' should be supported and that is there by default.

~For UIMode, the other operations should be supported as well.~