### PR TITLE
fix: Avoid flproxy._scheme_eval in pyfluent code

### DIFF
--- a/src/ansys/fluent/core/codegen/settingsgen.py
+++ b/src/ansys/fluent/core/codegen/settingsgen.py
@@ -357,9 +357,11 @@ def _populate_classes(parent_dir):
                 doc = f"'child_object_type' of {parent_name}."
 
             _write_doc_string(doc, istr1, f)
-            f.write(f'{istr1}fluent_name = "{cls.fluent_name}"\n\n')
+            f.write(f'{istr1}fluent_name = "{cls.fluent_name}"\n')
+            f.write(f'{istr1}version = "{cls.version}"\n\n')
             if stub_f:
                 stub_f.write(f"{istr1}fluent_name = ...\n")
+                stub_f.write(f"{istr1}version = ...\n\n")
 
             child_class_strings = []
 

--- a/src/ansys/fluent/core/data_model_cache.py
+++ b/src/ansys/fluent/core/data_model_cache.py
@@ -112,9 +112,12 @@ def _is_dict_parameter_type(version: FluentVersion, rules: str, rules_path: str)
     )
     from ansys.fluent.core.utils import load_module
 
-    module = load_module(
-        rules, CODEGEN_OUTDIR / f"datamodel_{version.number}" / f"{rules}.py"
-    )
+    try:
+        module = load_module(
+            rules, CODEGEN_OUTDIR / f"datamodel_{version.number}" / f"{rules}.py"
+        )
+    except FileNotFoundError:  # no codegen or during codegen
+        return False
     cls = module.Root
     comps = rules_path.split("/")
     for i, comp in enumerate(comps):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1119,7 +1119,7 @@ class Group(SettingsBase[DictStateType]):
             modified_search_results = []
             if use_search(
                 codegen_outdir=pyfluent.CODEGEN_OUTDIR,
-                version=self.version,
+                version=super().__getattribute__("version"),
             ):
                 search_results = pyfluent.utils._search(
                     word=name,

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -291,7 +291,7 @@ class Base:
         Constructed in python syntax from 'python_path' and the parents python path.
         """
         if self._parent is None:
-            if FluentVersion(self.flproxy._scheme_eval.version).number < 251:
+            if FluentVersion(self.version).number < 251:
                 return "<session>"
             else:
                 return "<session>.settings"
@@ -1119,7 +1119,7 @@ class Group(SettingsBase[DictStateType]):
             modified_search_results = []
             if use_search(
                 codegen_outdir=pyfluent.CODEGEN_OUTDIR,
-                version=self.flproxy._scheme_eval.version,
+                version=self.version,
             ):
                 search_results = pyfluent.utils._search(
                     word=name,
@@ -1982,7 +1982,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
                 f"Falling back to String."
             )
             base = String
-        dct = {"fluent_name": name}
+        dct = {"fluent_name": name, "version": version}
         helpinfo = info.get("help")
         if helpinfo:
             dct["__doc__"] = _clean_helpinfo(helpinfo)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -470,6 +470,7 @@ class root(Group):
     """
 
     fluent_name = ""
+    version = "251"
 
     child_names = \\
         ['G1', 'P1', 'N1']
@@ -511,7 +512,8 @@ class A1(String):
     A1 help.
     """
 
-    fluent_name = "A1"'''
+    fluent_name = "A1"
+    version = "251"'''
 
 
 _expected_C1_settings_api_output = '''#
@@ -544,6 +546,7 @@ class C1(Command):
     """
 
     fluent_name = "C1"
+    version = "251"
 
     argument_names = \\
         ['A1']
@@ -580,6 +583,7 @@ class G1(Group):
     """
 
     fluent_name = "G1"
+    version = "251"
 
     child_names = \\
         ['G2', 'P2']
@@ -624,6 +628,7 @@ class N1(NamedObject[N1_child], _NonCreatableNamedObjectMixin[N1_child]):
     """
 
     fluent_name = "N1"
+    version = "251"
 
     child_names = \\
         ['P4']
@@ -660,7 +665,8 @@ class N1_child(Group):
     'child_object_type' of N1.
     """
 
-    fluent_name = "child-object-type"'''
+    fluent_name = "child-object-type"
+    version = "251"'''
 
 
 _expected_P1_settings_api_output = '''#
@@ -685,7 +691,8 @@ class P1(String):
     P1 help.
     """
 
-    fluent_name = "P1"'''
+    fluent_name = "P1"
+    version = "251"'''
 
 
 _expected_Q1_settings_api_output = '''#
@@ -718,6 +725,7 @@ class Q1(Query):
     """
 
     fluent_name = "Q1"
+    version = "251"
 
     argument_names = \\
         ['A1']

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -515,7 +515,7 @@ def test_command():
 
 
 def test_attrs():
-    r = flobject.get_root(Proxy())
+    r = flobject.get_root(Proxy(), version="251")
     assert r.g_1.s_4.get_attr("active?")
     assert r.g_1.s_4.get_attr("allowed-values") == ["foo", "bar"]
     r.g_1.b_3 = True


### PR DESCRIPTION
`flproxy._scheme_eval` was not available in PyConsole (it has been made temporarily available which will be removed). I have added a static `version` attribute to the generated classes.