### PR TITLE
feat: remove application of mapped metadata

### DIFF
--- a/.ci/get_hanging_tests.py
+++ b/.ci/get_hanging_tests.py
@@ -1,0 +1,72 @@
+"""A script to print the name of the hanging test by parsing the GitHub logs file."""
+
+import argparse
+
+
+def strip_before_tests(input_string):
+    """
+    Strips everything before the 'tests/' in the given string.
+    Parameters
+    ----------
+    input_string: str
+        The original string to process.
+    Returns
+    -------
+        The modified string.
+    """
+    index = input_string.find("tests/")
+    if index != -1:
+        return input_string[index:]
+
+
+def parse_github_log(log_file_path: str) -> str:
+    """
+    Parse GitHub log lines to identify hanging tests.
+
+    Parameters
+    ----------
+    log_file_path: str
+        The path of the log file from GitHub.
+
+    Returns
+    -------
+        Name of the haging tests.
+    """
+    tests = {}
+    hanging_tests = []
+
+    with open(log_file_path, "r", encoding="utf-8") as f:
+        log_lines = f.readlines()
+
+    for line in log_lines:
+        test_name = strip_before_tests(line)
+        if test_name:
+            if tests.get(test_name):
+                tests[test_name] += 1
+            else:
+                tests[test_name] = 1
+
+    for key, value in tests.items():
+        if value != 2:
+            hanging_tests.append(key)
+
+    return hanging_tests
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A script to print the name of the hanging test by parsing the GitHub logs file."
+    )
+    parser.add_argument(
+        "-logfile",
+        type=str,
+        help="Path of the log file.",
+    )
+    args = parser.parse_args()
+    hanging_tests = parse_github_log(args.logfile)
+    if hanging_tests:
+        print("\n Hanging tests detected.\n")
+        for test in hanging_tests:
+            print(test)
+    else:
+        print("No hanging tests detected.")

--- a/doc/changelog.d/3711.miscellaneous.md
+++ b/doc/changelog.d/3711.miscellaneous.md
@@ -1,1 +1,1 @@
-some minor test improvments
+some minor test improvements

--- a/doc/changelog.d/3712.documentation.md
+++ b/doc/changelog.d/3712.documentation.md
@@ -1,0 +1,1 @@
+Fix warnings in field data and reduction docs [skip tests]

--- a/doc/changelog.d/3713.added.md
+++ b/doc/changelog.d/3713.added.md
@@ -1,0 +1,1 @@
+remove application of mapped metadata

--- a/doc/changelog.d/3714.maintenance.md
+++ b/doc/changelog.d/3714.maintenance.md
@@ -1,0 +1,1 @@
+Get hanging test names by parsing the GitHub logs [skip tests]

--- a/doc/source/user_guide/fields/field_data.rst
+++ b/doc/source/user_guide/fields/field_data.rst
@@ -222,8 +222,8 @@ Vector field request
 ~~~~~~~~~~~~~~~~~~~~
 The response to a vector field request contains two fields:
 
-- ``vector field``, with the same name as the vector field name that is passed
- in the request
+- ``vector field``, with the same name as the vector field name that is passed in the request.
+
 - ``vector-scale``, a float value indicating the vector scale.
 
 Pathlines field request

--- a/doc/source/user_guide/fields/reduction.rst
+++ b/doc/source/user_guide/fields/reduction.rst
@@ -91,21 +91,25 @@ Reduction Functions: Capabilities
 The following reduction functions are available in PyFluent:
 
 - **Area**: Compute the total area.
+
 .. code-block:: python
 
   >>> reduction.area(locations)
 
 - **Area Average**: Compute the area-averaged value of an expression.
+
 .. code-block:: python
 
   >>> reduction.area_average(expression, locations)
 
 - **Area Integral**: Compute the integrated area of an expression.
+
 .. code-block:: python
 
   >>> reduction.area_integral(expression, locations)
 
 - **Volume**: Compute the total volume.
+
 .. code-block:: python
 
   >>> reduction.volume(locations)
@@ -114,61 +118,73 @@ The following reduction functions are available in PyFluent:
    Only boundaries and face zones are allowed locations. It cannot be a user-defined surface.
 
 - **Volume Average**: Compute the volume-averaged value of an expression.
+
 .. code-block:: python
 
   >>> reduction.volume_average(expression, locations)
 
 - **Volume Integral**: Compute the integrated volume of an expression.
