### PR TITLE
refactor: Raise an exception for Python journaling in 22R2

### DIFF
--- a/doc/changelog.d/3684.miscellaneous.md
+++ b/doc/changelog.d/3684.miscellaneous.md
@@ -1,0 +1,1 @@
+Raise an exception for Python journaling in 22R2

--- a/src/ansys/fluent/core/journaling.py
+++ b/src/ansys/fluent/core/journaling.py
@@ -1,6 +1,16 @@
 """A module for controlling the writing of Fluent Python journals."""
 
 
+class PythonJournalNotSupported(RuntimeError):
+    """Raised when Python journal is unsupported."""
+
+    def __init__(self):
+        """Initialize PythonJournalNotSupported."""
+        super().__init__(
+            "Python journaling is available in Fluent version 2023 R1 or later."
+        )
+
+
 class Journal:
     """Control the writing of Fluent Python journals."""
 
@@ -8,10 +18,16 @@ class Journal:
         """__init__ method of Journal class."""
         self._app_utilities = app_utilities
 
+    def _check_python_journaling_support(self):
+        if self._app_utilities.get_product_version() == "22.2.0":
+            raise PythonJournalNotSupported()
+
     def start(self, file_name: str):
         """Start writing a Fluent Python journal at the specified file_name."""
+        self._check_python_journaling_support()
         self._app_utilities.start_python_journal(journal_name=file_name)
 
     def stop(self):
         """Stop writing the Fluent Python journal."""
+        self._check_python_journaling_support()
         self._app_utilities.stop_python_journal()


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3059

Python journaling is available in Fluent version 2023 R1 or later. 

**Earlier**

```
>>> import os
>>> os.environ["PYFLUENT_FLUENT_ROOT"] = r"D:\Installations\Ansys\v222_07082024\ANSYS Inc\v222\fluent"
>>> import ansys.fluent.core as ppf
>>> solver = ppf.launch_fluent()
>>> solver.journal.start("test_222_jou.py") 

Error: eval: unbound variable
Error Object: api-start-python-journal
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 13, in start
    self._app_utilities.start_python_journal(journal_name=file_name)
  File "D:\pyfluent\src\ansys\fluent\core\services\app_utilities.py", line 189, in start_python_journal
    self.scheme_eval.exec([f'(api-start-python-journal "{journal_name}")'])
  File "D:\pyfluent\src\ansys\fluent\core\services\scheme_eval.py", line 303, in exec
    response = self.service.exec(request)
  File "D:\pyfluent\src\ansys\fluent\core\services\scheme_eval.py", line 64, in exec
    return self.__stub.Exec(request, metadata=self.__metadata)
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 277, in __call__
    response, ignored_call = self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 343, in with_call
    return self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 343, in with_call
    return self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 1198, in with_call
    return _end_unary_response_blocking(state, call, True, None)
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 1006, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNKNOWN
        details = "Error Occurred!"
        debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2025-01-29T08:55:57.8398036+00:00", grpc_status:2, grpc_message:"Error Occurred!"}"
>
>>> solver.journal.stop("test_222_jou.py")  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Journal.stop() takes 1 positional argument but 2 were given
>>> solver.journal.stop()                  

Error: eval: unbound variable
Error Object: api-stop-python-journal
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 17, in stop
    self._app_utilities.stop_python_journal()
  File "D:\pyfluent\src\ansys\fluent\core\services\app_utilities.py", line 210, in stop_python_journal
    self.scheme_eval.exec(["(api-stop-python-journal)"])
  File "D:\pyfluent\src\ansys\fluent\core\services\scheme_eval.py", line 303, in exec
    response = self.service.exec(request)
  File "D:\pyfluent\src\ansys\fluent\core\services\scheme_eval.py", line 64, in exec
    return self.__stub.Exec(request, metadata=self.__metadata)
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 277, in __call__
    response, ignored_call = self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 343, in with_call
    return self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 343, in with_call
    return self._with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 332, in _with_call
    return call.result(), call
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 440, in result
    raise self
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_interceptor.py", line 315, in continuation
    response, call = self._thunk(new_method).with_call(
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 1198, in with_call
    return _end_unary_response_blocking(state, call, True, None)
  File "D:\virtual_envs\pyfluent-api\lib\site-packages\grpc\_channel.py", line 1006, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNKNOWN
        details = "Error Occurred!"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Error Occurred!", grpc_status:2, created_time:"2025-01-29T09:01:22.6889836+00:00"}"
>
>>>
```

**Now**

```
>>> import os
>>> os.environ["PYFLUENT_FLUENT_ROOT"] = r"D:\Installations\Ansys\v222_07082024\ANSYS Inc\v222\fluent"
>>> import ansys.fluent.core as ppf
>>> solver = ppf.launch_fluent()
>>> solver.journal.start(test_222_jou.py)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'test_222_jou' is not defined
>>> solver.journal.start("test_222_jou.py")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 25, in start
    self._check_python_journaling_support()
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 21, in _check_python_journaling_support
    raise PythonJournalNotSupported()
ansys.fluent.core.journaling.PythonJournalNotSupported: Python journaling is available in Fluent version 2023 R1 or later.
>>>                                             
>>> solver.journal.stop()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 30, in stop
    self._check_python_journaling_support()
  File "D:\pyfluent\src\ansys\fluent\core\journaling.py", line 21, in _check_python_journaling_support
    raise PythonJournalNotSupported()
ansys.fluent.core.journaling.PythonJournalNotSupported: Python journaling is available in Fluent version 2023 R1 or later.
>>>       
>>> solver.exit()
>>> 
```