### PR TITLE
build: Update local doc build instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,6 @@ jobs:
           make build-doc-source
         env:
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          PYFLUENT_DOC_SKIP_CHEATSHEET: 1
 
       - name: Zip HTML Documentation before upload
         run: |

--- a/.github/workflows/doc-build-dev-nightly.yml
+++ b/.github/workflows/doc-build-dev-nightly.yml
@@ -66,6 +66,7 @@ jobs:
           make build-all-docs
         env:
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          BUILD_ALL_DOCS: 1
 
       - name: Zip HTML Documentation before upload
         run: |

--- a/.github/workflows/doc-build-release.yml
+++ b/.github/workflows/doc-build-release.yml
@@ -63,6 +63,7 @@ jobs:
           make build-all-docs
         env:
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          BUILD_ALL_DOCS: 1
 
       - name: Zip HTML Documentation before upload
         run: |

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,12 +17,12 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: 
 	@if [ -z "$$BUILD_ALL_DOCS" ]; then \
-		python api_rstgen.py; \
-		python doc/datamodel_rstgen.py; \
-		python doc/tui_rstgen.py; \
-		python doc/settings_rstgen.py; \
+		echo "BUILD_ALL_DOCS is not set. Skipping RST file generation."; \
 	else \
-		echo "BUILD_ALL_DOCS is set. Skipping Python script execution."; \
+		python api_rstgen.py; \
+		python datamodel_rstgen.py; \
+		python tui_rstgen.py; \
+		python settings_rstgen.py; \
 	fi
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,16 +9,24 @@ BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
-.PHONY: help Makefile
+.PHONY: help clean
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+%: 
+	@if [ -z "$$BUILD_ALL_DOCS" ]; then \
+		python api_rstgen.py; \
+		python doc/datamodel_rstgen.py; \
+		python doc/tui_rstgen.py; \
+		python doc/settings_rstgen.py; \
+	else \
+		echo "BUILD_ALL_DOCS is set. Skipping Python script execution."; \
+	fi
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
-# customized clean due to examples gallery
+# Customized clean due to examples gallery
 clean:
 	rm -rf build_errors.txt
 	rm -rf $(BUILDDIR)/*
@@ -27,4 +35,6 @@ clean:
 	rm -rf $(SOURCEDIR)/api/meshing/tui
 	rm -rf $(SOURCEDIR)/api/solver/datamodel
 	rm -rf $(SOURCEDIR)/api/solver/tui
-	find . -type d -name "_autosummary" "datamodel" -exec rm -rf {} +
+	find . -type d \( -name "_autosummary" -o -name "datamodel" \) -exec rm -rf {} +
+
+.PHONY: clean

--- a/doc/changelog.d/3671.dependencies.md
+++ b/doc/changelog.d/3671.dependencies.md
@@ -1,0 +1,1 @@
+Update local doc build instructions

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -5,10 +5,10 @@ setlocal
 pushd %~dp0
 
 REM Command file for Sphinx documentation
-
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+    set SPHINXBUILD=sphinx-build
 )
+
 set SOURCEDIR=source
 set BUILDDIR=_build
 set SPHINXOPTS=-j auto -w build_errors.txt -N -q
@@ -16,35 +16,53 @@ set SPHINXOPTS=-j auto -w build_errors.txt -N -q
 if "%1" == "" goto help
 if "%1" == "clean" goto clean
 
+REM Check if sphinx-build command exists
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
-	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
-	exit /b 1
+    echo.
+    echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+    echo.installed, then set the SPHINXBUILD environment variable to point
+    echo.to the full path of the 'sphinx-build' executable. Alternatively you
+    echo.may add the Sphinx directory to PATH.
+    echo.
+    echo.If you don't have Sphinx installed, grab it from
+    echo.http://sphinx-doc.org/
+    exit /b 1
 )
 
-%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+REM Check if BUILD_ALL_DOCS is set, and if so, skip Python script execution
+if defined BUILD_ALL_DOCS (
+    echo BUILD_ALL_DOCS is set. Skipping Python script execution.
+) else (
+    REM Build documentation with Sphinx by generating RST files
+    python api_rstgen.py
+    python doc/datamodel_rstgen.py
+    python doc/tui_rstgen.py
+    python doc/settings_rstgen.py
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end
 
 :clean
-rmdir /s /q %BUILDDIR% > /NUL 2>&1
-del /q %SOURCEDIR%\examples\* > /NUL 2>&1
-rmdir /s /q %SOURCEDIR%\api\meshing\datamodel > /NUL 2>&1
-rmdir /s /q %SOURCEDIR%\api\meshing\tui > /NUL 2>&1
-rmdir /s /q %SOURCEDIR%\api\solver\datamodel > /NUL 2>&1
-rmdir /s /q %SOURCEDIR%\api\solver\tui > /NUL 2>&1
+echo Cleaning build directories...
+rmdir /s /q %BUILDBIR% > NUL 2>&1
+del /q %SOURCEDIR%\examples\* > NUL 2>&1
+rmdir /s /q %SOURCEDIR%\api\meshing\datamodel > NUL 2>&1
+rmdir /s /q %SOURCEDIR%\api\meshing\tui > NUL 2>&1
+rmdir /s /q %SOURCEDIR%\api\solver\datamodel > NUL 2>&1
+rmdir /s /q %SOURCEDIR%\api\solver\tui > NUL 2>&1
+
 for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
-del build_errors.txt > /NUL 2>&1
+del build_errors.txt > NUL 2>&1
 goto end
 
 :help
-%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+echo.
+echo Usage: makefile.bat [clean|other_commands]
+echo.
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
 
 :end
 popd

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -32,13 +32,13 @@ if errorlevel 9009 (
 
 REM Check if BUILD_ALL_DOCS is set, and if so, skip Python script execution
 if defined BUILD_ALL_DOCS (
-    echo BUILD_ALL_DOCS is set. Skipping Python script execution.
-) else (
-    REM Build documentation with Sphinx by generating RST files
+	REM Build documentation with Sphinx by generating RST files
     python api_rstgen.py
-    python doc/datamodel_rstgen.py
-    python doc/tui_rstgen.py
-    python doc/settings_rstgen.py
+    python datamodel_rstgen.py
+    python tui_rstgen.py
+    python settings_rstgen.py
+) else (
+    echo BUILD_ALL_DOCS is not set. Skipping RST file generation.
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -46,6 +46,8 @@ To build the PyFluent documentation locally, run the following commands in the r
 
     pip install ansys-fluent-core[docs]
     cd doc
+    set BUILD_ALL_DOCS=1
+    set FLUENT_IMAGE_TAG=v0.25.1
     make html
 
 After the build completes, the HTML documentation is located in the


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3480

No need to execute following scripts manually to build all docs locally.

```
python doc/api_rstgen.py
python doc/datamodel_rstgen.py
python doc/tui_rstgen.py
python doc/settings_rstgen.py
```

Just execute the following commands to build all docs locally.

```
pip install ansys-fluent-core[docs]
cd doc
set BUILD_ALL_DOCS=1
set FLUENT_IMAGE_TAG=v0.25.1
make html

```
