### PR TITLE
fix: Option to clear Fluent parallel env vars

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -124,3 +124,6 @@ START_WATCHDOG = None
 
 # Whether to skip health check
 CHECK_HEALTH = True
+
+# Whether to clear environment variables related to Fluent parallel mode
+CLEAR_FLUENT_PARA_ENVS = False

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -21,6 +21,8 @@ def is_windows():
 
 
 def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str, Any]:
+    from ansys.fluent.core import CLEAR_FLUENT_PARA_ENVS, INFER_REMOTING_IP
+
     scheduler_options = argvals.get("scheduler_options")
     is_slurm = scheduler_options and scheduler_options["scheduler"] == "slurm"
     kwargs: Dict[str, Any] = {}
@@ -33,10 +35,11 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str,
     fluent_env = os.environ.copy()
     fluent_env.update({k: str(v) for k, v in env.items()})
     fluent_env["REMOTING_THROW_LAST_TUI_ERROR"] = "1"
+    if CLEAR_FLUENT_PARA_ENVS:
+        del fluent_env["PARA_NPROCS"]
+        del fluent_env["PARA_MESH_NPROCS"]
 
     if not is_slurm:
-        from ansys.fluent.core import INFER_REMOTING_IP
-
         if INFER_REMOTING_IP and not "REMOTING_SERVER_ADDRESS" in fluent_env:
             remoting_ip = find_remoting_ip()
             if remoting_ip:


### PR DESCRIPTION
Related Fluent bug - 1160401

Adding option to clear some environment variables related to parallel Fluent before launch_fluent(). These env vars control number of processors of Fluent process launched from meshing PyConsole.