### PR TITLE
ci: Run unittests with 25.2 Fluent image in CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v25.1.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 25.1 Fluent version info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,13 @@ jobs:
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ansys-bot
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull 25.2 Fluent docker image
         if: steps.cache-252-api-code.outputs.cache-hit != 'true'
         run: make docker-pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,55 +397,25 @@ jobs:
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
             doc/source/api/core/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0
 
       - name: Pull 25.1 Fluent docker image
         if: steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          FLUENT_IMAGE_TAG: v25.1.0
 
       - name: Run 25.1 API codegen
         if: steps.cache-251-api-code.outputs.cache-hit != 'true'
         run: make api-codegen
         env:
-          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          FLUENT_IMAGE_TAG: v25.1.0
 
       - name: Print 25.1 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_251.py
           python -c "from ansys.fluent.core.generated.solver.settings_251 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
-      # - name: Cache 25.2 API Code
-      #   uses: actions/cache@v4
-      #   id: cache-252-api-code
-      #   with:
-      #     path:
-      #       src/ansys/fluent/core/generated
-      #       doc/source/api/core/meshing/tui
-      #       doc/source/api/core/meshing/datamodel
-      #       doc/source/api/core/solver/tui
-      #       doc/source/api/core/solver/datamodel
-      #     key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
-      #     restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
-
-      # - name: Pull 25.2 Fluent docker image
-      #   if: steps.cache-252-api-code.outputs.cache-hit != 'true'
-      #   run: make docker-pull
-      #   env:
-      #     FLUENT_IMAGE_TAG: v25.2.0
-
-      # - name: Run 25.2 API codegen
-      #   if: steps.cache-252-api-code.outputs.cache-hit != 'true'
-      #   run: make api-codegen
-      #   env:
-      #     FLUENT_IMAGE_TAG: v25.2.0
-
-      # - name: Print 25.2 Fluent version info
-      #   run: |
-      #     cat src/ansys/fluent/core/generated/fluent_version_252.py
-      #     python -c "from ansys.fluent.core.generated.solver.settings_252 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |
@@ -487,11 +457,9 @@ jobs:
             version: 242
           - image-tag: v25.1.0
             version: 251
-          # - image-tag: v25.2.0
-          #   version: 252
     timeout-minutes: 120
     env:
-        FLUENT_IMAGE_TAG: ${{ matrix.version == 251 && vars.FLUENT_STABLE_IMAGE_DEV || matrix.image-tag }}
+        FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
     steps:
 
@@ -549,6 +517,89 @@ jobs:
         with:
           name: coverage_report
           path: ./htmlcov
+
+# This job is kept separate till we can package 25.2 API code
+  build_test_252:
+    name: Build and Test with Fluent 25.2
+    if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+    needs: test-import
+    runs-on: [public-ubuntu-latest-8-cores]
+    timeout-minutes: 120
+    env:
+      # Enable this after the first successful nightly test run
+      # FLUENT_IMAGE_TAG: {{ vars.FLUENT_STABLE_IMAGE_DEV }}
+      FLUENT_IMAGE_TAG: v25.2.0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Add version information
+        run: make version-info
+
+      - name: Install pyfluent
+        run: make install
+
+      - name: Retrieve PyFluent version
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)"
+        id: version
+
+      - name: Cache 25.2 API Code
+        uses: actions/cache@v4
+        id: cache-252-api-code
+        with:
+          path:
+            src/ansys/fluent/core/generated
+            doc/source/api/core/meshing/tui
+            doc/source/api/core/meshing/datamodel
+            doc/source/api/core/solver/tui
+            doc/source/api/core/solver/datamodel
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
+
+      - name: Pull 25.2 Fluent docker image
+        if: steps.cache-252-api-code.outputs.cache-hit != 'true'
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
+
+      - name: Run 25.2 API codegen
+        if: steps.cache-252-api-code.outputs.cache-hit != 'true'
+        run: make api-codegen
+        env:
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
+
+      - name: Print 25.2 Fluent version info
+        run: |
+          cat src/ansys/fluent/core/generated/fluent_version_252.py
+          python -c "from ansys.fluent.core.generated.solver.settings_252 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
+      - name: Install again after codegen
+        run: |
+          rm -rf dist
+          make install > /dev/null
+
+      - name: Unit Testing
+        run: |
+          make install-test
+          make unittest-dev-252
+
+      - name: Cleanup previous docker containers
+        run: make cleanup-previous-docker-containers
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v22.2.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 22.2 Fluent version info
         run: |
