### PR TITLE
fix: fix minor issues in settings and fluent version.

### DIFF
--- a/src/ansys/fluent/core/launcher/error_handler.py
+++ b/src/ansys/fluent/core/launcher/error_handler.py
@@ -54,7 +54,7 @@ def _raise_non_gui_exception_in_windows(
         and product_version < FluentVersion.v241
     ):
         raise InvalidArgument(
-            f"'{ui_mode}' supported in Windows only for Fluent version 24.1 or later."
+            f"'{ui_mode}' supported in Windows only for {str(FluentVersion.v241)} or later."
         )
 
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -49,6 +49,7 @@ import warnings
 import weakref
 from zipimport import zipimporter
 
+from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.warnings import PyFluentDeprecationWarning, PyFluentUserWarning
 
 from .flunits import UnhandledQuantity, get_si_unit_for_fluent_quantity
@@ -291,7 +292,10 @@ class Base:
         Constructed in python syntax from 'python_path' and the parents python path.
         """
         if self._parent is None:
-            return "<session>"
+            if FluentVersion(self.flproxy._scheme_eval.version).number < 251:
+                return "<session>"
+            else:
+                return "<session>.settings"
         ppath = self._parent.python_path
         if not ppath:
             return self.python_name
@@ -723,7 +727,7 @@ class SettingsBase(Base, Generic[StateT]):
                 self.value.set_state(state, **kwargs)
             else:
                 state = self._unalias(kwargs or state)
-                return self.flproxy.set_var(self.path, self.to_scheme_keys(state))
+                self.flproxy.set_var(self.path, self.to_scheme_keys(state))
 
     @staticmethod
     def _print_state_helper(state, out, indent=0, indent_factor=2):

--- a/src/ansys/fluent/core/systemcoupling.py
+++ b/src/ansys/fluent/core/systemcoupling.py
@@ -51,7 +51,7 @@ class SystemCoupling:
         # version check - this requires Fluent 2024 R1 or newer.
         if self._solver.get_fluent_version() < FluentVersion.v241:
             raise RuntimeError(
-                f"Fluent version is {self._solver.get_fluent_version().value}. PySystemCoupling integration requires Fluent {FluentVersion.v241.value} or later."
+                f"Using {str(self._solver.get_fluent_version())}. PySystemCoupling integration requires {str(FluentVersion.v241)} or later."
             )
 
     @property

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -128,3 +128,9 @@ class FluentVersion(Enum):
     def __repr__(self) -> str:
         """Return a string representation for the Fluent version."""
         return self.value
+
+    def __str__(self) -> str:
+        """String output for the Fluent version."""
+        return (
+            f"Fluent version 20{self.value.split('.')[0]} R{self.value.split('.')[1]}"
+        )

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -356,6 +356,10 @@ class Root(Group):
     }
 
 
+class _SchemeEval:
+    version = "25.1.0"
+
+
 class Proxy:
     """Proxy class."""
 
@@ -363,6 +367,7 @@ class Proxy:
 
     def __init__(self):
         self.r = self.root(None)
+        self._scheme_eval = _SchemeEval()
 
     def get_obj(self, path):
         if not path:

--- a/tests/test_fluent_version.py
+++ b/tests/test_fluent_version.py
@@ -59,3 +59,8 @@ def test_ne():
 def test_eq():
     assert FluentVersion.v232 == FluentVersion.v232
     assert FluentVersion.v241 == FluentVersion.v241
+
+
+def test_str_output():
+    assert str(FluentVersion.v232) == "Fluent version 2023 R2"
+    assert str(FluentVersion.v251) == "Fluent version 2025 R1"


### PR DESCRIPTION
1. '<session>.setup.models' should be '<session>.settings.setup.models' from versions 25.1 and above.
2. solver.settings.setup.models.viscous.model.set_state("k-epsilon"), etc. were returning some values in PyConsole. This has been rectified.
3. FluentVersion enum's string representation has been updated as follows:
          >>> str(FluentVersion.v241) -> 'Fluent version 2024 R1'

