### PR TITLE
fix: Remove settings API hash comparison and runtime generation of settings API classes

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2207,42 +2207,28 @@ def get_root(
     """
     from ansys.fluent.core import CODEGEN_OUTDIR, CODEGEN_ZIP_SETTINGS, utils
 
-    obj_info = flproxy.get_static_info()
-    try:
-        if os.getenv("PYFLUENT_USE_OLD_SETTINGSGEN") != "1":
+    if os.getenv("PYFLUENT_USE_OLD_SETTINGSGEN") != "1":
+        settings = utils.load_module(
+            f"settings_{version}",
+            CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
+        )
+    else:
+        if CODEGEN_ZIP_SETTINGS:
+            importer = zipimporter(
+                str(CODEGEN_OUTDIR / "solver" / f"settings_{version}.zip")
+            )
+            settings = importer.load_module("settings")
+        else:
             settings = utils.load_module(
                 f"settings_{version}",
-                CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
+                CODEGEN_OUTDIR / "solver" / f"settings_{version}" / "__init__.py",
             )
-        else:
-            if CODEGEN_ZIP_SETTINGS:
-                importer = zipimporter(
-                    str(CODEGEN_OUTDIR / "solver" / f"settings_{version}.zip")
-                )
-                settings = importer.load_module("settings")
-            else:
-                settings = utils.load_module(
-                    f"settings_{version}",
-                    CODEGEN_OUTDIR / "solver" / f"settings_{version}" / "__init__.py",
-                )
-
-        if settings.SHASH != _gethash(obj_info):
-            settings_logger.warning(
-                "Mismatch between generated file and server object "
-                "info. Dynamically created settings classes will "
-                "be used."
-            )
-            raise RuntimeError("Mismatch in hash values")
-        cls = settings.root
-    except Exception:
-        cls, _ = get_cls("", obj_info, version=version)
-    root = cls()
+    root = settings.root()
     root.set_flproxy(flproxy)
     root._set_on_interrupt(interrupt)
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
-    root._setattr("_static_info", obj_info)
     root._setattr("_file_transfer_service", file_transfer_service)
     return root
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -520,7 +520,8 @@ def test_command():
 
 
 def test_attrs():
-    r = flobject.get_root(Proxy(), version="251")
+    r = flobject.get_root(Proxy())
+    r._setattr("version", "251")
     assert r.g_1.s_4.get_attr("active?")
     assert r.g_1.s_4.get_attr("allowed-values") == ["foo", "bar"]
     r.g_1.b_3 = True


### PR DESCRIPTION
This PR removes settings API hash comparison and runtime generation of settings API classes. This is not required anymore because:
- In PyConsole, we don't use this mechanism. The latest settings API classes are always generated while building Fluent.
- In released versions of PyFluent, the settings API classes generated from the latest Fluent images are up-to-date.
- This was useful only during the local development of PyFluent to avoid running settingsgen after updating the Fluent code. However, it is better to run settingsgen in this case so the generated files are used and tested during local development. Note that, we can run just settingsgen as `python src\ansys\fluent\core\codegen\settingsgen.py` which takes much less time than full codegen.

This PR saves 4s during the first settings API access at runtime.