### PR TITLE
chore: Move pyansys-tools-report dependency from pyproject.toml to CI step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	@pip install -r requirements/requirements_build.txt
 	@flit build
 	@pip install -q --force-reinstall dist/*.whl
+	@pip install pyansys-tools-report>=0.8.1
 	@python src/ansys/fluent/core/report.py
 
 install-test:

--- a/doc/changelog.d/3735.maintenance.md
+++ b/doc/changelog.d/3735.maintenance.md
@@ -1,0 +1,1 @@
+Move pyansys-tools-report dependency from pyproject.toml to CI step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "nltk>=3.9.1",
     "numpy>=1.14.0,<3.0.0",
     "pandas>=1.1.0,<2.3",
-    "pyansys-tools-report>=0.8.1",
     "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
As the vtk version (pyansys-tools-report dependency) is not available on ARM platform