### PR TITLE
fix: Cheat sheet dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ beautifulsoup4 = "==4.12.3"
 openpyxl = { version = ">=3.1.5", optional = true }
 plotly = { version = ">=5.22.0", optional = true }
 python-pptx = { version = ">=0.6.23", optional = true }
+quarto-cli = "==1.5.57"
+pdf2image = "==1.17.0"
 seaborn = { version = ">=0.13.2", optional = true }
 tensorflow = { version = ">=2.17.0", optional = true }
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3494

We need following dependencies for local PyFluent cheat sheet generation.

1. quarto-cli
2. pdf2image
3. poppler 

**poppler on windows** 

1. Download latest release from [here](https://github.com/oschwartz10612/poppler-windows/releases/).
2. Extract zip.
3. Add <Release-24.08.0-0\poppler-24.08.0\Library\bin> to path.

**poppler on Linux**
1. Follow steps described in the ci.yml.

