### PR TITLE
feat: Remove PyFluentUserWarning on example download

### DIFF
--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -5,13 +5,11 @@ import os
 from pathlib import Path
 import re
 import shutil
-import warnings
 import zipfile
 
 import requests
 
 import ansys.fluent.core as pyfluent
-from ansys.fluent.core.warnings import PyFluentUserWarning
 
 logger = logging.getLogger("pyfluent.networking")
 
@@ -74,10 +72,6 @@ def _retrieve_file(
     # First check if file has already been downloaded
     logger.info(f"Checking if {local_path_no_zip} already exists...")
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
-        warnings.warn(
-            f"\nFile already exists. File path:\n{local_path_no_zip}\n",
-            PyFluentUserWarning,
-        )
         logger.info("File already exists.")
         if return_without_path:
             return file_name_no_zip


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3110

Remove `PyFluentUserWarning` on example download.

```
>>> from ansys.fluent.core import examples
>>> import_case = examples.download_file(file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system")
>>> import_case = examples.download_file(file_name="exhaust_system.cas.h5", directory="pyfluent/exhaust_system")
>>>
```

![image](https://github.com/user-attachments/assets/cf46ee60-b53a-4a67-922f-cdccad9deaf0)
