### PR TITLE
refactor: Remove refreshing of task_accessors.

### DIFF
--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -458,7 +458,6 @@ class BaseTask:
     def delete(self) -> None:
         """Delete this task from the workflow."""
         self._command_source.delete_tasks(list_of_tasks=[self.python_name()])
-        _call_refresh_task_accessors(self._command_source)
 
     def rename(self, new_name: str):
         """Rename the current task to a given name."""
@@ -1634,7 +1633,11 @@ class Workflow:
                     "Use the 'task_names()' method to view a list of allowed tasks."
                 ) from ex
 
-        return self._workflow.DeleteTasks(ListOfTasks=list_of_tasks_with_display_name)
+        ret_val = self._workflow.DeleteTasks(
+            ListOfTasks=list_of_tasks_with_display_name
+        )
+        _call_refresh_task_accessors(self)
+        return ret_val
 
 
 class ClassicWorkflow:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1583,22 +1583,6 @@ class Workflow:
 
     def _initialize_methods(self, dynamic_interface: bool):
         _init_task_accessors(self)
-        if dynamic_interface:
-            self._main_thread_ident = threading.get_ident()
-            logger.debug(f"setting main thread to {self._main_thread_ident}")
-
-            def refresh_after_sleep(_):
-                while self._refreshing:
-                    logger.debug("Already _refreshing, ...")
-                self._refreshing = True
-                logger.debug("Call _refresh_task_accessors")
-                _call_refresh_task_accessors(self)
-                self._refresh_count += 1
-                self._refreshing = False
-
-            self._root_affected_cb_by_server[self._workflow.service] = (
-                self.add_on_affected(refresh_after_sleep)
-            )
 
     def save_workflow(self, file_path: str):
         """Save the current workflow to the location provided."""

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -458,6 +458,7 @@ class BaseTask:
     def delete(self) -> None:
         """Delete this task from the workflow."""
         self._command_source.delete_tasks(list_of_tasks=[self.python_name()])
+        _call_refresh_task_accessors(self._command_source)
 
     def rename(self, new_name: str):
         """Rename the current task to a given name."""
@@ -488,7 +489,9 @@ class BaseTask:
             new_name
         )
         self._python_name = new_name
-        return self._task.Rename(NewName=new_name)
+        ret_val = self._task.Rename(NewName=new_name)
+        _call_refresh_task_accessors(self._command_source)
+        return ret_val
 
     def add_child_to_task(self):
         """Add a child task."""
@@ -1210,6 +1213,7 @@ class CompoundTask(CommandTask):
                 self._task.AddChildAndUpdate()
         finally:
             self._command_source._compound_child = False
+        _call_refresh_task_accessors(self._command_source)
         return self.last_child()
 
     def last_child(self) -> BaseTask:


### PR DESCRIPTION
https://github.com/ansys/pyfluent/pull/3041#discussion_r1765348183


As per this comment we have now removed the task-list refreshing based on add-on-affected. Some manual refreshing from the client side has been done instead on functions which can update the tasks, like -"delete", "rename" and "add_child_and_update".