@@ -291,6 +292,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v23.1.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 23.1 Fluent version info
         run: |
@@ -321,6 +323,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v23.2.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 23.2 Fluent version info
         run: |
@@ -351,6 +354,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v24.1.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 24.1 Fluent version info
         run: |
@@ -381,6 +385,7 @@ jobs:
         run: make api-codegen
         env:
           FLUENT_IMAGE_TAG: v24.2.0
+          PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS: 1
 
       - name: Print 24.2 Fluent version info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,37 @@ jobs:
           cat src/ansys/fluent/core/generated/fluent_version_251.py
           python -c "from ansys.fluent.core.generated.solver.settings_251 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
+      # Replace v25.2.0 with ${{ vars.FLUENT_STABLE_IMAGE_DEV }} after the first successful nightly test run
+      - name: Cache 25.2 API Code
+        uses: actions/cache@v4
+        id: cache-252-api-code
+        with:
+          path:
+            src/ansys/fluent/core/generated
+            doc/source/api/core/meshing/tui
+            doc/source/api/core/meshing/datamodel
+            doc/source/api/core/solver/tui
+            doc/source/api/core/solver/datamodel
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
+
+      - name: Pull 25.2 Fluent docker image
+        if: steps.cache-251-api-code.outputs.cache-hit != 'true'
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v25.2.0
+
+      - name: Run 25.2 API codegen
+        if: steps.cache-252-api-code.outputs.cache-hit != 'true'
+        run: make api-codegen
+        env:
+          FLUENT_IMAGE_TAG: v25.2.0
+
+      - name: Print 25.2 Fluent version info
+        run: |
+          cat src/ansys/fluent/core/generated/fluent_version_252.py
+          python -c "from ansys.fluent.core.generated.solver.settings_251 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
       - name: Install again after codegen
         run: |
           rm -rf dist
@@ -462,8 +493,12 @@ jobs:
             version: 242
           - image-tag: v25.1.0
             version: 251
+          - image-tag: v25.2.0
+            version: 252
     timeout-minutes: 120
     env:
+        # Enable this after the first successful nightly test run
+        # FLUENT_IMAGE_TAG: ${{ matrix.version == 252 && vars.FLUENT_STABLE_IMAGE_DEV || matrix.image-tag }}
         FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
     steps:
@@ -522,96 +557,6 @@ jobs:
         with:
           name: coverage_report
           path: ./htmlcov
-
-# This job is kept separate till we can package 25.2 API code
-  build_test_252:
-    name: Build and Test with Fluent 25.2
-    if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
-    needs: test-import
-    runs-on: [public-ubuntu-latest-8-cores]
-    timeout-minutes: 120
-    env:
-      # Enable this after the first successful nightly test run
-      # FLUENT_IMAGE_TAG: {{ vars.FLUENT_STABLE_IMAGE_DEV }}
-      FLUENT_IMAGE_TAG: v25.2.0
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
-
-      - name: Add version information
-        run: make version-info
-
-      - name: Install pyfluent
-        run: make install
-
-      - name: Retrieve PyFluent version
-        run: |
-          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)" >> $GITHUB_OUTPUT
-          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)"
-        id: version
-
-      - name: Cache 25.2 API Code
-        uses: actions/cache@v4
-        id: cache-252-api-code
-        with:
-          path:
-            src/ansys/fluent/core/generated
-            doc/source/api/core/meshing/tui
-            doc/source/api/core/meshing/datamodel
-            doc/source/api/core/solver/tui
-            doc/source/api/core/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ansys-bot
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull 25.2 Fluent docker image
-        if: steps.cache-252-api-code.outputs.cache-hit != 'true'
-        run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
-
-      - name: Run 25.2 API codegen
-        if: steps.cache-252-api-code.outputs.cache-hit != 'true'
-        run: make api-codegen
-        env:
-          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
-
-      - name: Print 25.2 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/generated/fluent_version_252.py
-          python -c "from ansys.fluent.core.generated.solver.settings_252 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
-      - name: Install again after codegen
-        run: |
-          rm -rf dist
-          make install > /dev/null
-
-      - name: Unit Testing
-        run: |
-          make install-test
-          make unittest-dev-252
-
-      - name: Cleanup previous docker containers
-        run: make cleanup-previous-docker-containers
 
   release:
     name: Release

