### PR TITLE
fix: missing space in fluent_connection.py

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -262,7 +262,7 @@ class _ConnectionInterface:
             logger.debug("Cortex connection properties successfully obtained.")
         except _InactiveRpcError:
             logger.warning(
-                "Fluent Cortex properties unobtainable. 'force exit()' and other"
+                "Fluent Cortex properties unobtainable. 'force exit()' and other "
                 "methods are not going to work properly. Proceeding..."
             )
             fluent_host_pid = None


### PR DESCRIPTION
"othermethods" to "other methods"