### PR TITLE
feat: Implement IterationEndedSyncEvent and TimestepEndedSyncEvent

### DIFF
--- a/src/ansys/fluent/core/streaming_services/events_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/events_streaming.py
@@ -4,7 +4,7 @@ from enum import Enum
 from functools import partial
 import inspect
 import logging
-from typing import Callable, Generic, Type, TypeVar
+from typing import Callable, Generic, Literal, Type, TypeVar
 import warnings
 
 from ansys.api.fluent.v0 import events_pb2 as EventsProtoModule
@@ -27,8 +27,10 @@ class SolverEvent(Enum):
 
     TIMESTEP_STARTED = "TimestepStartedEvent"
     TIMESTEP_ENDED = "TimestepEndedEvent"
+    TIMESTEP_ENDED_SYNC = "TimestepEndedSyncEvent"
     ITERATION_STARTED = "IterationStartedEvent"
     ITERATION_ENDED = "IterationEndedEvent"
+    ITERATION_ENDED_SYNC = "IterationEndedSyncEvent"
     CALCULATIONS_STARTED = "CalculationsStartedEvent"
     CALCULATIONS_ENDED = "CalculationsEndedEvent"
     CALCULATIONS_PAUSED = "CalculationsPausedEvent"
@@ -99,6 +101,7 @@ class EventsManager(Generic[TEvent]):
         # This has been updated from id to session, which
         # can also be done in other streaming services
         self._session = session