--- a/.github/workflows/test-run-dev-version-nightly.yml
+++ b/.github/workflows/test-run-dev-version-nightly.yml
@@ -19,6 +19,9 @@ jobs:
     name: Unit Testing
     runs-on: [self-hosted, pyfluent]
     timeout-minutes: 120
+    env:
+      FLUENT_IMAGE_TAG: v25.2.0
+      FLUENT_VERSION: 252
 
     steps:
       - uses: actions/checkout@v4
@@ -55,32 +58,32 @@ jobs:
           username: ansys-bot
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull 25.1 Fluent docker image
+      - name: Pull Fluent docker image
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: v25.1.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
-      - name: Run 25.1 API codegen
+      - name: Run API codegen
         run: make api-codegen
         env:
-          FLUENT_IMAGE_TAG: v25.1.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
-      - name: Print 25.1 Fluent version info
+      - name: Print Fluent version info
         run: |
-          cat src/ansys/fluent/core/generated/fluent_version_251.py
-          python -c "from ansys.fluent.core.generated.solver.settings_251 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+          cat src/ansys/fluent/core/generated/fluent_version_${{ env.FLUENT_VERSION }}.py
+          python -c "from ansys.fluent.core.generated.solver.settings_${{ env.FLUENT_VERSION }} import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |
           rm -rf dist
           make install > /dev/null
 
-      - name: 25.1 Unit Testing
+      - name: Unit Testing
         run: |
           make install-test
-          make unittest-all-251
+          make unittest-all-{{ env.FLUENT_VERSION }}
         env:
-          FLUENT_IMAGE_TAG: v25.1.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
       - name: Cleanup previous docker containers
         if: always()
@@ -91,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ADMIN_ACCESS_TOKEN }}
         if: github.ref == 'refs/heads/main'
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ansys/pyfluent:v25.1.0 | sed 's/.*@//')
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ansys/pyfluent:${{ env.FLUENT_IMAGE_TAG }} | sed 's/.*@//')
           gh variable set FLUENT_STABLE_IMAGE_DEV --body $DIGEST
 
   clean-up:
@@ -104,4 +107,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Delete 25.1 Fluent docker image
-        run: docker rmi -f ghcr.io/ansys/pyfluent:v25.1.0
+        run: docker rmi -f ghcr.io/ansys/pyfluent:{{ env.FLUENT_IMAGE_TAG }}

--- a/doc/source/contributing/environment_variables.rst
+++ b/doc/source/contributing/environment_variables.rst
@@ -21,6 +21,8 @@ Following is a list of environment variables that can be set to control various 
       - Specifies the Docker image name while starting a Fluent container in :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>`.
     * - FLUENT_IMAGE_TAG
       - Specifies the Docker image tag while starting a Fluent container in :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>`.
