### PR TITLE
fix: Fix python_name issue in runtime python classes

### DIFF
--- a/doc/changelog.d/3797.fixed.md
+++ b/doc/changelog.d/3797.fixed.md
@@ -1,0 +1,1 @@
+Fix python_name issue in runtime python classes

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,17 +1,22 @@
 {% if sections[""] %}
-{% for category, val in definitions.items() if category in sections[""] %}
 
-{{ definitions[category]['name'] }}
-{% set underline = '^' * definitions[category]['name']|length %}
-{{ underline }}
+.. tab-set::
+
+{%+ for category, val in definitions.items() if category in sections[""] %}
+
+  .. tab-item:: {{ definitions[category]['name'] }}
+
+    .. list-table::
+        :header-rows: 0
+        :widths: auto
 
 {% for text, values in sections[""][category].items() %}
-- {{ text }} {{ values|join(', ') }}
-{% endfor %}
+        * - {{ text }}
+          - {{ values|join(', ') }}
 
 {% endfor %}
+{% endfor %}
+
 {% else %}
 No significant changes.
-
-
 {% endif %}

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,22 +1,17 @@
 {% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
 
-.. tab-set::
-
-{%+ for category, val in definitions.items() if category in sections[""] %}
-
-  .. tab-item:: {{ definitions[category]['name'] }}
-
-    .. list-table::
-        :header-rows: 0
-        :widths: auto
+{{ definitions[category]['name'] }}
+{% set underline = '^' * definitions[category]['name']|length %}
+{{ underline }}
 
 {% for text, values in sections[""][category].items() %}
-        * - {{ text }}
-          - {{ values|join(', ') }}
-
-{% endfor %}
+- {{ text }} {{ values|join(', ') }}
 {% endfor %}
 
+{% endfor %}
 {% else %}
 No significant changes.
+
+
 {% endif %}

--- a/doc/source/contributing/environment_variables.rst
+++ b/doc/source/contributing/environment_variables.rst
@@ -55,6 +55,8 @@ Following is a list of environment variables that can be set to control various 
       - Disables printing of TUI to settings API upgrade advice.
     * - PYFLUENT_TIMEOUT_FORCE_EXIT
       - Enables force exit while exiting a Fluent session and specifies the timeout in seconds.
+    * - PYFLUENT_USE_RUNTIME_PYTHON_CLASSES
+      - Uses runtime Python classes for settings API.
     * - PYFLUENT_WATCHDOG_DEBUG
       - Enables debugging for the PyFluent watchdog process.
     * - PYFLUENT_WATCHDOG_EXCEPTION_ON_ERROR

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -200,10 +200,10 @@ def _get_python_path_comps(obj):
     """Get python path components for traversing class hierarchy."""
     comps = []
     while obj:
-        python_name = obj._python_name
+        python_name = obj.python_name
         obj = obj._parent
         if isinstance(obj, (NamedObject, ListObject)):
-            comps.append(obj._python_name)
+            comps.append(obj.python_name)
             obj = obj._parent
         else:
             comps.append(python_name)
@@ -1407,7 +1407,7 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
                 )
             raise KeyError(
                 allowed_name_error_message(
-                    context=self.__class__._python_name,
+                    context=self.python_name,
                     trial_name=name,
                     allowed_values=self.get_object_names(),
                 )
@@ -1960,7 +1960,7 @@ class _NonCreatableNamedObjectMixin(
             else:
                 raise KeyError(
                     allowed_name_error_message(
-                        context=self.__class__._python_name,
+                        context=self.python_name,
                         trial_name=name,
                         allowed_values=self.get_object_names(),
                     )
@@ -2214,15 +2214,19 @@ def get_root(
     """
     from ansys.fluent.core import CODEGEN_OUTDIR, utils
 
-    try:
-        settings = utils.load_module(
-            f"settings_{version}",
-            CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
-        )
-        root_cls = settings.root
-    except FileNotFoundError:
+    if os.getenv("PYFLUENT_USE_RUNTIME_PYTHON_CLASSES") == "1":
         obj_info = flproxy.get_static_info()
         root_cls, _ = get_cls("", obj_info, version=version)
+    else:
+        try:
+            settings = utils.load_module(
+                f"settings_{version}",
+                CODEGEN_OUTDIR / "solver" / f"settings_{version}.py",
+            )
+            root_cls = settings.root
+        except FileNotFoundError:
+            obj_info = flproxy.get_static_info()
+            root_cls, _ = get_cls("", obj_info, version=version)
     root = root_cls()
     root.set_flproxy(flproxy)
     root._set_on_interrupt(interrupt)

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -639,3 +639,24 @@ def test_return_types_of_operations_on_named_objects(mixing_elbow_settings_sessi
     )
     assert var3 == solver.settings.setup.materials.fluid["air-copied"]
     assert var3.obj_name == "air-copied"
+
+
+@pytest.fixture
+def use_runtime_python_classes(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PYFLUENT_USE_RUNTIME_PYTHON_CLASSES", "1")
+
+
+def test_runtime_python_classes(
+    use_runtime_python_classes, mixing_elbow_settings_session
+):
+    solver = mixing_elbow_settings_session
+    solver.setup.materials.database.copy_by_name(type="fluid", name="water-liquid")
+    solver.settings.setup.cell_zone_conditions.fluid["elbow-fluid"] = {
+        "material": "water-liquid"
+    }
+    assert (
+        solver.settings.setup.cell_zone_conditions.fluid[
+            "elbow-fluid"
+        ].general.material()
+        == "water-liquid"
+    )

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -646,6 +646,7 @@ def use_runtime_python_classes(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("PYFLUENT_USE_RUNTIME_PYTHON_CLASSES", "1")
 
 
+@pytest.mark.fluent_version(">=24.2")
 def test_runtime_python_classes(
     use_runtime_python_classes, mixing_elbow_settings_session
 ):


### PR DESCRIPTION
Runtime Python classes for settings API are still supported in Fluent's Python console behind an environment variable. This PR fixes an issue with python-name in the runtime classes.