### PR TITLE
fix: Keep switch-to-meshing as hidden to fix Fluent journal replay.

### DIFF
--- a/doc/changelog.d/3792.fixed.md
+++ b/doc/changelog.d/3792.fixed.md
@@ -1,0 +1,1 @@
+Keep switch-to-meshing as hidden to fix Fluent journal replay.

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -364,7 +364,7 @@ class TUIMenu:
         ]
 
     def __getattribute__(self, name) -> Any:
-        if name in ["exit", "switch_to_meshing_mode"] and not self._path:
+        if name in ["exit"] and not self._path:
             raise AttributeError(
                 f"'{self.__class__.__name__}' object has no attribute '{name}'"
             )

--- a/tests/test_tui_api.py
+++ b/tests/test_tui_api.py
@@ -86,7 +86,14 @@ def test_exit_not_in_meshing_tui(new_meshing_session):
 def test_commands_not_in_solver_tui(new_solver_session):
     solver = new_solver_session
 
-    for command in ["exit", "switch_to_meshing_mode"]:
+    deleted_commands = ["exit"]
+    hidden_commands = ["switch_to_meshing_mode"]
+
+    for command in deleted_commands:
         assert command not in dir(solver.tui)
         with pytest.raises(AttributeError):
             getattr(solver.tui, command)
+
+    for command in hidden_commands:
+        assert command not in dir(solver.tui)
+        assert getattr(solver.tui, command)


### PR DESCRIPTION
Keep `solver.tui.switch_to_meshing_mode` as hidden as it is expected in Fluent journals.

Fluent bug id - 1218147