### PR TITLE
fix: Show search results in a particular order

### DIFF
--- a/src/ansys/fluent/core/search.py
+++ b/src/ansys/fluent/core/search.py
@@ -168,6 +168,7 @@ def _print_search_results(queries: list, api_tree_data: dict):
             for api_object in api_tree_data:
                 if api_object.split()[0].endswith(query):
                     results.append(api_object)
+    results.sort(key=len)
     if pyfluent.PRINT_SEARCH_RESULTS:
         for result in results:
             print(result)

--- a/src/ansys/fluent/core/search.py
+++ b/src/ansys/fluent/core/search.py
@@ -178,9 +178,6 @@ def _print_search_results(queries: list, api_tree_data: dict):
     settings_results.sort()
     tui_results.sort()
 
-    # settings_results.sort(key=lambda item: (len(item), item))
-    # tui_results.sort(key=lambda item: (len(item), item))
-
     results.extend(settings_results)
     results.extend(tui_results)
 

--- a/src/ansys/fluent/core/search.py
+++ b/src/ansys/fluent/core/search.py
@@ -163,12 +163,27 @@ def _print_search_results(queries: list, api_tree_data: dict):
     results = []
     api_tree_data = api_tree_data if api_tree_data else _get_api_tree_data()
     api_tree_datas = [api_tree_data["api_objects"], api_tree_data["api_tui_objects"]]
-    for api_tree_data in api_tree_datas:
+
+    def _get_results(api_tree_data):
+        results = []
         for query in queries:
             for api_object in api_tree_data:
                 if api_object.split()[0].endswith(query):
                     results.append(api_object)
-    results.sort(key=len)
+        return results
+
+    settings_results = _get_results(api_tree_datas[0])
+    tui_results = _get_results(api_tree_datas[1])
+
+    settings_results.sort()
+    tui_results.sort()
+
+    # settings_results.sort(key=lambda item: (len(item), item))
+    # tui_results.sort(key=lambda item: (len(item), item))
+
+    results.extend(settings_results)
+    results.extend(tui_results)
+
     if pyfluent.PRINT_SEARCH_RESULTS:
         for result in results:
             print(result)


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3502

Settings results are at the top.

![image](https://github.com/user-attachments/assets/a6a1572b-c1bb-47c8-a1a0-6d78b1836a45)

TUI results are at the end.

![image](https://github.com/user-attachments/assets/13baaee5-2b07-47cf-871f-bd51019d3c0e)

![image](https://github.com/user-attachments/assets/fb7f3bff-6869-4a33-8441-a0fcbcb98d8a)
