### PR TITLE
refactor: Access named objects via internal names in datamodel_se

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1480,6 +1480,23 @@ class PyNamedObjectContainer:
             )
         return child_object_display_names
 
+    def _get_id_name(self):
+        child_object_id_name_list = []
+        obj_type = self.path[-1][0]
+        for name in self._get_child_object_names():
+            child_object_id_name_list.append(obj_type + ":" + name)
+        return child_object_id_name_list
+
+    def _check_via_internal_names(self, name) -> str:
+        if name in self._get_id_name() or name in self._get_child_object_names():
+            _name = name.split(":")[-1] if ":" in name else name
+            name_path = self.path[0:-1]
+            name_path.append((self.path[-1][0], _name))
+            name_path.append(("_name_", ""))
+            return PyMenu(self.service, self.rules, name_path).get_state()
+        else:
+            return name
+
     def get_object_names(self) -> Any:
         """Displays the name of objects within a container."""
         return self.service.get_object_names(
@@ -1514,6 +1531,7 @@ class PyNamedObjectContainer:
             )
 
     def _get_item(self, key: str) -> PyMenu:
+        key = self._check_via_internal_names(key)
         if key in self._get_child_object_display_names():
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
@@ -1526,6 +1544,7 @@ class PyNamedObjectContainer:
             )
 
     def _del_item(self, key: str) -> None:
+        key = self._check_via_internal_names(key)
         if key in self._get_child_object_display_names():
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
@@ -2195,6 +2214,7 @@ class PyNamedObjectContainerGeneric(PyNamedObjectContainer):
             yield PyMenuGeneric(self.service, self.rules, child_path)
 
     def _get_item(self, key: str) -> PyMenuGeneric:
+        key = self._check_via_internal_names(key)
         if key in self._get_child_object_display_names():
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1480,23 +1480,6 @@ class PyNamedObjectContainer:
             )
         return child_object_display_names
 
-    def _get_id_name(self):
-        child_object_id_name_list = []
-        obj_type = self.path[-1][0]
-        for name in self._get_child_object_names():
-            child_object_id_name_list.append(obj_type + ":" + name)
-        return child_object_id_name_list
-
-    def _check_via_internal_names(self, name) -> str:
-        if name in self._get_id_name() or name in self._get_child_object_names():
-            _name = name.split(":")[-1] if ":" in name else name
-            name_path = self.path[0:-1]
-            name_path.append((self.path[-1][0], _name))
-            name_path.append(("_name_", ""))
-            return PyMenu(self.service, self.rules, name_path).get_state()
-        else:
-            return name
-
     def get_object_names(self) -> Any:
         """Displays the name of objects within a container."""
         return self.service.get_object_names(
@@ -1531,8 +1514,11 @@ class PyNamedObjectContainer:
             )
 
     def _get_item(self, key: str) -> PyMenu:
-        key = self._check_via_internal_names(key)
-        if key in self._get_child_object_display_names():
+        key = key.split(":")[-1]
+        if (
+            key in self._get_child_object_display_names()
+            or key in self._get_child_object_names()
+        ):
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
             return getattr(self.__class__, f"_{self.__class__.__name__}")(
@@ -1544,8 +1530,11 @@ class PyNamedObjectContainer:
             )
 
     def _del_item(self, key: str) -> None:
-        key = self._check_via_internal_names(key)
-        if key in self._get_child_object_display_names():
+        key = key.split(":")[-1]
+        if (
+            key in self._get_child_object_display_names()
+            or key in self._get_child_object_names()
+        ):
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
             se_path = convert_path_to_se_path(child_path)
@@ -2214,8 +2203,11 @@ class PyNamedObjectContainerGeneric(PyNamedObjectContainer):
             yield PyMenuGeneric(self.service, self.rules, child_path)
 
     def _get_item(self, key: str) -> PyMenuGeneric:
-        key = self._check_via_internal_names(key)
-        if key in self._get_child_object_display_names():
+        key = key.split(":")[-1]
+        if (
+            key in self._get_child_object_display_names()
+            or key in self._get_child_object_names()
+        ):
             child_path = self.path[:-1]
             child_path.append((self.path[-1][0], key))
             return PyMenuGeneric(self.service, self.rules, child_path)

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -429,7 +429,11 @@ def test_setting_none_type_tasks(new_meshing_session):
 @pytest.mark.fluent_version(">=23.2")
 def test_named_object_access(new_meshing_session):
     meshing = new_meshing_session
-    meshing.workflow.InitializeWorkflow(WorkflowType=r"Watertight Geometry")
-    assert meshing.workflow.TaskObject["Import Geometry"]
+    meshing.workflow.InitializeWorkflow(WorkflowType=r"Fault-tolerant Meshing")
+    assert meshing.workflow.TaskObject["Import CAD and Part Management"]
     assert meshing.workflow.TaskObject["TaskObject1"]
     assert meshing.workflow.TaskObject["TaskObject:TaskObject1"]
+
+    assert meshing.PartManagement.Node["Meshing Model"]
+    assert meshing.PartManagement.Node["Node1"]
+    assert meshing.PartManagement.Node["Node:Node1"]

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -424,3 +424,12 @@ def test_setting_none_type_tasks(new_meshing_session):
         meshing.workflow.TaskObject["Describe Overset Features"].CommandName()
         == "DescribeOversetFeatures"
     )
+
+
+@pytest.mark.fluent_version(">=23.2")
+def test_named_object_access(new_meshing_session):
+    meshing = new_meshing_session
+    meshing.workflow.InitializeWorkflow(WorkflowType=r"Watertight Geometry")
+    assert meshing.workflow.TaskObject["Import Geometry"]
+    assert meshing.workflow.TaskObject["TaskObject1"]
+    assert meshing.workflow.TaskObject["TaskObject:TaskObject1"]


### PR DESCRIPTION
Earlier, only access via display names was allowed:
```Python
>>> assert meshing.workflow.TaskObject["Import Geometry"]
```
Now, internal names are supported as well:

```Python
>>> assert meshing.workflow.TaskObject["TaskObject1"]
>>> assert meshing.workflow.TaskObject["TaskObject:TaskObject1"]
```