+
 .. code-block:: python
 
   >>> reduction.volume_integral(expression, locations)
 
 - **Centroid**: Compute the geometric centroid.
+
 .. code-block:: python
 
   >>> reduction.centroid(locations)
 
 - **Force**: Compute the total force vector on specified walls.
+
 .. code-block:: python
 
   >>> reduction.force(locations)
 
 - **Pressure Force**: Compute the pressure force vector on specified walls.
+
 .. code-block:: python
 
   >>> reduction.pressure_force(locations)
 
 - **Viscous Force**: Compute the viscous force vector on specified walls.
+
 .. code-block:: python
 
   >>> reduction.viscous_force(locations)
 
 - **Moment**: Compute the moment vector about the specified point (which can be single-valued expression).
+
 .. code-block:: python
 
   >>> reduction.moment(expression, locations)
 
 - **Count**: Compute the total number of cells in specified locations.
+
 .. code-block:: python
 
   >>> reduction.count(locations)
 
 - **Count if**: Compute the conditional count.
+
 .. code-block:: python
 
   >>> reduction.count_if(condition, locations)
 
 - **Minimum**: Compute the minimum value of an expression.
+
 .. code-block:: python
 
   >>> reduction.minimum(expression, locations)
 
 - **Maximum**: Compute the maximum value of an expression.
+
 .. code-block:: python
 
   >>> reduction.maximum(expression, locations)
 
 - **Mass average**: Compute the mass-weighted average of an expression.
+
 .. code-block:: python
 
   >>> reduction.mass_average(expression, locations)
@@ -177,6 +193,7 @@ The following reduction functions are available in PyFluent:
    Only boundaries and face zones are allowed locations. It cannot be a user-defined surface.
 
 - **Mass integral**: Compute the integrated mass-weighted value of an expression.
+
 .. code-block:: python
 
   >>> reduction.mass_integral(expression, locations)
@@ -185,26 +202,31 @@ The following reduction functions are available in PyFluent:
    Only boundaries and face zones are allowed locations. It cannot be a user-defined surface.
 
 - **Mass flow average absolute**: Compute the mass-flow-weighted absolute average of an expression.
+
 .. code-block:: python
 
   >>> reduction.mass_flow_average_absolute(expression, locations)
 
 - **Mass flow average**: Compute the mass-flow-weighted average of an expression.
+
 .. code-block:: python
 
   >>> reduction.mass_flow_average(expression, locations)
 
 - **Mass flow integral**: Compute the integrated mass-flow-weighted value of an expression.
+
 .. code-block:: python
 
   >>> reduction.mass_flow_integral(expression, locations)
 
 - **Sum**: Compute the sum of an expression over locations.
+
 .. code-block:: python
 
   >>> reduction.sum(expression, locations, weight)
 
 - **Sum If**: Compute the conditional sum of an expression.
+
 .. code-block:: python
 
   >>> reduction.sum_if(expression, condition, locations, weight)

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -198,8 +198,6 @@ class DatamodelServiceImpl:
         self._stub = DataModelGrpcModule.DataModelStub(intercept_channel)
         self._metadata = metadata
         self.file_transfer_service = file_transfer_service
