### PR TITLE
fix: Fix recent nightly failure [use latest image]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
           python -c "from ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Cache 25.1 API Code
-        if: !contains(github.event.pull_request.title, '[use latest image]')
+        if: ! contains(github.event.pull_request.title, '[use latest image]')
         uses: actions/cache@v4
         id: cache-251-api-code
         with:
@@ -402,13 +402,13 @@ jobs:
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Pull 25.1 Fluent docker image
-        if: !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: ! contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Run 25.1 API codegen
-        if: !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: ! contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,7 @@ jobs:
           python -c "from ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Cache 25.1 API Code
+        if: !contains(github.event.pull_request.title, '[use latest image]')
         uses: actions/cache@v4
         id: cache-251-api-code
         with:
@@ -401,16 +402,42 @@ jobs:
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Pull 25.1 Fluent docker image
-        if: steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Run 25.1 API codegen
-        if: steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+
+      - name: Cache 25.1 API Code [use latest image]
+        if: contains(github.event.pull_request.title, '[use latest image]')
+        uses: actions/cache@v4
+        id: cache-251-api-code-latest-image
+        with:
+          path:
+            src/ansys/fluent/core/generated
+            doc/source/api/core/meshing/tui
+            doc/source/api/core/meshing/datamodel
+            doc/source/api/core/solver/tui
+            doc/source/api/core/solver/datamodel
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0
+
+      - name: Pull 25.1 Fluent docker image [use latest image]
+        if: contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code-latest-image.outputs.cache-hit != 'true'
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v25.1.0
+
+      - name: Run 25.1 API codegen [use latest image]
+        if: contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code-latest-image.outputs.cache-hit != 'true'
+        run: make api-codegen
+        env:
+          FLUENT_IMAGE_TAG: v25.1.0
 
       - name: Print 25.1 Fluent version info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
           python -c "from ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Cache 25.1 API Code
-        if: ! contains(github.event.pull_request.title, '[use latest image]')
+        if: ${{ !contains(github.event.pull_request.title, '[use latest image]') }}
         uses: actions/cache@v4
         id: cache-251-api-code
         with:
@@ -402,13 +402,13 @@ jobs:
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Pull 25.1 Fluent docker image
-        if: ! contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: ${{ !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true' }}
         run: make docker-pull
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Run 25.1 API codegen
-        if: ! contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true'
+        if: ${{ !contains(github.event.pull_request.title, '[use latest image]') && steps.cache-251-api-code.outputs.cache-hit != 'true' }}
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1220,7 +1220,6 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
             "list_properties",
             "make_a_copy",
             "display",
-            "copy",
             "add_to_graphics",
             "clear_history",
         }


### PR DESCRIPTION
`[use latest image]` is a new directive for PR titles to run the PR CI with the latest 25.1 image instead of the stable image updated by nightly CI. The fixed test passes with the latest image, but will fail with the old stable image. 