### PR TITLE
fix: Hiding switch-to-meshing-mode command from tui and settings

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -330,13 +330,13 @@ class TUIMenu:
             for x in PyMenu(
                 self._service, self._version, self._mode, self._path
             ).get_child_names()
-            if x != "exit"
+            if x not in ["exit", "switch_to_meshing_mode"]
         ]
 
     def __getattribute__(self, name) -> Any:
-        if name == "exit" and not self._path:
+        if name in ["exit", "switch_to_meshing_mode"] and not self._path:
             raise AttributeError(
-                f"'{self.__class__.__name__}' object has no attribute 'exit'"
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
             )
         try:
             attr = super().__getattribute__(name)

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2089,7 +2089,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
         commands = info.get("commands")
         if commands:
             commands.pop("exit", None)
-            commands.pop("switch_to_meshing_mode", None)
+            commands.pop("switch-to-meshing-mode", None)
         if commands and not user_creatable:
             commands.pop("create", None)
         if commands:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2089,6 +2089,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
         commands = info.get("commands")
         if commands:
             commands.pop("exit", None)
+            commands.pop("switch_to_meshing_mode", None)
         if commands and not user_creatable:
             commands.pop("create", None)
         if commands:

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -512,10 +512,10 @@ def test_child_alias_with_parent_path(mixing_elbow_settings_session):
 
 
 @pytest.mark.fluent_version(">=25.1")
-def test_exit_not_in_settings(new_solver_session):
+def test_commands_not_in_settings(new_solver_session):
     solver = new_solver_session
 
-    assert "exit" not in dir(solver.settings)
-
-    with pytest.raises(AttributeError):
-        solver.settings.exit()
+    for command in ["exit", "switch_to_meshing_mode"]:
+        assert command not in dir(solver.settings)
+        with pytest.raises(AttributeError):
+            getattr(solver.settings, command)

--- a/tests/test_tui_api.py
+++ b/tests/test_tui_api.py
@@ -61,10 +61,10 @@ def test_exit_not_in_meshing_tui(new_meshing_session):
         meshing.tui.exit()
 
 
-def test_exit_not_in_solver_tui(new_solver_session):
+def test_commands_not_in_solver_tui(new_solver_session):
     solver = new_solver_session
 
-    assert "exit" not in dir(solver.tui)
-
-    with pytest.raises(AttributeError):
-        solver.tui.exit()
+    for command in ["exit", "switch_to_meshing_mode"]:
+        assert command not in dir(solver.tui)
+        with pytest.raises(AttributeError):
+            getattr(solver.tui, command)


### PR DESCRIPTION
ADO Fluent PR 530389
GitHub fluids-webui PR 398

Changes
- Hiding switch-to-meshing-mode command from solver.tui and solver.settings
- Adding tests to make sure this command does not appear in either location as we will most likely never want it in those locations, in my understanding