### PR TITLE
feat: Retrieve mesh data in solution mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ansys-api-fluent>=0.3.30",
+    "ansys-api-fluent>=0.3.31",
     "ansys-platform-instancemanagement~=1.0",
     "ansys-tools-filetransfer>=0.1,<0.3",
     "ansys-units>=0.3.3,<0.5",

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -1027,9 +1027,10 @@ class Mesh:
     Attributes:
     -----------
     nodes : list[Node]
-        List of nodes in the mesh.
+        List of nodes in the mesh. Sorted by Fluent's node ID.
     elements : list[Element]
-        List of elements in the mesh.
+        List of elements in the mesh. Unsorted as we want to correlate with the
+        solution data retrieved via svar service.
     """
 
     nodes: list[Node]
@@ -1433,5 +1434,4 @@ class FieldData:
             )
             for element in elements
         ]
-        elements = sorted(elements, key=lambda x: x._id)
         return Mesh(nodes=nodes, elements=elements)

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -1,10 +1,15 @@
 import numpy as np
 import pytest
+from test_utils import pytest_approx
 
 from ansys.fluent.core import examples
 from ansys.fluent.core.examples.downloads import download_file
 from ansys.fluent.core.exceptions import DisallowedValuesError
-from ansys.fluent.core.services.field_data import FieldUnavailable, SurfaceDataType
+from ansys.fluent.core.services.field_data import (
+    CellElementType,
+    FieldUnavailable,
+    SurfaceDataType,
+)
 
 HOT_INLET_TEMPERATURE = 313.15
 
@@ -464,3 +469,19 @@ def test_field_data_streaming_in_meshing_mode(new_meshing_session):
     assert len(mesh_data[5]["faces"]) == 80
 
     assert list(mesh_data[12].keys()) == ["vertices", "faces"]
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_mesh_data(static_mixer_case_session):
+    solver = static_mixer_case_session
+    mesh = solver.fields.field_data.get_mesh(zone_id=97)
+    assert len(mesh.nodes) == 82247
+    assert len(mesh.elements) == 22771
+    assert mesh.elements[0].element_type == CellElementType.POLYHEDRON
+    assert len(mesh.elements[0].node_indices) == 19
+    assert min(mesh.nodes, key=lambda x: x.x).x == pytest_approx(-1.999075e-03)
+    assert max(mesh.nodes, key=lambda x: x.x).x == pytest_approx(1.999125e-03)
+    assert min(mesh.nodes, key=lambda x: x.y).y == pytest_approx(-3.000000e-03)
+    assert max(mesh.nodes, key=lambda x: x.y).y == pytest_approx(3.000000e-03)
+    assert min(mesh.nodes, key=lambda x: x.z).z == pytest_approx(-2.000000e-03)
+    assert max(mesh.nodes, key=lambda x: x.z).z == pytest_approx(2.500000e-03)

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -478,7 +478,7 @@ def test_mesh_data(static_mixer_case_session):
     assert len(mesh.nodes) == 82247
     assert len(mesh.elements) == 22771
     assert mesh.elements[0].element_type == CellElementType.POLYHEDRON
-    assert len(mesh.elements[0].node_indices) == 19
+    assert len(mesh.elements[0].node_indices) == 14
     assert min(mesh.nodes, key=lambda x: x.x).x == pytest_approx(-1.999075e-03)
     assert max(mesh.nodes, key=lambda x: x.x).x == pytest_approx(1.999125e-03)
     assert min(mesh.nodes, key=lambda x: x.y).y == pytest_approx(-3.000000e-03)

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -478,7 +478,7 @@ def test_mesh_data(static_mixer_case_session):
     assert len(mesh.nodes) == 82247
     assert len(mesh.elements) == 22771
     assert mesh.elements[0].element_type == CellElementType.POLYHEDRON
-    assert len(mesh.elements[0].node_indices) == 14
+    assert len(mesh.elements[0].node_indices) > 0
     assert min(mesh.nodes, key=lambda x: x.x).x == pytest_approx(-1.999075e-03)
     assert max(mesh.nodes, key=lambda x: x.x).x == pytest_approx(1.999125e-03)
     assert min(mesh.nodes, key=lambda x: x.y).y == pytest_approx(-3.000000e-03)


### PR DESCRIPTION
```
import pyvista as pv
import numpy as np
import ansys.fluent.core as pyfluent
from ansys.fluent.core.services.field_data import CellElementType

def convert_fluent_element_type_to_pv_cell_type(element_type):
    if element_type == CellElementType.TETRAHEDRON:
        return pv.CellType.TETRA
    if element_type == CellElementType.HEXAHEDRON:
        return pv.CellType.HEXAHEDRON
    # Add other element types
    raise ValueError(f"Unknown element type {element_type}")

solver = pyfluent.launch_fluent(processor_count=4)
solver.settings.file.read_case(file_name="d:/work/elbow.cas.h5")
mesh = solver.fields.field_data.get_mesh(zone_id=2)
points = np.array([(node.x, node.y, node.z) for node in mesh.nodes])
cells = np.array([[len(element.node_indices)] + element.node_indices for element in mesh.elements]).ravel()
cell_types = [convert_fluent_element_type_to_pv_cell_type(element.element_type) for element in mesh.elements]
grid = pv.UnstructuredGrid(cells, cell_types, points)
pv.plot(grid, show_edges=True)
```
![image](https://github.com/user-attachments/assets/d9d77613-28e3-4ab2-a53d-764032681ed8)
