### PR TITLE
test: Add tests for new datamodel API

### DIFF
--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -318,6 +318,17 @@ def configure_container_dict(
             container_dict["environment"] = {}
         container_dict["environment"]["FLUENT_NO_AUTOMATIC_TRANSCRIPT"] = "1"
 
+    if (
+        os.getenv("REMOTING_NEW_DM_API") == "1"
+        or os.getenv("REMOTING_MAPPED_NEW_DM_API") == "1"
+    ):
+        if "environment" not in container_dict:
+            container_dict["environment"] = {}
+        if os.getenv("REMOTING_NEW_DM_API") == "1":
+            container_dict["environment"]["REMOTING_NEW_DM_API"] = "1"
+        if os.getenv("REMOTING_MAPPED_NEW_DM_API") == "1":
+            container_dict["environment"]["REMOTING_MAPPED_NEW_DM_API"] = "1"
+
     fluent_commands = ["-gu", f"-sifile={container_server_info_file}"] + args
 
     container_dict_default = {}

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1577,7 +1577,7 @@ class PyNamedObjectContainer:
             # On-deleted subscription objects are unsubscribed after the datamodel
             # object is deleted.
             self[key].add_on_deleted(
-                lambda _: self.service.subscriptions.unsubscribe_while_deleting(
+                lambda: self.service.subscriptions.unsubscribe_while_deleting(
                     self.rules, se_path, "after"
                 )
             )

--- a/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
@@ -66,12 +66,12 @@ class DatamodelEvents(StreamingService):
                         elif response.HasField("commandAttributeChangedEventResponse"):
                             value = response.commandAttributeChangedEventResponse.value
                             cb[1](_convert_variant_to_value(value))
-                        elif (
-                            response.HasField("modifiedEventResponse")
-                            or response.HasField("deletedEventResponse")
-                            or response.HasField("affectedEventResponse")
-                        ):
+                        elif response.HasField(
+                            "modifiedEventResponse"
+                        ) or response.HasField("affectedEventResponse"):
                             cb[1](cb[0])
+                        elif response.HasField("deletedEventResponse"):
+                            cb[1]()
                         elif response.HasField("commandExecutedEventResponse"):
                             command = response.commandExecutedEventResponse.command
                             args = _convert_variant_to_value(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from ansys.fluent.core.examples.downloads import download_file
 from ansys.fluent.core.utils.file_transfer_service import RemoteFileTransferStrategy
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
+sys.path.append(Path(__file__).parent / "util")
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -383,3 +385,10 @@ def periodic_rot_settings_session(new_solver_session):
 @pytest.fixture
 def disable_datamodel_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(pyfluent, "DATAMODEL_USE_STATE_CACHE", False)
+
+
+@pytest.fixture(params=["old", "new"])
+def datamodel_api_version(request, monkeypatch: pytest.MonkeyPatch) -> None:
+    if request.param == "new":
+        monkeypatch.setenv("REMOTING_NEW_DM_API", "1")
+        monkeypatch.setenv("REMOTING_MAPPED_NEW_DM_API", "1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,7 +388,13 @@ def disable_datamodel_cache(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(params=["old", "new"])
-def datamodel_api_version(request, monkeypatch: pytest.MonkeyPatch) -> None:
+def datamodel_api_version_all(request, monkeypatch: pytest.MonkeyPatch) -> None:
     if request.param == "new":
         monkeypatch.setenv("REMOTING_NEW_DM_API", "1")
         monkeypatch.setenv("REMOTING_MAPPED_NEW_DM_API", "1")
+
+
+@pytest.fixture
+def datamodel_api_version_new(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REMOTING_NEW_DM_API", "1")
+    monkeypatch.setenv("REMOTING_MAPPED_NEW_DM_API", "1")

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from util import create_datamodel_root_in_server
+from util import create_datamodel_root_in_server, create_root_cls_using_datamodelgen
 
 from ansys.fluent.core.services.datamodel_se import (
     PyCommand,
@@ -134,8 +134,11 @@ def test_env_var_setting(datamodel_api_version_all, request, new_solver_session)
 def test_datamodel_api_on_child_created(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    static_info = service.get_static_info(app_name)
+    root = create_root_cls_using_datamodelgen(static_info)(service, app_name, [])
+
     called = 0
     created = []
 

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -117,7 +117,7 @@ class test_root(PyMenu):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_env_var_setting(datamodel_api_version, request, new_solver_session):
+def test_env_var_setting(datamodel_api_version_all, request, new_solver_session):
     solver = new_solver_session
     test_name = request.node.name
     for var in ["REMOTING_NEW_DM_API", "REMOTING_MAPPED_NEW_DM_API"]:
@@ -130,7 +130,7 @@ def test_env_var_setting(datamodel_api_version, request, new_solver_session):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_child_created(datamodel_api_version, new_solver_session):
+def test_datamodel_api_on_child_created(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -154,7 +154,7 @@ def test_datamodel_api_on_child_created(datamodel_api_version, new_solver_sessio
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_changed(datamodel_api_version, new_solver_session):
+def test_datamodel_api_on_changed(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -204,7 +204,7 @@ def test_datamodel_api_on_changed(datamodel_api_version, new_solver_session):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_affected(datamodel_api_version, new_solver_session):
+def test_datamodel_api_on_affected(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -233,7 +233,7 @@ def test_datamodel_api_on_affected(datamodel_api_version, new_solver_session):
 
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_affected_at_type_path(
-    datamodel_api_version, new_solver_session
+    datamodel_api_version_all, new_solver_session
 ):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
@@ -262,7 +262,9 @@ def test_datamodel_api_on_affected_at_type_path(
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_deleted(datamodel_api_version, request, new_solver_session):
+def test_datamodel_api_on_deleted(
+    datamodel_api_version_all, request, new_solver_session
+):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -296,7 +298,9 @@ def test_datamodel_api_on_deleted(datamodel_api_version, request, new_solver_ses
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_attribute_changed(datamodel_api_version, new_solver_session):
+def test_datamodel_api_on_attribute_changed(
+    datamodel_api_version_all, new_solver_session
+):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -329,7 +333,7 @@ def test_datamodel_api_on_attribute_changed(datamodel_api_version, new_solver_se
 
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_command_attribute_changed(
-    datamodel_api_version, new_solver_session
+    datamodel_api_version_all, new_solver_session
 ):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
@@ -366,7 +370,9 @@ def test_datamodel_api_on_command_attribute_changed(
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_command_executed(datamodel_api_version, new_solver_session):
+def test_datamodel_api_on_command_executed(
+    datamodel_api_version_all, new_solver_session
+):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -401,7 +407,7 @@ def test_datamodel_api_on_command_executed(datamodel_api_version, new_solver_ses
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_get_state(datamodel_api_version, new_solver_session):
+def test_datamodel_api_get_state(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -409,7 +415,7 @@ def test_datamodel_api_get_state(datamodel_api_version, new_solver_session):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_set_state(datamodel_api_version, new_solver_session):
+def test_datamodel_api_set_state(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -418,7 +424,7 @@ def test_datamodel_api_set_state(datamodel_api_version, new_solver_session):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_update_dict(datamodel_api_version, new_solver_session):
+def test_datamodel_api_update_dict(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -427,7 +433,9 @@ def test_datamodel_api_update_dict(datamodel_api_version, new_solver_session):
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_on_bad_input(datamodel_api_version, request, new_solver_session):
+def test_datamodel_api_on_bad_input(
+    datamodel_api_version_all, request, new_solver_session
+):
     solver = new_solver_session
     root = create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service
@@ -476,7 +484,7 @@ def test_datamodel_api_on_bad_input(datamodel_api_version, request, new_solver_s
 
 
 @pytest.mark.fluent_version(">=25.2")
-def test_datamodel_api_static_info(datamodel_api_version, new_solver_session):
+def test_datamodel_api_static_info(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     create_datamodel_root_in_server(solver, rule_str, test_root)
     service = solver._se_service

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -229,9 +229,9 @@ def test_datamodel_api_on_deleted(
     assert not called
     assert not called_obj
     service.delete_object(app_name, "/B:b")
-    timeout_loop(lambda: called_obj, timeout=5)
+    time.sleep(5)
     test_name = request.node.name
-    # Note comment in StateEngine test testDataModelAPIOnDeleted
+    # TODO: Note comment in StateEngine test testDataModelAPIOnDeleted
     if test_name.endswith("[old]"):
         assert called
     elif test_name.endswith("[new]"):

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -1,0 +1,501 @@
+import time
+
+import pytest
+
+from ansys.fluent.core.services.datamodel_se import (
+    PyCommand,
+    PyDictionary,
+    PyMenu,
+    PyNamedObjectContainer,
+    PyTextual,
+    SubscribeEventError,
+    convert_path_to_se_path,
+)
+from ansys.fluent.core.utils.execution import timeout_loop
+
+ENV_VARS = ["REMOTING_NEW_DM_API", "REMOTING_MAPPED_NEW_DM_API"]
+
+
+@pytest.fixture(params=["old", "new"])
+def api_version(request, monkeypatch: pytest.MonkeyPatch) -> None:
+    if request.param == "new":
+        for var in ENV_VARS:
+            monkeypatch.setenv(var, "1")
+
+
+rule_str = (
+    "RULES:\n"
+    "  STRING: X\n"
+    "    default = ijk\n"
+    "  END\n"
+    "  SINGLETON: ROOT\n"
+    "    members = A, B, D, G\n"
+    "    commands= C\n"
+    "    SINGLETON: A\n"
+    "      members = X\n"
+    "      x = $./X\n"
+    "    END\n"
+    "    OBJECT: B\n"
+    "      members = X\n"
+    "    END\n"
+    "    SINGLETON: D\n"
+    "      members = E, F, X\n"
+    "      SINGLETON: E\n"
+    "        members = X\n"
+    "      END\n"
+    "      SINGLETON: F\n"
+    "        members = X\n"
+    "      END\n"
+    "    END\n"
+    "    SINGLETON: G\n"
+    "      members = H\n"
+    "      DICT: H\n"
+    "      END\n"
+    "    END\n"
+    "    COMMAND: C\n"
+    "      arguments = X\n"
+    "      x = $/A/X\n"
+    "    END\n"
+    "  END\n"
+    "END\n"
+)
+
+
+class test_root(PyMenu):
+    def __init__(self, service, rules, path):
+        self.A = self.__class__.A(service, rules, path + [("A", "")])
+        self.B = self.__class__.B(service, rules, path + [("B", "")])
+        self.C = self.__class__.C(service, rules, path + [("C", "")])
+        self.D = self.__class__.D(service, rules, path + [("D", "")])
+        self.G = self.__class__.G(service, rules, path + [("G", "")])
+        super().__init__(service, rules, path)
+
+    class A(PyMenu):
+        def __init__(self, service, rules, path):
+            self.X = self.__class__.X(service, rules, path + [("X", "")])
+            super().__init__(service, rules, path)
+
+        class X(PyTextual):
+            pass
+
+    class B(PyNamedObjectContainer):
+        class _B(PyMenu):
+            def __init__(self, service, rules, path):
+                self.X = self.__class__.X(service, rules, path + [("X", "")])
+                super().__init__(service, rules, path)
+
+            class X(PyTextual):
+                pass
+
+    class C(PyCommand):
+        pass
+
+    class D(PyMenu):
+        def __init__(self, service, rules, path):
+            self.E = self.__class__.E(service, rules, path + [("E", "")])
+            self.F = self.__class__.F(service, rules, path + [("F", "")])
+            self.X = self.__class__.X(service, rules, path + [("X", "")])
+            super().__init__(service, rules, path)
+
+        class E(PyMenu):
+            def __init__(self, service, rules, path):
+                self.X = self.__class__.X(service, rules, path + [("X", "")])
+                super().__init__(service, rules, path)
+
+            class X(PyTextual):
+                pass
+
+        class F(PyMenu):
+            def __init__(self, service, rules, path):
+                self.X = self.__class__.X(service, rules, path + [("X", "")])
+                super().__init__(service, rules, path)
+
+            class X(PyTextual):
+                pass
+
+        class X(PyTextual):
+            pass
+
+    class G(PyMenu):
+        def __init__(self, service, rules, path):
+            self.H = self.__class__.H(service, rules, path + [("H", "")])
+            super().__init__(service, rules, path)
+
+        class H(PyDictionary):
+            pass
+
+
+def _create_datamodel_root(session, rules_str) -> None:
+    rules_file_name = "test.fdl"
+    session.scheme_eval.scheme_eval(
+        f'(with-output-to-file "{rules_file_name}" (lambda () (format "~a" "{rules_str}")))'
+    )
+    session.scheme_eval.scheme_eval(
+        '(state/register-new-state-engine "test" "test.fdl")'
+    )
+    session.scheme_eval.scheme_eval(f'(remove-file "{rules_file_name}")')
+    assert session.scheme_eval.scheme_eval('(state/find-root "test")') > 0
+    return test_root(session._se_service, "test", [])
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_env_var_setting(api_version, request, new_solver_session):
+    solver = new_solver_session
+    test_name = request.node.name
+    for var in ENV_VARS:
+        # TODO: It might be possible to check the param value in the fixture
+        # instead of checking the test name here.
+        if test_name.endswith("[old]"):
+            assert solver.scheme_eval.scheme_eval(f'(getenv "{var}")') is None
+        elif test_name.endswith("[new]"):
+            assert solver.scheme_eval.scheme_eval(f'(getenv "{var}")') == "1"
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_child_created(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+    created = []
+
+    def cb(obj):
+        nonlocal called
+        nonlocal created
+        called += 1
+        created.append(convert_path_to_se_path(obj.path))
+
+    subscription = service.add_on_child_created("test", "/", "B", root, cb)
+    assert called == 0
+    assert created == []
+    service.set_state("test", "/", {"B:b": {"_name_": "b"}})
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    assert created == ["/B:b"]
+    subscription.unsubscribe()
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_changed(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+    state = None
+    called_obj = 0
+    state_obj = None
+
+    def cb(obj):
+        nonlocal called
+        nonlocal state
+        state = obj()
+        called += 1
+
+    def cb_obj(obj):
+        nonlocal called_obj
+        nonlocal state_obj
+        state_obj = obj()
+        called_obj += 1
+
+    subscription = service.add_on_changed("test", "/A/X", root.A.X, cb)
+    subscription_obj = service.add_on_changed("test", "/A", root.A, cb_obj)
+    assert called == 0
+    assert state is None
+    assert called_obj == 0
+    assert state_obj is None
+    service.set_state("test", "/A/X", "lmn")
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    assert state == "lmn"
+    assert called_obj == 1
+    assert state_obj == {"X": "lmn"}
+    service.set_state("test", "/A/X", "abc")
+    timeout_loop(lambda: called == 2, timeout=5)
+    assert called == 2
+    assert state == "abc"
+    assert called_obj == 2
+    assert state_obj == {"X": "abc"}
+    subscription.unsubscribe()
+    subscription_obj.unsubscribe()
+    service.set_state("test", "/A/X", "xyz")
+    time.sleep(5)
+    assert called == 2
+    assert state == "abc"
+    assert called_obj == 2
+    assert state_obj == {"X": "abc"}
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_affected(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+
+    def cb(obj):
+        nonlocal called
+        called += 1
+
+    subscription = service.add_on_affected("test", "/D", root.D, cb)
+    assert called == 0
+    service.set_state("test", "/D/X", "lmn")
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    service.set_state("test", "/D/E/X", "lmn")
+    timeout_loop(lambda: called == 2, timeout=5)
+    assert called == 2
+    service.set_state("test", "/A/X", "lmn")
+    time.sleep(5)
+    assert called == 2
+    subscription.unsubscribe()
+    service.set_state("test", "/D/E/X", "pqr")
+    time.sleep(5)
+    assert called == 2
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_affected_at_type_path(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+
+    def cb(obj):
+        nonlocal called
+        called += 1
+
+    subscription = service.add_on_affected_at_type_path("test", "/D", "E", root.D.E, cb)
+    assert called == 0
+    service.set_state("test", "/D/X", "lmn")
+    time.sleep(5)
+    assert called == 0
+    service.set_state("test", "/D/E/X", "lmn")
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    service.set_state("test", "/D/F/X", "lmn")
+    time.sleep(5)
+    assert called == 1
+    subscription.unsubscribe()
+    service.set_state("test", "/D/E/X", "pqr")
+    time.sleep(5)
+    assert called == 1
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_deleted(api_version, request, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = False
+    called_obj = False
+
+    def cb():
+        nonlocal called
+        called = True
+
+    def cb_obj():
+        nonlocal called_obj
+        called_obj = True
+
+    service.set_state("test", "/", {"B:b": {"_name_": "b"}})
+    subscription = service.add_on_deleted("test", "/B:b/X", root.B["b"].X, cb)
+    subscription_obj = service.add_on_deleted("test", "/B:b", root.B["b"], cb_obj)
+    assert not called
+    assert not called_obj
+    service.delete_object("test", "/B:b")
+    timeout_loop(lambda: called_obj, timeout=5)
+    test_name = request.node.name
+    # Note comment in StateEngine test testDataModelAPIOnDeleted
+    if test_name.endswith("[old]"):
+        assert called
+    elif test_name.endswith("[new]"):
+        assert not called
+    assert called_obj
+    subscription.unsubscribe()
+    subscription_obj.unsubscribe()
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_attribute_changed(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+    value = None
+
+    def cb(val):
+        nonlocal called
+        nonlocal value
+        value = val
+        called += 1
+
+    subscription = service.add_on_attribute_changed("test", "/A", "x", root.A, cb)
+    assert called == 0
+    assert value is None
+    service.set_state("test", "/A/X", "cde")
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    assert value == "cde"
+    service.set_state("test", "/A/X", "xyz")
+    timeout_loop(lambda: called == 2, timeout=5)
+    assert called == 2
+    assert value == "xyz"
+    subscription.unsubscribe()
+    service.set_state("test", "/A/X", "abc")
+    time.sleep(5)
+    assert called == 2
+    assert value == "xyz"
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_command_attribute_changed(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    called = 0
+    value = None
+
+    def cb(val):
+        nonlocal called
+        nonlocal value
+        value = val
+        called += 1
+
+    subscription = service.add_on_command_attribute_changed(
+        "test", "/", "C", "x", root.C, cb
+    )
+    assert called == 0
+    assert value is None
+    service.set_state("test", "/A/X", "cde")
+    timeout_loop(lambda: called == 1, timeout=5)
+    assert called == 1
+    assert value == "cde"
+    service.set_state("test", "/A/X", "xyz")
+    timeout_loop(lambda: called == 2, timeout=5)
+    assert called == 2
+    # TODO: value is still "cde" in both old and new API
+    # assert value == "xyz"
+    subscription.unsubscribe()
+    service.set_state("test", "/A/X", "abc")
+    time.sleep(5)
+    assert called == 2
+    # Commented out because of the issue above
+    # assert value == "xyz"
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_command_executed(api_version, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    executed = 0
+    command = None
+    arguments = None
+
+    def cb(obj, cmd, args):
+        nonlocal executed
+        nonlocal command
+        nonlocal arguments
+        command = cmd
+        arguments = args
+        executed += 1
+
+    # TODO: In C++ API, we don't need to pass the command name
+    subscription = service.add_on_command_executed("test", "/", "C", root, cb)
+    assert executed == 0
+    assert command is None
+    assert arguments is None
+    service.execute_command("test", "/", "C", dict(X="abc"))
+    timeout_loop(lambda: executed == 1, timeout=5)
+    assert executed == 1
+    assert command == "C"
+    assert arguments == {"X": "abc"}
+    subscription.unsubscribe()
+    service.execute_command("test", "/", "C", dict(X="uvw"))
+    time.sleep(5)
+    assert executed == 1
+    assert command == "C"
+    assert arguments == {"X": "abc"}
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_get_state(api_version, new_solver_session):
+    solver = new_solver_session
+    _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    assert service.get_state("test", "/A/X") == "ijk"
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_set_state(api_version, new_solver_session):
+    solver = new_solver_session
+    _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    service.set_state("test", "/A/X", "new_val")
+    assert service.get_state("test", "/A/X") == "new_val"
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_update_dict(api_version, new_solver_session):
+    solver = new_solver_session
+    _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    service.update_dict("test", "/G/H", {"X": "abc"})
+    assert service.get_state("test", "/G/H") == {"X": "abc"}
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_on_bad_input(api_version, request, new_solver_session):
+    solver = new_solver_session
+    root = _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    test_name = request.node.name
+    new_api = test_name.endswith("[new]")
+    with pytest.raises(SubscribeEventError):
+        service.add_on_child_created("test", "", "", root, lambda _: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_child_created("test", "/BB", "B", root, lambda _: None)
+    with pytest.raises(SubscribeEventError):
+        service.add_on_child_created("test", "/", "A", root, lambda _: None)
+    with pytest.raises(SubscribeEventError):
+        service.add_on_child_created("test", "/", "BB", root, lambda _: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_changed("test", "/BB", root, lambda _: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_deleted("test", "/BB", root, lambda: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_affected("test", "/BB", root, lambda _: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_affected_at_type_path("test", "/BB", "B", root, lambda: None)
+    # TODO: not raised in the old API - issue
+    if new_api:
+        with pytest.raises(SubscribeEventError):
+            service.add_on_affected_at_type_path("test", "/", "BB", root, lambda: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_attribute_changed(
+            "test", "/BB", "isActive", root, lambda _: None
+        )
+    with pytest.raises(SubscribeEventError):
+        service.add_on_attribute_changed("test", "/A", "", root, lambda _: None)
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_command_attribute_changed(
+            "test", "/BB", "C", "isActive", root, lambda _: None
+        )
+    with pytest.raises(SubscribeEventError):
+        service.add_on_command_attribute_changed(
+            "test", "/A", "CC", "", root, lambda _: None
+        )
+    with pytest.raises(SubscribeEventError):
+        service.add_on_command_attribute_changed(
+            "test", "/", "CC", "isActive", root, lambda _: None
+        )
+    with pytest.raises(RuntimeError if new_api else SubscribeEventError):  # TODO: issue
+        service.add_on_command_executed("test", "/BB", "C", root, lambda _: None)
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_datamodel_api_static_info(api_version, new_solver_session):
+    solver = new_solver_session
+    _create_datamodel_root(solver, rule_str)
+    service = solver._se_service
+    assert service.get_static_info("test")

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -52,6 +52,7 @@ rule_str = (
 )
 
 
+# TODO: Generate the class hierarchy via codegen
 class test_root(PyMenu):
     def __init__(self, service, rules, path):
         self.A = self.__class__.A(service, rules, path + [("A", "")])

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -1,14 +1,9 @@
 import time
 
 import pytest
-from util import create_datamodel_root_in_server, create_root_cls_using_datamodelgen
+from util import create_datamodel_root_in_server, create_root_using_datamodelgen
 
 from ansys.fluent.core.services.datamodel_se import (
-    PyCommand,
-    PyDictionary,
-    PyMenu,
-    PyNamedObjectContainer,
-    PyTextual,
     SubscribeEventError,
     convert_path_to_se_path,
 )
@@ -52,71 +47,6 @@ rule_str = (
 )
 
 
-# TODO: Generate the class hierarchy via codegen
-class test_root(PyMenu):
-    def __init__(self, service, rules, path):
-        self.A = self.__class__.A(service, rules, path + [("A", "")])
-        self.B = self.__class__.B(service, rules, path + [("B", "")])
-        self.C = self.__class__.C(service, rules, path + [("C", "")])
-        self.D = self.__class__.D(service, rules, path + [("D", "")])
-        self.G = self.__class__.G(service, rules, path + [("G", "")])
-        super().__init__(service, rules, path)
-
-    class A(PyMenu):
-        def __init__(self, service, rules, path):
-            self.X = self.__class__.X(service, rules, path + [("X", "")])
-            super().__init__(service, rules, path)
-
-        class X(PyTextual):
-            pass
-
-    class B(PyNamedObjectContainer):
-        class _B(PyMenu):
-            def __init__(self, service, rules, path):
-                self.X = self.__class__.X(service, rules, path + [("X", "")])
-                super().__init__(service, rules, path)
-
-            class X(PyTextual):
-                pass
-
-    class C(PyCommand):
-        pass
-
-    class D(PyMenu):
-        def __init__(self, service, rules, path):
-            self.E = self.__class__.E(service, rules, path + [("E", "")])
-            self.F = self.__class__.F(service, rules, path + [("F", "")])
-            self.X = self.__class__.X(service, rules, path + [("X", "")])
-            super().__init__(service, rules, path)
-
-        class E(PyMenu):
-            def __init__(self, service, rules, path):
-                self.X = self.__class__.X(service, rules, path + [("X", "")])
-                super().__init__(service, rules, path)
-
-            class X(PyTextual):
-                pass
-
-        class F(PyMenu):
-            def __init__(self, service, rules, path):
-                self.X = self.__class__.X(service, rules, path + [("X", "")])
-                super().__init__(service, rules, path)
-
-            class X(PyTextual):
-                pass
-
-        class X(PyTextual):
-            pass
-
-    class G(PyMenu):
-        def __init__(self, service, rules, path):
-            self.H = self.__class__.H(service, rules, path + [("H", "")])
-            super().__init__(service, rules, path)
-
-        class H(PyDictionary):
-            pass
-
-
 @pytest.mark.fluent_version(">=25.2")
 def test_env_var_setting(datamodel_api_version_all, request, new_solver_session):
     solver = new_solver_session
@@ -136,8 +66,7 @@ def test_datamodel_api_on_child_created(datamodel_api_version_all, new_solver_se
     app_name = "test"
     create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
-    static_info = service.get_static_info(app_name)
-    root = create_root_cls_using_datamodelgen(static_info)(service, app_name, [])
+    root = create_root_using_datamodelgen(service, app_name)
 
     called = 0
     created = []
@@ -162,8 +91,9 @@ def test_datamodel_api_on_child_created(datamodel_api_version_all, new_solver_se
 def test_datamodel_api_on_changed(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = 0
     state = None
     called_obj = 0
@@ -213,8 +143,9 @@ def test_datamodel_api_on_changed(datamodel_api_version_all, new_solver_session)
 def test_datamodel_api_on_affected(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = 0
 
     def cb(obj):
@@ -244,8 +175,9 @@ def test_datamodel_api_on_affected_at_type_path(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = 0
 
     def cb(obj):
@@ -277,8 +209,9 @@ def test_datamodel_api_on_deleted(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = False
     called_obj = False
 
@@ -314,8 +247,9 @@ def test_datamodel_api_on_attribute_changed(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = 0
     value = None
 
@@ -349,8 +283,9 @@ def test_datamodel_api_on_command_attribute_changed(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     called = 0
     value = None
 
@@ -388,8 +323,9 @@ def test_datamodel_api_on_command_executed(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     executed = 0
     command = None
     arguments = None
@@ -424,7 +360,7 @@ def test_datamodel_api_on_command_executed(
 def test_datamodel_api_get_state(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
     assert service.get_state(app_name, "/A/X") == "ijk"
 
@@ -433,7 +369,7 @@ def test_datamodel_api_get_state(datamodel_api_version_all, new_solver_session):
 def test_datamodel_api_set_state(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
     service.set_state(app_name, "/A/X", "new_val")
     assert service.get_state(app_name, "/A/X") == "new_val"
@@ -443,7 +379,7 @@ def test_datamodel_api_set_state(datamodel_api_version_all, new_solver_session):
 def test_datamodel_api_update_dict(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
     service.update_dict(app_name, "/G/H", {"X": "abc"})
     assert service.get_state(app_name, "/G/H") == {"X": "abc"}
@@ -455,8 +391,9 @@ def test_datamodel_api_on_bad_input(
 ):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
+    root = create_root_using_datamodelgen(service, app_name)
     test_name = request.node.name
     new_api = test_name.endswith("[new]")
     with pytest.raises(SubscribeEventError):
@@ -507,6 +444,6 @@ def test_datamodel_api_on_bad_input(
 def test_datamodel_api_static_info(datamodel_api_version_all, new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    create_datamodel_root_in_server(solver, rule_str, app_name, test_root)
+    create_datamodel_root_in_server(solver, rule_str, app_name)
     service = solver._se_service
     assert service.get_static_info(app_name)

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -3,18 +3,14 @@ from time import sleep
 
 from google.protobuf.json_format import MessageToDict
 import pytest
-from util import create_datamodel_root_in_server
+from util import create_datamodel_root_in_server, create_root_using_datamodelgen
 
 from ansys.api.fluent.v0 import datamodel_se_pb2
 from ansys.api.fluent.v0.variant_pb2 import Variant
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
 from ansys.fluent.core.services.datamodel_se import (
-    PyCommand,
-    PyMenu,
     PyMenuGeneric,
-    PyNamedObjectContainer,
-    PyTextual,
     ReadOnlyObjectError,
     _convert_value_to_variant,
     _convert_variant_to_value,
@@ -544,35 +540,12 @@ test_rules = (
 )
 
 
-class test_root(PyMenu):
-    def __init__(self, service, rules, path):
-        self.A = self.__class__.A(service, rules, path + [("A", "")])
-        super().__init__(service, rules, path)
-
-    class A(PyNamedObjectContainer):
-        class _A(PyMenu):
-            def __init__(self, service, rules, path):
-                self.B = self.__class__.B(service, rules, path + [("B", "")])
-                self.X = self.__class__.X(service, rules, path + [("X", "")])
-                self.C = self.__class__.C(service, rules, "C", path)
-                super().__init__(service, rules, path)
-
-            class B(PyNamedObjectContainer):
-                class _B(PyMenu):
-                    pass
-
-            class X(PyTextual):
-                pass
-
-            class C(PyCommand):
-                pass
-
-
 @pytest.mark.fluent_version(">=24.2")
 def test_on_child_created_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_child_created("B", lambda _: data.append(1))
@@ -591,7 +564,8 @@ def test_on_child_created_lifetime(new_solver_session):
 def test_on_deleted_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_deleted(lambda _: data.append(1))
@@ -613,7 +587,8 @@ def test_on_deleted_lifetime(new_solver_session):
 def test_on_changed_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].X.add_on_changed(lambda _: data.append(1))
@@ -632,7 +607,8 @@ def test_on_changed_lifetime(new_solver_session):
 def test_on_affected_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected(lambda _: data.append(1))
@@ -651,7 +627,8 @@ def test_on_affected_lifetime(new_solver_session):
 def test_on_affected_at_type_path_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected_at_type_path("B", lambda _: data.append(1))
@@ -670,7 +647,8 @@ def test_on_affected_at_type_path_lifetime(new_solver_session):
 def test_on_command_executed_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_executed("C", lambda *args: data.append(1))
@@ -689,7 +667,8 @@ def test_on_command_executed_lifetime(new_solver_session):
 def test_on_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_attribute_changed("isABC", lambda _: data.append(1))
@@ -710,7 +689,8 @@ def test_on_attribute_changed_lifetime(new_solver_session):
 def test_on_command_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_attribute_changed(
@@ -745,7 +725,8 @@ def test_on_command_attribute_changed_lifetime(new_solver_session):
 def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []
@@ -765,7 +746,8 @@ def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
 def test_on_affected_lifetime_with_delete_all_child_objects(new_solver_session):
     solver = new_solver_session
     app_name = "test"
-    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
+    create_datamodel_root_in_server(solver, test_rules, app_name)
+    root = create_root_using_datamodelgen(solver._se_service, app_name)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -571,7 +571,8 @@ class test_root(PyMenu):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_child_created_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_child_created("B", lambda _: data.append(1))
@@ -589,7 +590,8 @@ def test_on_child_created_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_deleted_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_deleted(lambda _: data.append(1))
@@ -610,7 +612,8 @@ def test_on_deleted_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].X.add_on_changed(lambda _: data.append(1))
@@ -628,7 +631,8 @@ def test_on_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected(lambda _: data.append(1))
@@ -646,7 +650,8 @@ def test_on_affected_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_at_type_path_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected_at_type_path("B", lambda _: data.append(1))
@@ -664,7 +669,8 @@ def test_on_affected_at_type_path_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_command_executed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_executed("C", lambda *args: data.append(1))
@@ -682,7 +688,8 @@ def test_on_command_executed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_attribute_changed("isABC", lambda _: data.append(1))
@@ -702,7 +709,8 @@ def test_on_attribute_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_command_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_attribute_changed(
@@ -736,7 +744,8 @@ def test_on_command_attribute_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []
@@ -755,7 +764,8 @@ def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime_with_delete_all_child_objects(new_solver_session):
     solver = new_solver_session
-    root = create_datamodel_root_in_server(solver, test_rules, test_root)
+    app_name = "test"
+    root = create_datamodel_root_in_server(solver, test_rules, app_name, test_root)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -122,7 +122,7 @@ def test_add_on_deleted(new_meshing_session):
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
     data = []
     _ = meshing.workflow.TaskObject["Import Geometry"].add_on_deleted(
-        lambda obj: data.append(convert_path_to_se_path(obj.path))
+        lambda: data.append(True)
     )
     assert data == []
     meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
@@ -568,8 +568,8 @@ def test_on_deleted_lifetime(new_solver_session):
     root = create_root_using_datamodelgen(solver._se_service, app_name)
     root.A["A1"] = {}
     data = []
-    _ = root.A["A1"].add_on_deleted(lambda _: data.append(1))
-    root.A["A1"].add_on_deleted(lambda _: data.append(2))
+    _ = root.A["A1"].add_on_deleted(lambda: data.append(1))
+    root.A["A1"].add_on_deleted(lambda: data.append(2))
     gc.collect()
     assert "/test/deleted/A:A1" in solver._se_service.subscriptions
     assert "/test/deleted/A:A1-1" in solver._se_service.subscriptions

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from google.protobuf.json_format import MessageToDict
 import pytest
+from util import create_datamodel_root_in_server
 
 from ansys.api.fluent.v0 import datamodel_se_pb2
 from ansys.api.fluent.v0.variant_pb2 import Variant
@@ -567,23 +568,10 @@ class test_root(PyMenu):
                 pass
 
 
-def _create_datamodel_root(session, rules_str) -> PyMenu:
-    rules_file_name = "test.fdl"
-    session.scheme_eval.scheme_eval(
-        f'(with-output-to-file "{rules_file_name}" (lambda () (format "~a" "{rules_str}")))'
-    )
-    session.scheme_eval.scheme_eval(
-        '(state/register-new-state-engine "test" "test.fdl")'
-    )
-    session.scheme_eval.scheme_eval(f'(remove-file "{rules_file_name}")')
-    assert session.scheme_eval.scheme_eval('(state/find-root "test")') > 0
-    return test_root(session._se_service, "test", [])
-
-
 @pytest.mark.fluent_version(">=24.2")
 def test_on_child_created_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_child_created("B", lambda _: data.append(1))
@@ -601,7 +589,7 @@ def test_on_child_created_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_deleted_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_deleted(lambda _: data.append(1))
@@ -622,7 +610,7 @@ def test_on_deleted_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].X.add_on_changed(lambda _: data.append(1))
@@ -640,7 +628,7 @@ def test_on_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected(lambda _: data.append(1))
@@ -658,7 +646,7 @@ def test_on_affected_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_at_type_path_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_affected_at_type_path("B", lambda _: data.append(1))
@@ -676,7 +664,7 @@ def test_on_affected_at_type_path_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_command_executed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_executed("C", lambda *args: data.append(1))
@@ -694,7 +682,7 @@ def test_on_command_executed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_attribute_changed("isABC", lambda _: data.append(1))
@@ -714,7 +702,7 @@ def test_on_attribute_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_command_attribute_changed_lifetime(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     root.A["A1"] = {}
     data = []
     _ = root.A["A1"].add_on_command_attribute_changed(
@@ -748,7 +736,7 @@ def test_on_command_attribute_changed_lifetime(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []
@@ -767,7 +755,7 @@ def test_on_affected_lifetime_with_delete_child_objects(new_solver_session):
 @pytest.mark.fluent_version(">=24.2")
 def test_on_affected_lifetime_with_delete_all_child_objects(new_solver_session):
     solver = new_solver_session
-    root = _create_datamodel_root(solver, test_rules)
+    root = create_datamodel_root_in_server(solver, test_rules, test_root)
     pyfluent.logging.enable()
     root.A["A1"] = {}
     data = []

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -135,9 +135,9 @@ def test_datamodel_api_get_attrs_bool_for_str(
 ):
     solver = new_solver_session
     app_name = "test"
-    create_datamodel_root_in_server(solver, rules_str_caps, app_name)
+    create_datamodel_root_in_server(solver, rules_str, app_name)
     service = solver._se_service
-    # assert service.get_attribute_value(app_name, "/A/Z", "allowedValues") is None  # TODO: issue in accessing the object
+    assert service.get_attribute_value(app_name, "/A/Z", "allowedValues") is None
     assert service.get_attribute_value(app_name, "/A/X", "allowedValues") is None
 
 

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -165,3 +165,33 @@ def test_state_of_command_args_with_mapping(
     assert service.get_state(app_name, f"/C:{c_name}") == {"X": False}
     service.set_state(app_name, f"/C:{c_name}", {"X": True})
     assert service.get_state(app_name, f"/C:{c_name}") == {"X": True}
+
+
+def register_external_function_in_remote_app(session, app_name, func_name):
+    session.scheme_eval.scheme_eval(
+        f'(state/register-external-fn "{app_name}" "{func_name}" (lambda (obj . args) (car args)) (cons "Variant" (list "ModelObject" "Variant")))'
+    )
+
+
+def test_execute_command_with_args_mapping(
+    datamodel_api_version_new, new_solver_session
+):
+    solver = new_solver_session
+    app_name = "test"
+    create_datamodel_root_in_server(solver, rules_str, app_name)
+    service = solver._se_service
+    register_external_function_in_remote_app(solver, app_name, "CFunc")
+    result = service.execute_command(app_name, "/", "C", {"X": True})
+    assert result == "yes"
+
+
+def test_execute_command_with_args_and_path_mapping(
+    datamodel_api_version_new, new_solver_session
+):
+    solver = new_solver_session
+    app_name = "test"
+    create_datamodel_root_in_server(solver, rules_str, app_name)
+    service = solver._se_service
+    register_external_function_in_remote_app(solver, app_name, "CFunc")
+    result = service.execute_command(app_name, "/", "dd", {"X": True})
+    assert result == "yes"

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -1,0 +1,71 @@
+from util import create_datamodel_root_in_server
+
+rules_str = (
+    "RULES:\n"
+    "  STRING: X\n"
+    "    allowedValues = yes, no\n"
+    "    logicalMapping = True, False\n"
+    "  END\n"
+    "  STRING: Y\n"
+    '    allowedValues = \\"1\\", \\"2\\", \\"3\\"\n'
+    '    default = \\"2\\"\n'
+    "    isNumerical = True\n"
+    "  END\n"
+    "  INTEGER: Z\n"
+    "  END\n"
+    "  SINGLETON: ROOT\n"
+    "    members = A\n"
+    "    commands = C, D\n"
+    "    SINGLETON: A\n"
+    "      members = X, Y, Z\n"
+    "    END\n"
+    "    COMMAND: C\n"
+    "      arguments = X\n"
+    "      functionName = CFunc\n"
+    "    END\n"
+    "    COMMAND: D\n"
+    "      arguments = X\n"
+    "      functionName = CFunc\n"
+    "      APIName = dd\n"
+    "    END\n"
+    "  END\n"
+    "END\n"
+)
+
+rules_str_caps = (
+    "RULES:\n"
+    "  STRING: X\n"
+    "    allowedValues = Yes, No\n"
+    "    default = No\n"
+    "    logicalMapping = True, False\n"
+    "  END\n"
+    "  SINGLETON: ROOT\n"
+    "    members = A\n"
+    "    SINGLETON: A\n"
+    "      members = X\n"
+    "    END\n"
+    "  END\n"
+    "END\n"
+)
+
+
+def get_static_info_value(static_info, type_path):
+    for p in type_path.split("/"):
+        static_info = static_info[p]
+    return static_info
+
+
+def test_datamodel_api_bool_for_str_has_correct_type(
+    datamodel_api_version, new_solver_session
+):
+    solver = new_solver_session
+    create_datamodel_root_in_server(solver, rules_str)
+    service = solver._se_service
+    static_info = service.get_static_info("test")
+    assert (
+        get_static_info_value(static_info, "/singletons/A/parameters/X/type")
+        == "Logical"
+    )
+    cmd_args = get_static_info_value(static_info, "/commands/C/commandinfo/args")
+    arg0 = cmd_args[0]
+    assert arg0["type"] == "Logical"

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -1,3 +1,4 @@
+import pytest
 from util import create_datamodel_root_in_server
 
 rules_str = (
@@ -116,3 +117,51 @@ def test_datamodel_api_get_set_bool_for_str_with_flexible_strs_no_errors(
     service.set_state(app_name, "/A/X", True)
     assert service.get_state(app_name, "/A/X") is True
     assert get_error_state_message_from_remote_app(solver, app_name, "/A/X") is None
+
+
+def test_datamodel_api_get_attrs_bool_for_str(
+    datamodel_api_version_new, new_solver_session
+):
+    solver = new_solver_session
+    app_name = "test"
+    create_datamodel_root_in_server(solver, rules_str_caps, app_name)
+    service = solver._se_service
+    # assert service.get_attribute_value(app_name, "/A/Z", "allowedValues") is None  # TODO: issue in accessing the object
+    assert service.get_attribute_value(app_name, "/A/X", "allowedValues") is None
+
+
+def test_datamodel_api_get_and_set_int_for_str(
+    datamodel_api_version_new, new_solver_session
+):
+    solver = new_solver_session
+    app_name = "test"
+    create_datamodel_root_in_server(solver, rules_str, app_name)
+    service = solver._se_service
+    service.set_state(app_name, "/A/Y", 1)
+    assert service.get_state(app_name, "/A/Y") == 1
+    assert get_error_state_message_from_remote_app(solver, app_name, "/A/Y") is None
+
+
+# TODO: what are the equivalent of following tests in Python?
+# testPopulateMappingAttrTablePaths
+# testMapAPIStateToDM
+# testMapDMStateToAPI
+# testMapNestedAPIStateToDM
+# testUpdateStateDictWithMapping
+
+
+def test_state_of_command_args_with_mapping(
+    datamodel_api_version_new, new_solver_session
+):
+    solver = new_solver_session
+    app_name = "test"
+    create_datamodel_root_in_server(solver, rules_str, app_name)
+    service = solver._se_service
+    c_name = service.create_command_arguments(app_name, "/", "C")
+    with pytest.raises(RuntimeError):
+        service.set_state(app_name, f"/C:{c_name}/X", False)
+    assert service.get_state(app_name, f"/C:{c_name}") == {"X": None}
+    service.set_state(app_name, f"/C:{c_name}", {"X": False})
+    assert service.get_state(app_name, f"/C:{c_name}") == {"X": False}
+    service.set_state(app_name, f"/C:{c_name}", {"X": True})
+    assert service.get_state(app_name, f"/C:{c_name}") == {"X": True}

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -112,6 +112,7 @@ def get_error_state_message_from_remote_app(session, app_name, type_path):
     )
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_bool_for_str_has_correct_type(
     datamodel_api_version_new, new_solver_session
 ):
@@ -129,6 +130,7 @@ def test_datamodel_api_bool_for_str_has_correct_type(
     assert arg0["type"] == "Logical"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_set_bool_for_str(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
     app_name = "test"
@@ -139,6 +141,7 @@ def test_datamodel_api_set_bool_for_str(datamodel_api_version_new, new_solver_se
     assert get_state_from_remote_app(solver, app_name, "/A/X") == "yes"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_set_bool_nested_for_str(
     datamodel_api_version_new, new_solver_session
 ):
@@ -151,6 +154,7 @@ def test_datamodel_api_set_bool_nested_for_str(
     assert get_error_state_message_from_remote_app(solver, app_name, "/A/X") is None
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_set_bool_for_str_with_flexible_strs_no_errors(
     datamodel_api_version_new, new_solver_session
 ):
@@ -163,6 +167,7 @@ def test_datamodel_api_get_set_bool_for_str_with_flexible_strs_no_errors(
     assert get_error_state_message_from_remote_app(solver, app_name, "/A/X") is None
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_attrs_bool_for_str(
     datamodel_api_version_new, new_solver_session
 ):
@@ -174,6 +179,7 @@ def test_datamodel_api_get_attrs_bool_for_str(
     assert service.get_attribute_value(app_name, "/A/X", "allowedValues") is None
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_and_set_int_for_str(
     datamodel_api_version_new, new_solver_session
 ):
@@ -194,6 +200,7 @@ def test_datamodel_api_get_and_set_int_for_str(
 # testUpdateStateDictWithMapping
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_state_of_command_args_with_mapping(
     datamodel_api_version_new, new_solver_session
 ):
@@ -217,6 +224,7 @@ def register_external_function_in_remote_app(session, app_name, func_name):
     )
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_execute_command_with_args_mapping(
     datamodel_api_version_new, new_solver_session
 ):
@@ -229,6 +237,7 @@ def test_execute_command_with_args_mapping(
     assert result == "yes"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_execute_command_with_args_and_path_mapping(
     datamodel_api_version_new, new_solver_session
 ):
@@ -241,6 +250,7 @@ def test_execute_command_with_args_and_path_mapping(
     assert result == "yes"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_execute_query_with_args_mapping(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -266,6 +276,7 @@ def test_execute_query_with_args_mapping(datamodel_api_version_new, new_solver_s
     assert result == "yes"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_attr(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
     app_name = "test"
@@ -278,6 +289,7 @@ def test_get_mapped_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, "/A/Y", "default") == 2
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -311,6 +323,7 @@ def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session)
     assert service.get_attribute_value(app_name, "/A/Z", "default") == 42
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -338,6 +351,7 @@ def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -368,6 +382,7 @@ def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_sess
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -411,6 +426,7 @@ def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, f"/C:{c_name}", "Z/default") == 42
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
     app_name = "test"
@@ -467,6 +483,7 @@ def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
     assert state_obj == {"X": False, "Y": 2, "Z": None}
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_session):
     rules_str = (
         "RULES:\n"
@@ -547,6 +564,7 @@ def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_sessi
     assert value is True
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_command_executed_mapped_args(
     datamodel_api_version_new, new_solver_session
 ):
@@ -679,6 +697,7 @@ class api_name_rules_cls(PyMenu):
         pass
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_with_mapped_names(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
     app_name = "test"
@@ -724,6 +743,7 @@ def test_datamodel_api_with_mapped_names(datamodel_api_version_new, new_solver_s
 # testMapperMapDMValueToAPI
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_root_get_and_set_state_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -738,6 +758,7 @@ def test_datamodel_api_root_get_and_set_state_with_mapped_names(
     assert service.get_state(app_name, "/") == {"aaa": {"xxx": False}}
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_root_get_attrs_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -750,6 +771,7 @@ def test_datamodel_api_root_get_attrs_with_mapped_names(
     assert service.get_attribute_value(app_name, "/B:b/yyy", "default") == 2
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_cmd_args_op_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -766,6 +788,7 @@ def test_datamodel_api_cmd_args_op_with_mapped_names(
     assert service.get_attribute_value(app_name, f"/__C:{c_name}", "xxx/attr1") == 42.0
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_rename_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -781,6 +804,7 @@ def test_datamodel_api_rename_with_mapped_names(
     assert service.get_state(app_name, "/eee:x/yyy") == 2
 
 
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_delete_object_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -793,6 +817,7 @@ def test_datamodel_api_delete_object_with_mapped_names(
 
 
 @pytest.mark.skip
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):
@@ -834,6 +859,7 @@ def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
 
 
 @pytest.mark.skip
+@pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_changed_with_mapped_names(
     datamodel_api_version_new, new_solver_session
 ):

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -50,13 +50,13 @@ rules_str_caps = (
 
 
 def get_static_info_value(static_info, type_path):
-    for p in type_path.split("/"):
+    for p in type_path.removeprefix("/").split("/"):
         static_info = static_info[p]
     return static_info
 
 
 def test_datamodel_api_bool_for_str_has_correct_type(
-    datamodel_api_version, new_solver_session
+    datamodel_api_version_new, new_solver_session
 ):
     solver = new_solver_session
     create_datamodel_root_in_server(solver, rules_str)

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -9,9 +9,7 @@ from ansys.fluent.core.codegen import StaticInfoType, datamodelgen
 from ansys.fluent.core.utils import load_module
 
 
-def create_datamodel_root_in_server(
-    session, rules_str, app_name, root_cls=None
-) -> None:
+def create_datamodel_root_in_server(session, rules_str, app_name) -> None:
     rules_file_name = f"{uuid.uuid4()}.fdl"
     session.scheme_eval.scheme_eval(
         f'(with-output-to-file "{rules_file_name}" (lambda () (format "~a" "{rules_str}")))',
@@ -21,12 +19,11 @@ def create_datamodel_root_in_server(
     )
     session.scheme_eval.scheme_eval(f'(remove-file "{rules_file_name}")')
     assert session.scheme_eval.scheme_eval(f'(state/find-root "{app_name}")') > 0
-    if root_cls:
-        return root_cls(session._se_service, app_name, [])
 
 
-def create_root_cls_using_datamodelgen(static_info):
+def create_root_using_datamodelgen(service, app_name):
     version = "252"
+    static_info = service.get_static_info(app_name)
     with TemporaryDirectory() as temp_dir:
         with MonkeyPatch.context() as m:
             m.setattr(pyfluent, "CODEGEN_OUTDIR", Path(temp_dir))
@@ -36,4 +33,4 @@ def create_root_cls_using_datamodelgen(static_info):
             )
             gen_file = Path(temp_dir) / f"datamodel_{version}" / "workflow.py"
             module = load_module("datamodel", gen_file)
-            return module.Root
+            return module.Root(service, app_name, [])

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,16 @@
+import uuid
+
+
+def create_datamodel_root_in_server(session, rules_str, root_cls=None) -> None:
+    rules_file_name = f"{uuid.uuid4()}.fdl"
+    session.scheme_eval.scheme_eval(
+        f'(with-output-to-file "{rules_file_name}" (lambda () (format "~a" "{rules_str}")))',
+    )
+    # TODO: Pass appname via argument
+    session.scheme_eval.scheme_eval(
+        f'(state/register-new-state-engine "test" "{rules_file_name}")'
+    )
+    session.scheme_eval.scheme_eval(f'(remove-file "{rules_file_name}")')
+    assert session.scheme_eval.scheme_eval('(state/find-root "test")') > 0
+    if root_cls:
+        return root_cls(session._se_service, "test", [])

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,16 +1,17 @@
 import uuid
 
 
-def create_datamodel_root_in_server(session, rules_str, root_cls=None) -> None:
+def create_datamodel_root_in_server(
+    session, rules_str, app_name, root_cls=None
+) -> None:
     rules_file_name = f"{uuid.uuid4()}.fdl"
     session.scheme_eval.scheme_eval(
         f'(with-output-to-file "{rules_file_name}" (lambda () (format "~a" "{rules_str}")))',
     )
-    # TODO: Pass appname via argument
     session.scheme_eval.scheme_eval(
-        f'(state/register-new-state-engine "test" "{rules_file_name}")'
+        f'(state/register-new-state-engine "{app_name}" "{rules_file_name}")'
     )
     session.scheme_eval.scheme_eval(f'(remove-file "{rules_file_name}")')
-    assert session.scheme_eval.scheme_eval('(state/find-root "test")') > 0
+    assert session.scheme_eval.scheme_eval(f'(state/find-root "{app_name}")') > 0
     if root_cls:
-        return root_cls(session._se_service, "test", [])
+        return root_cls(session._se_service, app_name, [])


### PR DESCRIPTION
Adding StateEngine unittests corresponding to the new datamodel API. 

Added test_datamodel_api.py for testDataModelApi.cpp and testMappedApi.cpp. I've skipped testMFWMappedApi.cpp as this seems to be at workflow level - we can add it after updating the workflow classes based on the new API.

Some issues found are mentoned in TODO comments in the test code - will address them in separate PRs.