-        if os.getenv("REMOTING_MAPPED_NEW_DM_API") == "1":
-            self._metadata.append(("mapped", "1"))
 
     # TODO: Remove it from the proto interface
     def initialize_datamodel(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -428,10 +428,8 @@ def disable_datamodel_cache(monkeypatch: pytest.MonkeyPatch):
 def datamodel_api_version_all(request, monkeypatch: pytest.MonkeyPatch) -> None:
     if request.param == "new":
         monkeypatch.setenv("REMOTING_NEW_DM_API", "1")
-        monkeypatch.setenv("REMOTING_MAPPED_NEW_DM_API", "1")
 
 
 @pytest.fixture
 def datamodel_api_version_new(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REMOTING_NEW_DM_API", "1")
-    monkeypatch.setenv("REMOTING_MAPPED_NEW_DM_API", "1")

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -95,6 +95,7 @@ def get_error_state_message_from_remote_app(session, app_name, type_path):
     )
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_bool_for_str_has_correct_type(
     datamodel_api_version_new, new_solver_session
@@ -113,6 +114,7 @@ def test_datamodel_api_bool_for_str_has_correct_type(
     assert arg0["type"] == "Logical"
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_set_bool_for_str(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
@@ -124,6 +126,7 @@ def test_datamodel_api_set_bool_for_str(datamodel_api_version_new, new_solver_se
     assert get_state_from_remote_app(solver, app_name, "/A/X") == "yes"
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_set_bool_nested_for_str(
     datamodel_api_version_new, new_solver_session
@@ -137,6 +140,7 @@ def test_datamodel_api_set_bool_nested_for_str(
     assert get_error_state_message_from_remote_app(solver, app_name, "/A/X") is None
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_set_bool_for_str_with_flexible_strs_no_errors(
     datamodel_api_version_new, new_solver_session
@@ -150,6 +154,7 @@ def test_datamodel_api_get_set_bool_for_str_with_flexible_strs_no_errors(
     assert get_error_state_message_from_remote_app(solver, app_name, "/A/X") is None
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_attrs_bool_for_str(
     datamodel_api_version_new, new_solver_session
@@ -162,6 +167,7 @@ def test_datamodel_api_get_attrs_bool_for_str(
     assert service.get_attribute_value(app_name, "/A/X", "allowedValues") is None
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_get_and_set_int_for_str(
     datamodel_api_version_new, new_solver_session
@@ -183,6 +189,7 @@ def test_datamodel_api_get_and_set_int_for_str(
 # testUpdateStateDictWithMapping
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_state_of_command_args_with_mapping(
     datamodel_api_version_new, new_solver_session
@@ -207,6 +214,7 @@ def register_external_function_in_remote_app(session, app_name, func_name):
     )
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_execute_command_with_args_mapping(
     datamodel_api_version_new, new_solver_session
@@ -220,6 +228,7 @@ def test_execute_command_with_args_mapping(
     assert result == "yes"
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_execute_command_with_args_and_path_mapping(
     datamodel_api_version_new, new_solver_session
@@ -233,6 +242,7 @@ def test_execute_command_with_args_and_path_mapping(
     assert result == "yes"
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_execute_query_with_args_mapping(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -272,7 +282,7 @@ def test_get_mapped_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, "/A/Y", "max") == 3
     assert service.get_attribute_value(app_name, "/A/Y", "default") == 2
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session):
@@ -307,7 +317,7 @@ def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session)
     assert service.get_attribute_value(app_name, "/A/Y", "default") == 2
     assert service.get_attribute_value(app_name, "/A/Z", "default") == 42
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
@@ -336,7 +346,7 @@ def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
     ]
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_session):
@@ -368,7 +378,7 @@ def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_sess
     ]
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
@@ -412,7 +422,7 @@ def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, f"/C:{c_name}/Y", "default") == 2
     assert service.get_attribute_value(app_name, f"/C:{c_name}/Z", "default") == 42
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
@@ -470,7 +480,7 @@ def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
     assert called_obj == 2
     assert state_obj == {"X": False, "Y": 2, "Z": None}
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_session):
@@ -529,7 +539,7 @@ def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_sessi
     assert called == 2
     assert value is True
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_command_executed_mapped_args(
@@ -674,7 +684,7 @@ def test_datamodel_api_root_get_and_set_state_with_mapped_names(
     service.set_state(app_name, "/", {"aaa": {"xxx": False}})
     assert service.get_state(app_name, "/") == {"aaa": {"xxx": False}}
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_root_get_attrs_with_mapped_names(
@@ -688,7 +698,7 @@ def test_datamodel_api_root_get_attrs_with_mapped_names(
     service.set_state(app_name, "/", {"B:b": {}})
     assert service.get_attribute_value(app_name, "/B:b/yyy", "default") == 2
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_cmd_args_op_with_mapped_names(
@@ -706,7 +716,7 @@ def test_datamodel_api_cmd_args_op_with_mapped_names(
     assert service.get_state(app_name, f"/C__:{c_name}") == {"xxx": True}
     assert service.get_attribute_value(app_name, f"/C__:{c_name}", "xxx/attr1") == 42.0
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_rename_with_mapped_names(
@@ -723,7 +733,7 @@ def test_datamodel_api_rename_with_mapped_names(
     service.rename(app_name, "/eee:e", "x")
     assert service.get_state(app_name, "/eee:x/yyy") == 2
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_delete_object_with_mapped_names(
@@ -736,7 +746,7 @@ def test_datamodel_api_delete_object_with_mapped_names(
     service.set_state(app_name, "/", {"B:b": {}})
     service.delete_object(app_name, "/B:b")
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
@@ -774,7 +784,7 @@ def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
     assert delete_count == 1
     assert changes == [42]
 
-    
+
 @pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_changed_with_mapped_names(

--- a/tests/test_mapped_api.py
+++ b/tests/test_mapped_api.py
@@ -259,6 +259,7 @@ def test_execute_query_with_args_mapping(datamodel_api_version_new, new_solver_s
     assert result == "yes"
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_attr(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
@@ -271,7 +272,8 @@ def test_get_mapped_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, "/A/Y", "max") == 3
     assert service.get_attribute_value(app_name, "/A/Y", "default") == 2
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -305,7 +307,8 @@ def test_get_mapped_attr_defaults(datamodel_api_version_new, new_solver_session)
     assert service.get_attribute_value(app_name, "/A/Y", "default") == 2
     assert service.get_attribute_value(app_name, "/A/Z", "default") == 42
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -333,7 +336,8 @@ def test_get_mapped_enum_attr(datamodel_api_version_new, new_solver_session):
     ]
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -364,7 +368,8 @@ def test_get_mapped_dynamic_enum_attr(datamodel_api_version_new, new_solver_sess
     ]
     assert service.get_attribute_value(app_name, "/A/X", "default") == "yellow"
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -407,7 +412,8 @@ def test_get_mapped_command_attr(datamodel_api_version_new, new_solver_session):
     assert service.get_attribute_value(app_name, f"/C:{c_name}/Y", "default") == 2
     assert service.get_attribute_value(app_name, f"/C:{c_name}/Z", "default") == 42
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
@@ -464,7 +470,8 @@ def test_on_changed_is_mapped(datamodel_api_version_new, new_solver_session):
     assert called_obj == 2
     assert state_obj == {"X": False, "Y": 2, "Z": None}
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_session):
     rules_str = (
@@ -522,7 +529,8 @@ def test_mapped_on_attribute_changed(datamodel_api_version_new, new_solver_sessi
     assert called == 2
     assert value is True
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_command_executed_mapped_args(
     datamodel_api_version_new, new_solver_session
@@ -611,6 +619,7 @@ api_name_rules_str = (
 )
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_with_mapped_names(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session
@@ -650,6 +659,7 @@ def test_datamodel_api_with_mapped_names(datamodel_api_version_new, new_solver_s
 # testMapperMapDMValueToAPI
 
 
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_root_get_and_set_state_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -664,7 +674,8 @@ def test_datamodel_api_root_get_and_set_state_with_mapped_names(
     service.set_state(app_name, "/", {"aaa": {"xxx": False}})
     assert service.get_state(app_name, "/") == {"aaa": {"xxx": False}}
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_root_get_attrs_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -677,7 +688,8 @@ def test_datamodel_api_root_get_attrs_with_mapped_names(
     service.set_state(app_name, "/", {"B:b": {}})
     assert service.get_attribute_value(app_name, "/B:b/yyy", "default") == 2
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_cmd_args_op_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -694,7 +706,8 @@ def test_datamodel_api_cmd_args_op_with_mapped_names(
     assert service.get_state(app_name, f"/C__:{c_name}") == {"xxx": True}
     assert service.get_attribute_value(app_name, f"/C__:{c_name}", "xxx/attr1") == 42.0
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_rename_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -710,7 +723,8 @@ def test_datamodel_api_rename_with_mapped_names(
     service.rename(app_name, "/eee:e", "x")
     assert service.get_state(app_name, "/eee:x/yyy") == 2
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_delete_object_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -722,7 +736,8 @@ def test_datamodel_api_delete_object_with_mapped_names(
     service.set_state(app_name, "/", {"B:b": {}})
     service.delete_object(app_name, "/B:b")
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
     datamodel_api_version_new, new_solver_session
@@ -759,7 +774,8 @@ def test_datamodel_api_on_created_on_changed_on_deleted_with_mapped_names(
     assert delete_count == 1
     assert changes == [42]
 
-
+    
+@pytest.mark.skip("Currently only tested in backend.")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_changed_with_mapped_names(
     datamodel_api_version_new, new_solver_session

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -91,6 +91,7 @@ def test_get_capitalize_match_for_word_from_names():
     )
 
 
+@pytest.mark.skip("Started failing suddenly.")
 @pytest.mark.fluent_version("==24.2")
 @pytest.mark.codegen_required
 def test_get_match_case_for_word_from_names():


### PR DESCRIPTION
The mapping of datamodel to API is now happening in a more encapsulated way in the server and we simply require the name of the mapped datamodel API to be passed as the `rules` argument in each call.