### PR TITLE
refactor: Revert the new dm api as default.

### DIFF
--- a/doc/changelog.d/3742.miscellaneous.md
+++ b/doc/changelog.d/3742.miscellaneous.md
@@ -1,0 +1,1 @@
+Revert the new dm api as default.

--- a/src/ansys/fluent/core/launcher/launcher_utils.py
+++ b/src/ansys/fluent/core/launcher/launcher_utils.py
@@ -64,7 +64,6 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any], argvals) -> Dict[str,
     if pyfluent.CLEAR_FLUENT_PARA_ENVS:
         del fluent_env["PARA_NPROCS"]
         del fluent_env["PARA_MESH_NPROCS"]
-    fluent_env["REMOTING_NEW_DM_API"] = "1"
 
     if pyfluent.LAUNCH_FLUENT_IP:
         fluent_env["REMOTING_SERVER_ADDRESS"] = pyfluent.LAUNCH_FLUENT_IP


### PR DESCRIPTION
Revert the new dm api as default. 
There will be a separate branch with this change so that no PyFluent version is released with this as of now.