### PR TITLE
fix: Handle unitless parameters

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2204,28 +2204,42 @@ def get_root(
     """
     from ansys.fluent.core import CODEGEN_OUTDIR, CODEGEN_ZIP_SETTINGS, utils
 
-    if os.getenv("PYFLUENT_USE_OLD_SETTINGSGEN") != "1":
-        settings = utils.load_module(
-            f"settings_{version}",
-            CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
-        )
-    else:
-        if CODEGEN_ZIP_SETTINGS:
-            importer = zipimporter(
-                str(CODEGEN_OUTDIR / "solver" / f"settings_{version}.zip")
-            )
-            settings = importer.load_module("settings")
-        else:
+    obj_info = flproxy.get_static_info()
+    try:
+        if os.getenv("PYFLUENT_USE_OLD_SETTINGSGEN") != "1":
             settings = utils.load_module(
                 f"settings_{version}",
-                CODEGEN_OUTDIR / "solver" / f"settings_{version}" / "__init__.py",
+                CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
             )
-    root = settings.root()
+        else:
+            if CODEGEN_ZIP_SETTINGS:
+                importer = zipimporter(
+                    str(CODEGEN_OUTDIR / "solver" / f"settings_{version}.zip")
+                )
+                settings = importer.load_module("settings")
+            else:
+                settings = utils.load_module(
+                    f"settings_{version}",
+                    CODEGEN_OUTDIR / "solver" / f"settings_{version}" / "__init__.py",
+                )
+
+        if settings.SHASH != _gethash(obj_info):
+            settings_logger.warning(
+                "Mismatch between generated file and server object "
+                "info. Dynamically created settings classes will "
+                "be used."
+            )
+            raise RuntimeError("Mismatch in hash values")
+        cls = settings.root
+    except Exception:
+        cls, _ = get_cls("", obj_info, version=version)
+    root = cls()
     root.set_flproxy(flproxy)
     root._set_on_interrupt(interrupt)
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
+    root._setattr("_static_info", obj_info)
     root._setattr("_file_transfer_service", file_transfer_service)
     return root
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1750,7 +1750,7 @@ class BaseCommand(Action):
             raise KeyboardInterrupt
 
 
-# TODO: Remove this after paremater list() method is fixed from Fluent side
+# TODO: Remove this after parameter list() method is fixed from Fluent side
 def _fix_parameter_list_return(val):
     if isinstance(val, dict):
         new_val = {}

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -255,6 +255,15 @@ def test_parameters_list_function(static_mixer_settings_session):
     create_output_param("report-definition", "outlet-temp-avg")
     create_output_param("report-definition", "outlet-vel-avg")
 
+    # Create a unitless output parameter
+    unitless_quantity = solver.settings.solution.report_definitions.surface.create(
+        "temp-outlet-uniformity"
+    )
+    unitless_quantity.report_type = "surface-masswtui"
+    unitless_quantity.field = "temperature"
+    unitless_quantity.surface_names = ["outlet"]
+    unitless_quantity.output_parameter = True
+
     input_parameters_list = solver.parameters.input_parameters.list()
     output_parameters_list = solver.parameters.output_parameters.list()
     assert input_parameters_list == {
@@ -266,4 +275,5 @@ def test_parameters_list_function(static_mixer_settings_session):
     assert output_parameters_list == {
         "outlet-temp-avg-op": [0.0, "K"],
         "outlet-vel-avg-op": [0.0, "m/s"],
+        "temp-outlet-uniformity-op": [0.0, ""],
     }


### PR DESCRIPTION
Update `baseCommand._fix_parameter_list_return()` to handle units more robustly.