+        self._sync_event_ids = {}
 
     def _process_streaming(
         self, service, id, stream_begin_method, started_evt, *args, **kwargs
@@ -194,16 +197,26 @@ class EventsManager(Generic[TEvent]):
         event_name = self._event_type(event_name)
         with self._impl._lock:
             callback_id = f"{event_name}-{next(self._impl._service_callback_id)}"
-            callbacks_map = self._impl._service_callbacks.get(event_name)
             callback_to_call = EventsManager._make_callback_to_call(
                 callback, args, kwargs
             )
+            if event_name in [
+                SolverEvent.ITERATION_ENDED_SYNC,
+                SolverEvent.TIMESTEP_ENDED_SYNC,
+            ]:
+                event_name, callback_to_call = (
+                    self._register_solution_event_sync_callback(
+                        event_name, callback_id, callback_to_call
+                    )
+                )
+            callbacks_map = self._impl._service_callbacks.get(event_name)
             if callbacks_map:
                 callbacks_map.update({callback_id: callback_to_call})
             else:
                 self._impl._service_callbacks[event_name] = {
                     callback_id: callback_to_call
                 }
+            return callback_id
 
     def unregister_callback(self, callback_id: str):
         """Unregister the callback.
@@ -217,6 +230,11 @@ class EventsManager(Generic[TEvent]):
             for callbacks_map in self._impl._service_callbacks.values():
                 if callback_id in callbacks_map:
                     del callbacks_map[callback_id]
+            sync_event_id = self._sync_event_ids.pop(callback_id, None)
+            if sync_event_id:
+                self._session.scheme_eval.scheme_eval(
+                    f"(cancel-solution-monitor 'pyfluent-{sync_event_id})"
+                )
 
     def start(self, *args, **kwargs) -> None:
         """Start streaming."""
@@ -225,3 +243,57 @@ class EventsManager(Generic[TEvent]):
     def stop(self) -> None:
         """Stop streaming."""
         self._impl.stop()
+
+    def _register_solution_event_sync_callback(
+        self,
+        event_type: Literal[
+            SolverEvent.ITERATION_ENDED_SYNC, SolverEvent.TIMESTEP_ENDED_SYNC
+        ],
+        callback_id: str,
+        callback: Callable,
+    ) -> tuple[Literal[SolverEvent.SOLUTION_PAUSED], Callable]:
+        unique_id = self._session.scheme_eval.scheme_eval(
+            f"""
+            (let
+                ((ids
+                    (let loop ((i 1))
+                        (define next-id (string->symbol (format #f "pyfluent-~d" i)))
+                        (if (check-monitor-existence next-id)
+                            (loop (1+ i))
+                            (list i next-id)
+                            )
+                        )
+                    ))
+                (register-solution-monitor
+                    (cadr ids)
+                    (lambda (niter time)
+                        (if (integer? niter)
+                            (begin
+                                (events/transmit 'auto-pause (cons (car ids) niter))
+                                (grpcserver/auto-pause (is-server-running?) (cadr ids))
+                                )
+                            )
+                        ()
+                        )
+                    {'#t' if event_type == SolverEvent.TIMESTEP_ENDED_SYNC else '#f'}
+                    )
+                (car ids)
+                )
+        """
+        )
+
+        def on_pause(session, event_info: EventsProtoModule.AutoPauseEvent):
+            if unique_id == event_info.level:
+                event_info_cls = (
+                    EventsProtoModule.TimestepEndedEvent
+                    if event_type == SolverEvent.TIMESTEP_ENDED_SYNC
+                    else EventsProtoModule.IterationEndedEvent
+                )
+                event_info = event_info_cls(index=event_info.index)
+                callback(session, event_info)
+                session.scheme_eval.scheme_eval(
+                    f"(grpcserver/auto-resume (is-server-running?) 'pyfluent-{unique_id})"
+                )
+
+        self._sync_event_ids[callback_id] = unique_id
+        return SolverEvent.SOLUTION_PAUSED, on_pause

--- a/src/ansys/fluent/core/streaming_services/events_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/events_streaming.py
@@ -290,10 +290,17 @@ class EventsManager(Generic[TEvent]):
                     else EventsProtoModule.IterationEndedEvent
                 )
                 event_info = event_info_cls(index=event_info.index)
-                callback(session, event_info)
-                session.scheme_eval.scheme_eval(
-                    f"(grpcserver/auto-resume (is-server-running?) 'pyfluent-{unique_id})"
-                )
+                try:
+                    callback(session, event_info)
+                except Exception as e:
+                    network_logger.error(
+                        f"Error in callback for event {event_type}: {e}",
+                        exc_info=True,
+                    )
+                finally:
+                    session.scheme_eval.scheme_eval(
+                        f"(grpcserver/auto-resume (is-server-running?) 'pyfluent-{unique_id})"
+                    )
 
         self._sync_event_ids[callback_id] = unique_id
         return SolverEvent.SOLUTION_PAUSED, on_pause

--- a/src/ansys/fluent/core/streaming_services/events_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/events_streaming.py
@@ -27,10 +27,8 @@ class SolverEvent(Enum):
 
     TIMESTEP_STARTED = "TimestepStartedEvent"
     TIMESTEP_ENDED = "TimestepEndedEvent"
-    TIMESTEP_ENDED_SYNC = "TimestepEndedSyncEvent"
     ITERATION_STARTED = "IterationStartedEvent"
     ITERATION_ENDED = "IterationEndedEvent"
-    ITERATION_ENDED_SYNC = "IterationEndedSyncEvent"
     CALCULATIONS_STARTED = "CalculationsStartedEvent"
     CALCULATIONS_ENDED = "CalculationsEndedEvent"
     CALCULATIONS_PAUSED = "CalculationsPausedEvent"
@@ -201,8 +199,8 @@ class EventsManager(Generic[TEvent]):
                 callback, args, kwargs
             )
             if event_name in [
-                SolverEvent.ITERATION_ENDED_SYNC,
-                SolverEvent.TIMESTEP_ENDED_SYNC,
+                SolverEvent.ITERATION_ENDED,
+                SolverEvent.TIMESTEP_ENDED,
             ]:
                 event_name, callback_to_call = (
                     self._register_solution_event_sync_callback(
@@ -246,9 +244,7 @@ class EventsManager(Generic[TEvent]):
 
     def _register_solution_event_sync_callback(
         self,
-        event_type: Literal[
-            SolverEvent.ITERATION_ENDED_SYNC, SolverEvent.TIMESTEP_ENDED_SYNC
-        ],
+        event_type: Literal[SolverEvent.ITERATION_ENDED, SolverEvent.TIMESTEP_ENDED],
         callback_id: str,
         callback: Callable,
     ) -> tuple[Literal[SolverEvent.SOLUTION_PAUSED], Callable]:
@@ -275,7 +271,7 @@ class EventsManager(Generic[TEvent]):
                             )
                         ()
                         )
-                    {'#t' if event_type == SolverEvent.TIMESTEP_ENDED_SYNC else '#f'}
+                    {'#t' if event_type == SolverEvent.TIMESTEP_ENDED else '#f'}
                     )
                 (car ids)
                 )
@@ -286,7 +282,7 @@ class EventsManager(Generic[TEvent]):
             if unique_id == event_info.level:
                 event_info_cls = (
                     EventsProtoModule.TimestepEndedEvent
-                    if event_type == SolverEvent.TIMESTEP_ENDED_SYNC
+                    if event_type == SolverEvent.TIMESTEP_ENDED
                     else EventsProtoModule.IterationEndedEvent
                 )
                 event_info = event_info_cls(index=event_info.index)

--- a/tests/test_events_manager.py
+++ b/tests/test_events_manager.py
@@ -96,9 +96,7 @@ def test_iteration_ended_sync_event(static_mixer_case_session):
         nonlocal count
         count += 1
 
-    cb_id = solver.events.register_callback(
-        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, cb
-    )
+    cb_id = solver.events.register_callback(pyfluent.SolverEvent.ITERATION_ENDED, cb)
     solver.settings.solution.run_calculation.iterate(iter_count=10)
     assert count == 10
     solver.events.unregister_callback(cb_id)
@@ -130,12 +128,8 @@ def test_iteration_ended_sync_event_multiple_connections(static_mixer_case_sessi
             nonlocal solver2_count
             solver2_count += 1
 
-    solver1.events.register_callback(
-        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, solver1_cb
-    )
-    solver2.events.register_callback(
-        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, solver2_cb
-    )
+    solver1.events.register_callback(pyfluent.SolverEvent.ITERATION_ENDED, solver1_cb)
+    solver2.events.register_callback(pyfluent.SolverEvent.ITERATION_ENDED, solver2_cb)
     solver2.settings.solution.run_calculation.iterate(iter_count=5)
     assert solver1_count == 2
     assert solver2_count == 3
@@ -153,9 +147,7 @@ def test_timestep_ended_sync_event(static_mixer_case_session):
         nonlocal count
         count += 1
 
-    cb_id = solver.events.register_callback(
-        pyfluent.SolverEvent.TIMESTEP_ENDED_SYNC, cb
-    )
+    cb_id = solver.events.register_callback(pyfluent.SolverEvent.TIMESTEP_ENDED, cb)
     solver.settings.solution.run_calculation.dual_time_iterate(
         time_step_count=10, max_iter_per_step=2
     )
@@ -175,9 +167,7 @@ def test_sync_event_exception_in_callback(static_mixer_case_session, caplog):
     def cb(session, event_info):
         raise RuntimeError
 
-    cb_id = solver.events.register_callback(
-        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, cb
-    )
+    cb_id = solver.events.register_callback(pyfluent.SolverEvent.ITERATION_ENDED, cb)
     with caplog.at_level("ERROR", logger="pyfluent.networking"):
         solver.settings.solution.run_calculation.iterate(iter_count=10)
     assert (

--- a/tests/test_events_manager.py
+++ b/tests/test_events_manager.py
@@ -180,11 +180,27 @@ def test_sync_event_exception_in_callback(static_mixer_case_session, caplog):
     )
     with caplog.at_level("ERROR", logger="pyfluent.networking"):
         solver.settings.solution.run_calculation.iterate(iter_count=10)
-    assert len(caplog.records) == 10
-    for record in caplog.records:
-        assert "Error in callback" in record.message
+    assert (
+        len(
+            [
+                record
+                for record in caplog.records
+                if "Error in callback" in record.message
+            ]
+        )
+        == 10
+    )
     caplog.clear()
     solver.events.unregister_callback(cb_id)
     with caplog.at_level("ERROR", logger="pyfluent.networking"):
         solver.settings.solution.run_calculation.iterate(iter_count=5)
-    assert len(caplog.records) == 0
+    assert (
+        len(
+            [
+                record
+                for record in caplog.records
+                if "Error in callback" in record.message
+            ]
+        )
+        == 0
+    )

--- a/tests/test_events_manager.py
+++ b/tests/test_events_manager.py
@@ -1,3 +1,5 @@
+import pytest
+
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import MeshingEvent, SolverEvent, examples
 
@@ -81,6 +83,7 @@ def test_receive_meshing_events_on_case_loaded(new_meshing_session) -> None:
     # assert on_case_loaded.loaded
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_iteration_ended_sync_event(static_mixer_case_session):
     solver = static_mixer_case_session
     solver.settings.solution.initialization.hybrid_initialize()
@@ -103,6 +106,7 @@ def test_iteration_ended_sync_event(static_mixer_case_session):
     assert count == 10
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_iteration_ended_sync_event_multiple_connections(static_mixer_case_session):
     solver1 = static_mixer_case_session
     solver2 = pyfluent.connect_to_fluent(
@@ -137,6 +141,7 @@ def test_iteration_ended_sync_event_multiple_connections(static_mixer_case_sessi
     assert solver2_count == 3
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_timestep_ended_sync_event(static_mixer_case_session):
     solver = static_mixer_case_session
     solver.settings.setup.general.solver.time = "unsteady-2nd-order"
@@ -162,6 +167,7 @@ def test_timestep_ended_sync_event(static_mixer_case_session):
     assert count == 10
 
 
+@pytest.mark.fluent_version(">=23.1")
 def test_sync_event_exception_in_callback(static_mixer_case_session, caplog):
     solver = static_mixer_case_session
     solver.settings.solution.initialization.hybrid_initialize()

--- a/tests/test_events_manager.py
+++ b/tests/test_events_manager.py
@@ -1,3 +1,4 @@
+import ansys.fluent.core as pyfluent
 from ansys.fluent.core import MeshingEvent, SolverEvent, examples
 
 
@@ -78,3 +79,84 @@ def test_receive_meshing_events_on_case_loaded(new_meshing_session) -> None:
 
     # this is not working in meshing mode
     # assert on_case_loaded.loaded
+
+
+def test_iteration_ended_sync_event(static_mixer_case_session):
+    solver = static_mixer_case_session
+    solver.settings.solution.initialization.hybrid_initialize()
+    count = 0
+
+    def cb(session, event_info):
+        assert event_info.index == session.scheme_eval.scheme_eval(
+            "(get-current-iteration)"
+        )
+        nonlocal count
+        count += 1
+
+    cb_id = solver.events.register_callback(
+        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, cb
+    )
+    solver.settings.solution.run_calculation.iterate(iter_count=10)
+    assert count == 10
+    solver.events.unregister_callback(cb_id)
+    solver.settings.solution.run_calculation.iterate(iter_count=5)
+    assert count == 10
+
+
+def test_iteration_ended_sync_event_multiple_connections(static_mixer_case_session):
+    solver1 = static_mixer_case_session
+    solver2 = pyfluent.connect_to_fluent(
+        ip=solver1.connection_properties.ip,
+        port=solver1.connection_properties.port,
+        password=solver1.connection_properties.password,
+    )
+    solver1.settings.solution.initialization.hybrid_initialize()
+    solver1_count = 0
+    solver2_count = 0
+
+    def solver1_cb(session, event_info):
+        assert session == solver1
+        if event_info.index % 2 == 0:
+            nonlocal solver1_count
+            solver1_count += 1
+
+    def solver2_cb(session, event_info):
+        assert session == solver2
+        if event_info.index % 2 == 1:
+            nonlocal solver2_count
+            solver2_count += 1
+
+    solver1.events.register_callback(
+        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, solver1_cb
+    )
+    solver2.events.register_callback(
+        pyfluent.SolverEvent.ITERATION_ENDED_SYNC, solver2_cb
+    )
+    solver2.settings.solution.run_calculation.iterate(iter_count=5)
+    assert solver1_count == 2
+    assert solver2_count == 3
+
+
+def test_timestep_ended_sync_event(static_mixer_case_session):
+    solver = static_mixer_case_session
+    solver.settings.setup.general.solver.time = "unsteady-2nd-order"
+    solver.settings.solution.initialization.hybrid_initialize()
+    count = 0
+
+    def cb(session, event_info):
+        assert event_info.index == solver.rp_vars("time-step")
+        nonlocal count
+        count += 1
+
+    cb_id = solver.events.register_callback(
+        pyfluent.SolverEvent.TIMESTEP_ENDED_SYNC, cb
+    )
+    solver.settings.solution.run_calculation.dual_time_iterate(
+        time_step_count=10, max_iter_per_step=2
+    )
+    assert count == 10
+    solver.events.unregister_callback(cb_id)
+    solver.settings.solution.run_calculation.dual_time_iterate(
+        time_step_count=5, max_iter_per_step=2
+    )
+    assert count == 10


### PR DESCRIPTION
Implemented sync events for IterationEnded and TimestepEnded to execute PyFluent-side callbacks synchronously. Fluent's solution monitoring mechanism has been used for the implementation. On every solution event, Fluent streams an auto-pause event and then goes to a paused state. Upon receiving the auto-pause event, the client executes the PyFluent-side callback and then remotely resumes Fluent.

Any exception thrown in the callback is converted to a logging error to ensure Fluent resumes at the end of callback execution. Those exceptions are raised in a secondary thread, the user's script cannot react in any way to those exceptions from the primary thread. There could still be some edge cases like calling `solver.exit()` within the callback which will indefinitely hang Fluent.