### PR TITLE
fix: Dimensionality correction in PIM launcher

### DIFF
--- a/doc/changelog.d/3673.fixed.md
+++ b/doc/changelog.d/3673.fixed.md
@@ -1,0 +1,1 @@
+Dimensionality correction in PIM launcher

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -229,7 +229,7 @@ def launch_remote_fluent(
         product_name=(
             "fluent-meshing"
             if FluentMode.is_meshing(mode)
-            else "fluent-2ddp" if dimensionality == "2d" else "fluent-3ddp"
+            else "fluent-2ddp" if dimensionality == Dimension.TWO else "fluent-3ddp"
         ),
         product_version=product_version,
     )


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3672

Earlier - 

![image](https://github.com/user-attachments/assets/495b844a-1caa-4b3d-9832-2dba80e0f0db)

Now - 

![image](https://github.com/user-attachments/assets/b559dfa5-a984-4175-9090-970a9c46dba3)
