### PR TITLE
feat: Add mesh reading capability to case reader.

### DIFF
--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -221,6 +221,7 @@ class MeshType(Enum):
 
     SURFACE = "surface"
     VOLUME = "volume"
+    UNKNOWN = "unknown"
 
 
 class Mesh:
@@ -246,10 +247,13 @@ class Mesh:
 
     def get_mesh_type(self) -> MeshType:
         """Returns the type of the mesh."""
-        if "cells" in self._file_handle["meshes"]["1"].keys():
-            return MeshType.VOLUME
-        else:
-            return MeshType.SURFACE
+        try:
+            if "cells" in self._file_handle["meshes"]["1"].keys():
+                return MeshType.VOLUME
+            else:
+                return MeshType.SURFACE
+        except Exception:
+            return MeshType.UNKNOWN
 
     def get_surface_ids(self) -> list:
         """Returns list of ids of all available surfaces."""
@@ -650,11 +654,13 @@ class CaseFile(RPVarProcessor):
         return self._mesh
 
     def __getattribute__(self, item):
-        if item != "_is_case_file" and not self._is_case_file:
-            if item in set(
-                filter(lambda k: not k.startswith("__"), dir(RPVarProcessor))
-            ):
-                return EmptyContainer()
+        if (
+            item != "_is_case_file"
+            and not self._is_case_file
+            and item
+            in set(filter(lambda k: not k.startswith("__"), dir(RPVarProcessor)))
+        ):
+            return EmptyContainer()
         return super().__getattribute__(item)
 
 

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -640,7 +640,6 @@ class CaseFile(RPVarProcessor):
         return self._mesh
 
     def __dir__(self):
-        """dir() method"""
         if self._is_case_file:
             return sorted(set(list(self.__dict__.keys()) + dir(type(self))))
         else:

--- a/src/ansys/fluent/core/launcher/error_handler.py
+++ b/src/ansys/fluent/core/launcher/error_handler.py
@@ -50,7 +50,7 @@ def _raise_non_gui_exception_in_windows(
 
     if (
         launcher_utils.is_windows()
-        and UIMode(ui_mode) not in [UIMode.GUI and UIMode.HIDDEN_GUI]
+        and UIMode(ui_mode) not in [UIMode.GUI, UIMode.HIDDEN_GUI]
         and product_version < FluentVersion.v241
     ):
         raise InvalidArgument(

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -10,6 +10,7 @@ from ansys.fluent.core.filereader import lispy
 from ansys.fluent.core.filereader.case_file import (
     InputParameter,
     InputParameterOld,
+    MeshType,
     _get_processed_string,
 )
 from ansys.fluent.core.filereader.case_file import CaseFile as CaseReader
@@ -293,3 +294,22 @@ def test_lispy_for_quotes():
         "x",
         '"\n(format \\"\n-------------------------\nRunning Original Settings\n------------------------\n\\")"',
     ]
+
+
+def test_mesh_reader():
+    mesh_file_2d = r"C:\ANSYSDev\PyFluent_Dev_01\pyfluent\D2.msh.h5"
+    mesh_file_3d = examples.download_file(
+        "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
+    )
+    case_file = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    mesh_reader_2d = CaseReader(case_file_name=mesh_file_2d)
+    mesh_reader_3d = CaseReader(case_file_name=mesh_file_3d)
+    case_reader = CaseReader(case_file_name=case_file)
+
+    assert "rp_vars" not in dir(mesh_reader_2d)
+    assert "rp_vars" not in dir(mesh_reader_3d)
+    assert "rp_vars" in dir(case_reader)
+
+    assert mesh_reader_2d.get_mesh().get_mesh_type() == MeshType.SURFACE
+    assert mesh_reader_3d.get_mesh().get_mesh_type() == MeshType.VOLUME
+    assert case_reader.get_mesh().get_mesh_type() == MeshType.VOLUME

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -298,12 +298,20 @@ def test_lispy_for_quotes():
 
 def test_mesh_reader():
     mesh_file_2d = examples.download_file(
-        "sample_2d_mesh.msh.h5", "pyfluent/surface_mesh"
+        "sample_2d_mesh.msh.h5",
+        "pyfluent/surface_mesh",
+        return_without_path=False,
     )
     mesh_file_3d = examples.download_file(
-        "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
+        "mixing_elbow.msh.h5",
+        "pyfluent/mixing_elbow",
+        return_without_path=False,
     )
-    case_file = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    case_file = examples.download_file(
+        "mixing_elbow.cas.h5",
+        "pyfluent/mixing_elbow",
+        return_without_path=False,
+    )
     mesh_reader_2d = CaseReader(case_file_name=mesh_file_2d)
     mesh_reader_3d = CaseReader(case_file_name=mesh_file_3d)
     case_reader = CaseReader(case_file_name=case_file)

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -297,7 +297,9 @@ def test_lispy_for_quotes():
 
 
 def test_mesh_reader():
-    mesh_file_2d = r"C:\ANSYSDev\PyFluent_Dev_01\pyfluent\D2.msh.h5"
+    mesh_file_2d = examples.download_file(
+        "sample_2d_mesh.msh.h5", "pyfluent/surface_mesh"
+    )
     mesh_file_3d = examples.download_file(
         "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
     )
@@ -306,10 +308,10 @@ def test_mesh_reader():
     mesh_reader_3d = CaseReader(case_file_name=mesh_file_3d)
     case_reader = CaseReader(case_file_name=case_file)
 
-    assert "rp_vars" not in dir(mesh_reader_2d)
-    assert "rp_vars" not in dir(mesh_reader_3d)
-    assert "rp_vars" in dir(case_reader)
-
     assert mesh_reader_2d.get_mesh().get_mesh_type() == MeshType.SURFACE
     assert mesh_reader_3d.get_mesh().get_mesh_type() == MeshType.VOLUME
     assert case_reader.get_mesh().get_mesh_type() == MeshType.VOLUME
+
+    assert mesh_reader_2d.precision() is None
+    assert mesh_reader_3d.precision() is None
+    assert case_reader.precision() == 2


### PR DESCRIPTION
1. Case reader to support operations for reading mesh files.
2. The attributes not relevant to a mesh file returns None type container.
3. The below usage is supported now:

>>> mesh_reader_2d.get_mesh().get_mesh_type() == MeshType.SURFACE