### PR TITLE
chore: Doc/CI update for 25.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,8 +563,8 @@ jobs:
         if: always()
         run: make cleanup-previous-docker-containers
 
-      - name: Upload 24.2 Coverage Artifacts
-        if: matrix.image-tag == 'v24.2.0'
+      - name: Upload 25.1 Coverage Artifacts
+        if: matrix.image-tag == 'v25.1.0'
         uses: actions/upload-artifact@v4
         with:
           name: coverage_report

--- a/.github/workflows/test-run-nightly.yml
+++ b/.github/workflows/test-run-nightly.yml
@@ -13,6 +13,8 @@ env:
   PYFLUENT_WATCHDOG_DEBUG: 'OFF'
   PYFLUENT_HIDE_LOG_SECRETS: 1
   MAIN_PYTHON_VERSION: '3.10'
+  FLUENT_IMAGE_TAG: v25.1.0
+  FLUENT_VERSION: 251
 
 jobs:
   test:
@@ -55,56 +57,44 @@ jobs:
           username: ansys-bot
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull 24.2 Fluent docker image
+      - name: Pull Fluent docker image
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: v24.2.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
-      - name: Run 24.2 API codegen
+      - name: Run API codegen
         run: make api-codegen
         env:
-          FLUENT_IMAGE_TAG: v24.2.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
-      - name: Pull 25.1 Fluent docker image
-        run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: v25.1.0
-
-        # The version-independent built-in settings classes are generated only with Fluent 25.1
-        # which are required for the unit tests
-      - name: Run 25.1 API codegen
-        run: make api-codegen
-        env:
-          FLUENT_IMAGE_TAG: v25.1.0
-
-      - name: Print 24.2 Fluent version info
+      - name: Print Fluent version info
         run: |
-          cat src/ansys/fluent/core/generated/fluent_version_242.py
-          python -c "from ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+          cat src/ansys/fluent/core/generated/fluent_version_${{ env.FLUENT_VERSION }}.py
+          python -c "from ansys.fluent.core.generated.solver.settings_${{ env.FLUENT_VERSION }} import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |
           rm -rf dist
           make install > /dev/null
 
-      - name: 24.2 Unit Testing
+      - name: Unit Testing
         run: |
           make install-test
-          make unittest-all-242
+          make unittest-all-${{ env.FLUENT_VERSION }}
         env:
-          FLUENT_IMAGE_TAG: v24.2.0
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
 
-      - name: Upload 24.2 Coverage Results to Codecov
+      - name: Upload Coverage Results to Codecov
         uses: codecov/codecov-action@v5
         with:
           root_dir: ${{ github.workspace }}
           name: cov_xml.xml
 
-      - name: Upload 24.2 Coverage Artifacts
+      - name: Upload Coverage Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_report

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -33,9 +33,9 @@ To run the PyFluent unit tests, execute the following command in the root
 .. code:: console
 
     pip install ansys-fluent-core[tests]
-    python -m pytest -n 4 --fluent-version=24.2
+    python -m pytest -n 4 --fluent-version=25.1
 
-You can change the Fluent version by replacing ``24.2`` with the version you want to test.
+You can change the Fluent version by replacing ``25.1`` with the version you want to test.
 
 Build documentation
 -------------------

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -200,10 +200,10 @@ increasing order of precedence:
 
 #. ``AWP_ROOT<ver>`` environment variable, which is configured on Windows system
    when Fluent is installed, where ``<ver>`` is the Fluent release number such
-   as ``242`` for release 2024 R2.  PyFluent automatically uses this environment
+   as ``251`` for release 2025 R1.  PyFluent automatically uses this environment
    variable to locate the latest Fluent installation. On Linux systems configure
    ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such
-   as ``/apps/ansys_inc/v242``.
+   as ``/apps/ansys_inc/v251``.
 
 
 How do you disable PyFluent warnings shown in the console?

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -86,8 +86,8 @@ All versions of PyFluent support Fluent 2022 R2 and later.
 
 PyFluent uses an environment variable to locate your Ansys installation.
 
-On Windows, the Ansys installer sets the environment variable. For instance, the Ansys 2024R2
-installer sets the ``AWP_ROOT242`` environment variable to point to ``C:\Program Files\ANSYS Inc\v242``
+On Windows, the Ansys installer sets the environment variable. For instance, the Ansys 2025 R1
+installer sets the ``AWP_ROOT251`` environment variable to point to ``C:\Program Files\ANSYS Inc\v251``
 if you accept the default installation location.
 
 **On Linux, the environment variable is not set automatically.** It can be set for the
@@ -95,7 +95,7 @@ current user in the current shell session as follows:
 
 .. code:: console
 
-    export AWP_ROOT242=/usr/ansys_inc/v242
+    export AWP_ROOT251=/usr/ansys_inc/v251
 
 For this variable to persist between different shell sessions for the current user, the same
 export command can instead be added to the user's ``~/.profile`` file.

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -35,7 +35,7 @@ A simple example
 .. code:: python
 
   >>> import ansys.fluent.core as pyfluent
-  >>> meshing = pyfluent.launch_fluent(mode=pyfluent.FluentMode.MESHING, product_version=pyfluent.FluentVersion.v242)
+  >>> meshing = pyfluent.launch_fluent(mode=pyfluent.FluentMode.MESHING, product_version=pyfluent.FluentVersion.v251)
   >>> watertight = meshing.watertight()
   >>> watertight.import_geometry.file_name = pyfluent.examples.download_file("mixing_elbow.pmdb","pyfluent/mixing_elbow")
   >>> watertight.import_geometry()

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -161,7 +161,7 @@ scheduler using the ``sbatch`` command:
    #
    # Activate your favorite Python environment
    #