+    * - PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS
+      - Skips the generation of built-in settings during codegen.
     * - PYFLUENT_CONTAINER_MOUNT_SOURCE
       - Specifies the host path which is mounted inside the container while starting a Fluent container in :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>`.
     * - PYFLUENT_CONTAINER_MOUNT_TARGET

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -78,3 +78,4 @@ Univa
 venv
 create_workflow
 load_workflow
+codegen

--- a/src/ansys/fluent/core/codegen/__init__.py
+++ b/src/ansys/fluent/core/codegen/__init__.py
@@ -18,6 +18,3 @@ class StaticInfoType(Enum):
     DATAMODEL_SOLVER_WORKFLOW = auto()
     DATAMODEL_MESHING_UTILITIES = auto()
     SETTINGS = auto()
-
-
-CODEGEN_GENERATE_BUILTIN_SETTINGS = True

--- a/src/ansys/fluent/core/codegen/allapigen.py
+++ b/src/ansys/fluent/core/codegen/allapigen.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import pickle
 
-from ansys.fluent.core import codegen
 from ansys.fluent.core.codegen import (  # noqa: F401
     builtin_settingsgen,
     datamodelgen,
@@ -12,7 +11,6 @@ from ansys.fluent.core.codegen import (  # noqa: F401
     tuigen,
 )
 from ansys.fluent.core.search import get_api_tree_file_name
-from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
 def _update_first_level(d, u):
@@ -33,12 +31,7 @@ def generate(version: str, static_infos: dict):
     Path(api_tree_file).parent.mkdir(parents=True, exist_ok=True)
     with open(api_tree_file, "wb") as f:
         pickle.dump(api_tree, f)
-    # Built-in settings are always generated for the latest version
-    # TODO: Change the hardcoded version after 25.2 Fluent image is available
-    if (
-        codegen.CODEGEN_GENERATE_BUILTIN_SETTINGS
-        and FluentVersion(version) == FluentVersion.v251
-    ):
+    if os.getenv("PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS") != "1":
         builtin_settingsgen.generate(version)
 
 

--- a/src/ansys/fluent/core/codegen/builtin_settingsgen.py
+++ b/src/ansys/fluent/core/codegen/builtin_settingsgen.py
@@ -56,6 +56,7 @@ def generate(version: str):
     print("Generating builtin settings...")
     CODEGEN_OUTDIR.mkdir(exist_ok=True)
     root = _get_settings_root(version)
+    version = FluentVersion(version)
     with open(_PY_FILE, "w") as f:
         f.write('"""Solver settings."""\n\n')
         f.write(
@@ -68,7 +69,10 @@ def generate(version: str):
         f.write("]\n\n")
         for name, v in DATA.items():
             kind, path = v
-            path = path[FluentVersion(version)] if isinstance(path, dict) else path
+            if isinstance(path, dict):
+                if version not in path:
+                    continue
+                path = path[version]
             named_objects, final_type = _get_named_objects_in_path(root, path, kind)
             if kind == "NamedObject":
                 kind = f"{final_type}NamedObject"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from packaging.version import Version
 import pytest
 
 import ansys.fluent.core as pyfluent
-from ansys.fluent.core import codegen
 from ansys.fluent.core.examples.downloads import download_file
 from ansys.fluent.core.utils.file_transfer_service import RemoteFileTransferStrategy
 from ansys.fluent.core.utils.fluent_version import FluentVersion
@@ -71,9 +70,9 @@ def run_before_each_test(
     monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
 ) -> None:
     monkeypatch.setenv("PYFLUENT_TEST_NAME", request.node.name)
+    monkeypatch.setenv("PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS", "1")
     pyfluent.CONTAINER_MOUNT_SOURCE = pyfluent.EXAMPLES_PATH
     pyfluent.CONTAINER_MOUNT_TARGET = pyfluent.EXAMPLES_PATH
-    codegen.CODEGEN_GENERATE_BUILTIN_SETTINGS = False
 
 
 class Helpers:


### PR DESCRIPTION
1. Run unittests with Fluent 25.2 image in the main CI. I have kept the job separate as we cannot yet package 25.2 API code.
2. Run unittests with Fluent 25.2 image in the nightly dev CI. `FLUENT_STABLE_IMAGE_DEV` will be updated from there.
3. Relax some conditions such that the direct settings classes can be generated from any Fluent version.