### PR TITLE
feat: Add a hidden way to access Fluent's stdout/stderr

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -133,3 +133,11 @@ PRINT_SEARCH_RESULTS = True
 
 # Whether to clear environment variables related to Fluent parallel mode
 CLEAR_FLUENT_PARA_ENVS = False
+
+# Set stdout of the launched Fluent process
+# Valid values are same as subprocess.Popen's stdout argument
+LAUNCH_FLUENT_STDOUT = None
+
+# Set stderr of the launched Fluent process
+# Valid values are same as subprocess.Popen's stderr argument
+LAUNCH_FLUENT_STDERR = None

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -28,6 +28,10 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str,
     kwargs: Dict[str, Any] = {}
     if is_slurm:
         kwargs.update(stdout=subprocess.PIPE)
+    else:
+        kwargs.update(
+            stdout=pyfluent.LAUNCH_FLUENT_STDOUT, stderr=pyfluent.LAUNCH_FLUENT_STDERR
+        )
     if is_windows():
         kwargs.update(shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
     else:


### PR DESCRIPTION
Requested by @PyPablo 

We cannot expose this as a full feature due to the limitations mentioned in #3436. Exposing a hidden way to access Fluent's stdout/stderr.
```
import subprocess
import ansys.fluent.core as pyfluent
pyfluent.LAUNCH_FLUENT_STDOUT = subprocess.PIPE
solver = pyfluent.launch_fluent()

for line in iter(solver._process.stdout.readline, b''):
    decoded_line = line.decode('utf-8')
    print(decoded_line, end='')
    if decoded_line.startswith("Cleanup script file"):  # Any other termination condition, e.g. break after 10 lines
        break
```
Note that, this doesn't work in `ui_mode="gui"` as mentioned in #3436.