-   export AWP_ROOT242=/apps/ansys_inc/v242
+   export AWP_ROOT251=/apps/ansys_inc/v251
    . ./venv/bin/activate
    #
    # Run a PyFluent script
@@ -173,7 +173,7 @@ Here are a few notes about this example:
 
 - Eight machines with a total of 32 cores are requested. Fluent is started with
   the appropriate command line arguments passed to ``-t`` and ``-cnf``.
-- The variable ``AWP_ROOT242`` is configured so that PyFluent can find
+- The variable ``AWP_ROOT251`` is configured so that PyFluent can find
   the Fluent installation.
 - The code assumes that a Python virtual environment was pre-configured with
   PyFluent installed before the job script is submitted to Slurm. You could

--- a/examples/00-fluent/conjugate_heat_transfer.py
+++ b/examples/00-fluent/conjugate_heat_transfer.py
@@ -61,7 +61,7 @@ geom_filename = examples.download_file(
 # ================================================================
 
 meshing = pyfluent.launch_fluent(
-    product_version="24.2.0",
+    product_version="25.1.0",
     mode="meshing",
     dimension=3,
     precision="double",

--- a/examples/00-fluent/lunar_lander_thermal.py
+++ b/examples/00-fluent/lunar_lander_thermal.py
@@ -243,7 +243,7 @@ solver = pyfluent.launch_fluent(
     processor_count=12,
     mode="solver",
     cwd=pyfluent.EXAMPLES_PATH,
-    product_version="24.2.0",
+    product_version="25.1.0",
 )
 print(solver.get_fluent_version())
 

--- a/examples/00-fluent/modeling_ablation.py
+++ b/examples/00-fluent/modeling_ablation.py
@@ -86,7 +86,7 @@ set_config(blocking=True, set_view_on_display="isometric")
 # ==================================================================================
 
 solver = pyfluent.launch_fluent(
-    product_version="24.2.0",
+    product_version="25.1.0",
     dimension=3,
     precision="double",
     processor_count=4,

--- a/examples/00-fluent/tyler_sofrin_modes.py
+++ b/examples/00-fluent/tyler_sofrin_modes.py
@@ -123,7 +123,7 @@ examples.download_file(
 # Launch Fluent session and print Fluent version
 # =====================================================================================
 session = pyfluent.launch_fluent(
-    ui_mode="gui", processor_count=4, product_version="24.2.0"
+    ui_mode="gui", processor_count=4, product_version="25.1.0"
 )
 print(session.get_fluent_version())
 

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -12,7 +12,7 @@ version_info = 0, 29, "dev0"
 __version__ = ".".join(map(str, version_info))
 
 # Current Fluent version
-fluent_release_version = "24.2.0"
+fluent_release_version = "25.1.0"
 
 # Dev Fluent version
 fluent_dev_version = "25.2.0"

--- a/src/ansys/fluent/core/codegen/tuigen.py
+++ b/src/ansys/fluent/core/codegen/tuigen.py
@@ -73,7 +73,7 @@ _XML_HELPSTRINGS = {}
 
 def _copy_tui_help_xml_file(version: str):
     if os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1":
-        image_tag = os.getenv("FLUENT_IMAGE_TAG", "v24.2.0")
+        image_tag = os.getenv("FLUENT_IMAGE_TAG", "v25.1.0")
         image_name = f"ghcr.io/ansys/pyfluent:{image_tag}"
         container_name = uuid.uuid4().hex
         is_linux = platform.system() == "Linux"

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -80,8 +80,8 @@ class DockerLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
-            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            any of ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
+            Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
+            any of ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``, or ``251``.
             The default is ``None``, in which case the newest installed version is used.
         dimension : Dimension or int, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -130,8 +130,8 @@ def launch_fluent(
     Parameters
     ----------
     product_version : FluentVersion or str or float or int, optional
-        Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-        any of  ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``or ``242``.
+        Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
+        any of  ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``or ``251``.
         The default is ``None``, in which case the newest installed version is used.
     dimension : Dimension or int, optional
         Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -76,8 +76,8 @@ class PIMLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
-            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-           ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
+            Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
+           ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``, or ``251``.
             The default is ``None``, in which case the newest installed version is used.
         dimension : Dimension or int, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -301,8 +301,8 @@ class SlurmLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
-            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-            ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
+            Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
+            ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``, or ``251``.
             The default is ``None``, in which case the newest installed version is used.
         dimension : Dimension or int, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -96,8 +96,8 @@ class StandaloneLauncher:
             ``FluentWindowsGraphicsDriver`` enum in Windows or the values of the
             ``FluentLinuxGraphicsDriver`` enum in Linux.
         product_version : FluentVersion or str or float or int, optional
-            Version of Ansys Fluent to launch. To use Fluent version 2024 R2, pass
-           ``FluentVersion.v242``, ``"24.2.0"``, ``"24.2"``, ``24.2``, or ``242``.
+            Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
+           ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``, or ``251``.
             The default is ``None``, in which case the newest installed version is used.
         dimension : Dimension or int, optional
             Geometric dimensionality of the Fluent simulation. The default is ``None``,


### PR DESCRIPTION
Change doc and CI to reflect Fluent 25.1 as the primary release version.

This PR doesn't incude changes in cheatsheet and docker build instructions.