### PR TITLE
fix: Session was not garbage collected after settings access

### DIFF
--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -213,7 +213,8 @@ class Solver(BaseSession):
             )
         return self._workflow
 
-    def _interrupt(self, command):
+    @classmethod
+    def _interrupt(cls, command):
         interruptible_commands = [
             "solution/run-calculation/iterate",
             "solution/run-calculation/calculate",
@@ -221,7 +222,7 @@ class Solver(BaseSession):
         ]
         if pyfluent.SUPPORT_SOLVER_INTERRUPT:
             if command.path in interruptible_commands:
-                self.settings.solution.run_calculation.interrupt()
+                command._root.solution.run_calculation.interrupt()
 
     @property
     def settings(self):
@@ -230,7 +231,7 @@ class Solver(BaseSession):
             self._settings_root = flobject.get_root(
                 flproxy=self._settings_service,
                 version=self._version,
-                interrupt=self._interrupt,
+                interrupt=Solver._interrupt,
                 file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.scheme_eval.scheme_eval,
             )

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -199,11 +199,12 @@ class Base:
             self._setattr("_name", name)
         self._setattr("_child_alias_objs", {})
 
-    def _root(self, obj):
-        if obj._parent is None:
-            return obj
+    @property
+    def _root(self):
+        if self._parent is None:
+            return self
         else:
-            return self._root(obj._parent)
+            return self._parent._root
 
     def set_flproxy(self, flproxy):
         """Set flproxy object."""
@@ -1758,7 +1759,7 @@ class Command(BaseCommand):
         try:
             return self.execute_command(**kwds)
         except KeyboardInterrupt:
-            self._root(self)._on_interrupt(self)
+            self._root._on_interrupt(self)
             raise KeyboardInterrupt
 
 
@@ -1789,7 +1790,7 @@ class CommandWithPositionalArgs(BaseCommand):
         try:
             return self.execute_command(*args, **kwds)
         except KeyboardInterrupt:
-            self._root(self)._on_interrupt(self)
+            self._root._on_interrupt(self)
             raise KeyboardInterrupt
 
 

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -66,6 +66,7 @@ def test_session_starts_no_transcript_if_disabled(
 def test_server_exits_when_session_goes_out_of_scope() -> None:
     def f():
         session = pyfluent.launch_fluent()
+        session.settings
         _fluent_host_pid = session.connection_properties.fluent_host_pid
         _cortex_host = session.connection_properties.cortex_host
         _inside_container = session.connection_properties.inside_container
@@ -88,6 +89,7 @@ def test_server_exits_when_session_goes_out_of_scope() -> None:
 def test_server_does_not_exit_when_session_goes_out_of_scope() -> None:
     def f():
         session = pyfluent.launch_fluent(cleanup_on_exit=False)
+        session.settings
         _fluent_host_pid = session.connection_properties.fluent_host_pid
         _cortex_host = session.connection_properties.cortex_host
         _inside_container = session.connection_properties.inside_container


### PR DESCRIPTION
After settings access, solver session object was not getting garbage collected due to the cyclic reference: solver_session -> settings objects -> solver_session._interrupt.