### PR TITLE
docs: Update cheat sheet link [skip tests]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,8 @@ In the upper right corner of the documentation's title bar, there is an option f
 viewing the documentation for the latest stable release to viewing the documentation for the
 development version or previously released versions.
 
-You can also `view <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.png>`_ or
-`download <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf>`_ the
+You can also `view <https://fluent.docs.pyansys.com/version/stable/_static/cheat_sheet.pdf>`_ or
+`download <https://fluent.docs.pyansys.com/version/stable/_static/cheat_sheet.pdf>`_ the
 PyFluent cheat sheet. This one-page reference provides syntax rules and commands
 for using PyFluent.
 

--- a/doc/changelog.d/3772.documentation.md
+++ b/doc/changelog.d/3772.documentation.md
@@ -1,1 +1,1 @@
-Update cheat sheet link [skip docs]
+Update cheat sheet link [skip tests]

--- a/doc/changelog.d/3772.documentation.md
+++ b/doc/changelog.d/3772.documentation.md
@@ -1,0 +1,1 @@
+Update cheat sheet link [skip docs]


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3771

Current link points to https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.png and https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf

Now it will point to https://fluent.docs.pyansys.com/version/stable/_static/cheat_sheet.pdf.