### PR TITLE
fix: Remove exit from settings.

### DIFF
--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -234,7 +234,8 @@ class Solver(BaseSession):
                 file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.scheme_eval.scheme_eval,
             )
-            del self._settings_root.exit
+            if hasattr(self._settings_root, "exit"):
+                del self._settings_root.exit
         return self._settings_root
 
     @property

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -234,6 +234,7 @@ class Solver(BaseSession):
                 file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.scheme_eval.scheme_eval,
             )
+            del self._settings_root.exit
         return self._settings_root
 
     @property

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -234,8 +234,6 @@ class Solver(BaseSession):
                 file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.scheme_eval.scheme_eval,
             )
-            if hasattr(self._settings_root, "exit"):
-                del self._settings_root.exit
         return self._settings_root
 
     @property

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2080,6 +2080,8 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             _process_cls_names(children, cls.child_names)
 
         commands = info.get("commands")
+        if commands:
+            commands.pop("exit", None)
         if commands and not user_creatable:
             commands.pop("create", None)
         if commands:

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -440,9 +440,9 @@ def test_generated_code_special_cases(new_solver_session):
 @pytest.mark.fluent_version(">=25.1")
 def test_child_alias_with_parent_path(mixing_elbow_settings_session):
     solver = mixing_elbow_settings_session
-    solver.solution.initialization.hybrid_initialize()
+    solver.settings.solution.initialization.hybrid_initialize()
     assert (
-        solver.setup.models.discrete_phase.numerics.node_based_averaging.kernel._child_aliases
+        solver.settings.setup.models.discrete_phase.numerics.node_based_averaging.kernel._child_aliases
         == {"gaussian_factor": "../gaussian_factor", "option": "../kernel_type"}
     )
     solver.settings.setup.models.discrete_phase.numerics.node_based_averaging.enabled = (
@@ -470,3 +470,13 @@ def test_child_alias_with_parent_path(mixing_elbow_settings_session):
         solver.settings.setup.models.discrete_phase.numerics.node_based_averaging.gaussian_factor()
         == 0.6
     )
+
+
+@pytest.mark.fluent_version(">=25.1")
+def test_exit_not_in_settings(new_solver_session):
+    solver = new_solver_session
+
+    assert "exit" not in dir(solver.settings)
+
+    with pytest.raises(AttributeError):
+        solver.settings.exit()


### PR DESCRIPTION
Remove 'exit' from solver.settings in PyFluent exposure since we have a well documented way of exiting in PyFluent: solver.exit(). It solves a bug arising from solver.settings.exit() as well.

Earlier:

>>> solver.settings.exit()

Now:

"exit" not present in dir(solver.settings) and using it raises an attribute error.