### PR TITLE
fix: Skip Fluent's automatic transcript by default

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -113,8 +113,11 @@ CODEGEN_OUTDIR = (Path(__file__) / ".." / "generated").resolve()
 # Whether to zip settings API files during codegen
 CODEGEN_ZIP_SETTINGS = os.getenv("PYFLUENT_CODEGEN_ZIP_SETTINGS", False)
 
-# Whether to show mesh after case read
-SHOW_MESH_AFTER_CASE_READ = False
+# Whether to show mesh in Fluent after case read
+FLUENT_SHOW_MESH_AFTER_CASE_READ = False
+
+# Whether to write the automatic transcript in Fluent
+FLUENT_AUTOMATIC_TRANSCRIPT = False
 
 # Whether to interrupt Fluent solver from PyFluent
 SUPPORT_SOLVER_INTERRUPT = False

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -313,6 +313,11 @@ def configure_container_dict(
 
     container_dict["fluent_image"] = fluent_image
 
+    if not pyfluent.FLUENT_AUTOMATIC_TRANSCRIPT:
+        if "environment" not in container_dict:
+            container_dict["environment"] = {}
+        container_dict["environment"]["FLUENT_NO_AUTOMATIC_TRANSCRIPT"] = "1"
+
     fluent_commands = ["-gu", f"-sifile={container_server_info_file}"] + args
 
     container_dict_default = {}

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -21,7 +21,7 @@ def is_windows():
 
 
 def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str, Any]:
-    from ansys.fluent.core import CLEAR_FLUENT_PARA_ENVS, INFER_REMOTING_IP
+    import ansys.fluent.core as pyfluent
 
     scheduler_options = argvals.get("scheduler_options")
     is_slurm = scheduler_options and scheduler_options["scheduler"] == "slurm"
@@ -35,15 +35,18 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str,
     fluent_env = os.environ.copy()
     fluent_env.update({k: str(v) for k, v in env.items()})
     fluent_env["REMOTING_THROW_LAST_TUI_ERROR"] = "1"
-    if CLEAR_FLUENT_PARA_ENVS:
+    if pyfluent.CLEAR_FLUENT_PARA_ENVS:
         del fluent_env["PARA_NPROCS"]
         del fluent_env["PARA_MESH_NPROCS"]
 
     if not is_slurm:
-        if INFER_REMOTING_IP and "REMOTING_SERVER_ADDRESS" not in fluent_env:
+        if pyfluent.INFER_REMOTING_IP and "REMOTING_SERVER_ADDRESS" not in fluent_env:
             remoting_ip = find_remoting_ip()
             if remoting_ip:
                 fluent_env["REMOTING_SERVER_ADDRESS"] = remoting_ip
+
+    if not pyfluent.FLUENT_AUTOMATIC_TRANSCRIPT:
+        fluent_env["FLUENT_NO_AUTOMATIC_TRANSCRIPT"] = "1"
 
     kwargs.update(env=fluent_env)
     return kwargs

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -108,7 +108,7 @@ def _generate_launch_string(
     if " " in server_info_file_name:
         server_info_file_name = '"' + server_info_file_name + '"'
     launch_string += f" -sifile={server_info_file_name}"
-    if not pyfluent.SHOW_MESH_AFTER_CASE_READ:
+    if not pyfluent.FLUENT_SHOW_MESH_AFTER_CASE_READ:
         launch_string += " -nm"
     return launch_string
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -486,3 +486,11 @@ def test_container_warning_for_mount_source(caplog):
     _ = pyfluent.launch_fluent(container_dict=container_dict)
     assert container_dict["mount_source"] in caplog.text
     assert container_dict["mount_target"] in caplog.text
+
+
+def test_fluent_automatic_transcript(tmp_path, monkeypatch):
+    with pyfluent.launch_fluent(cwd=tmp_path):
+        assert not list(tmp_path.glob("*.trn"))
+    monkeypatch.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)
+    with pyfluent.launch_fluent(cwd=tmp_path):
+        assert list(tmp_path.glob("*.trn"))

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 from pathlib import Path
 import platform

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -491,7 +491,11 @@ def test_container_warning_for_mount_source(caplog):
 def test_fluent_automatic_transcript(tmp_path, monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)
-        with pyfluent.launch_fluent(cwd=tmp_path):
-            assert list(tmp_path.glob("*.trn"))
-    with pyfluent.launch_fluent(cwd=tmp_path):
-        assert not list(tmp_path.glob("*.trn"))
+        cwd = tmp_path / "test1"
+        cwd.mkdir()
+        with pyfluent.launch_fluent(cwd=cwd):
+            assert list(cwd.glob("*.trn"))
+    cwd = tmp_path / "test2"
+    cwd.mkdir()
+    with pyfluent.launch_fluent(cwd=cwd):
+        assert not list(cwd.glob("*.trn"))

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -489,8 +489,9 @@ def test_container_warning_for_mount_source(caplog):
 
 
 def test_fluent_automatic_transcript(tmp_path, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)
+        with pyfluent.launch_fluent(cwd=tmp_path):
+            assert list(tmp_path.glob("*.trn"))
     with pyfluent.launch_fluent(cwd=tmp_path):
         assert not list(tmp_path.glob("*.trn"))
-    monkeypatch.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)
-    with pyfluent.launch_fluent(cwd=tmp_path):
-        assert list(tmp_path.glob("*.trn"))


### PR DESCRIPTION
Added new module variable `FLUENT_AUTOMATIC_TRANSCRIPT` which is `False` by default.