### PR TITLE
test: Add test for _combine_set_states

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -665,10 +665,15 @@ def _combine_set_states(states: List[Tuple[str, StateT]]) -> Tuple[str, StateT]:
     for path, state in states:
         comps = path.split("/")
         comps = comps[len(common_path) :]
-        obj = combined_state
-        for comp in comps[:-1]:
-            obj = obj.setdefault(comp, {})
-        obj[comps[-1]] = state
+        if comps:
+            if not isinstance(combined_state, dict):
+                combined_state = {}
+            obj = combined_state
+            for comp in comps[:-1]:
+                obj = obj.setdefault(comp, {})
+            obj[comps[-1]] = state
+        else:
+            combined_state = state
     return "/".join(common_path), combined_state
 
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -11,6 +11,7 @@ from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.solver.flobject import (
     InactiveObjectError,
+    _combine_set_states,
     _gethash,
     find_children,
 )
@@ -1238,3 +1239,39 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
     # The following is the default behavior when no arguments are associated with the command.
     assert solver.results.graphics.contour.list.argument_names == []
+
+
+def test_combine_set_states():
+    assert _combine_set_states(
+        [
+            ("A/B/C", 1),
+        ]
+    ) == ("A/B/C", 1)
+
+    assert _combine_set_states(
+        [
+            ("A/B/C", 1),
+            ("A/B/C", 2),
+        ]
+    ) == ("A/B/C", 2)
+
+    assert _combine_set_states(
+        [
+            ("A/B/C", 1),
+            ("A/B/C", {"X": 2}),
+        ]
+    ) == ("A/B/C", {"X": 2})
+
+    assert _combine_set_states(
+        [
+            ("A/B/C", 1),
+            ("A/B/D", 2),
+        ]
+    ) == ("A/B", {"C": 1, "D": 2})
+
+    assert _combine_set_states(
+        [
+            ("A/B/C", {"X": 1}),
+            ("A/B/D/E", 2),
+        ]
+    ) == ("A/B", {"C": {"X": 1}, "D": {"E": 2}})


### PR DESCRIPTION
Support some edge cases - those won't affect 25.1 settings API aliasing behaviour.