### PR TITLE
fix: Handle special characters in child aliases.

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2074,7 +2074,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             # No need to differentiate in the Python implementation
             for k, v in (child_aliases | command_aliases | query_aliases).items():
                 cls._child_aliases[to_python_name(k)] = "/".join(
-                    to_python_name(x) for x in v.split("/")
+                    x if x == ".." else to_python_name(x) for x in v.split("/")
                 )
 
     except Exception:

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -435,3 +435,13 @@ def test_generated_code_special_cases(new_solver_session):
     write_file_bases = solver.file.write_case.file_name.__class__.__bases__
     assert _InputFile not in write_file_bases
     assert _OutputFile in write_file_bases
+
+
+@pytest.mark.fluent_version(">=25.1")
+def test_special_characters_in_child_alias(mixing_elbow_settings_session):
+    solver = mixing_elbow_settings_session
+    solver.solution.initialization.hybrid_initialize()
+    assert (
+        solver.setup.models.discrete_phase.numerics.node_based_averaging.kernel._child_aliases
+        == {"gaussian_factor": "../gaussian_factor", "option": "../kernel_type"}
+    )


### PR DESCRIPTION
Earlier: 
While populating the python names, the special characters were converted to '_'.

Now:
Only skip '..' pattern.