### PR TITLE
build: Bump version to v0.30.dev3

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -62,7 +62,7 @@ from ansys.fluent.core.utils import fldoc, get_examples_download_dir
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
 
-__version__ = "0.30.dev2"
+__version__ = "0.30.dev3"
 
 _VERSION_INFO = None
 """


### PR DESCRIPTION
Bump version to v0.30.dev3.

This will test the PyConsole locally and will lead into v0.30.0 to be integrated with PyConsole.