### PR TITLE
docs: Fix built in settings doc [skip tests]

### DIFF
--- a/doc/changelog.d/3807.documentation.md
+++ b/doc/changelog.d/3807.documentation.md
@@ -1,0 +1,1 @@
+Fix built in settings doc [skip tests]

--- a/doc/source/user_guide/solver_settings/solver_settings_contents.rst
+++ b/doc/source/user_guide/solver_settings/solver_settings_contents.rst
@@ -132,7 +132,7 @@ and ``NamedObject`` types, the state value is a dictionary. For the
   >>> viscous = pyfluent.solver.Viscous(settings_source=solver)
   >>> viscous.model = 'laminar'
   >>> energy = pyfluent.solver.Energy(settings_source=solver)
-  >>> energy = { 'enabled' : False }
+  >>> energy.enabled = False
   >>> inlet1 = pyfluent.solver.VelocityInlet(settings_source=solver, name="inlet1")
   >>> inlet1.vmag.constant = 14
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3806

```
>>> energy = pyfluent.solver.Energy(settings_source=solver)
>>> energy()             
{'enabled': True, 'viscous_dissipation': False, 'pressure_work': False, 'kinetic_energy': False, 'inlet_diffusion': True}
>>> dir(energy)
['__call__', '__class__', '__class_getitem__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__orig_bases__', '__parameters__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasshook__', '__weakref__', '_add_units_to_state', '_check_stable', '_child_alias_objs', '_child_aliases', '_child_classes', '_file_transfer_handler', '_file_transfer_service', '_flproxy', '_is_protocol', '_name', '_parent', '_print_state_helper', '_python_name', '_root', '_set_file_transfer_service', '_set_on_interrupt', '_setattr', '_state_type', '_while_creating', '_while_deleting', '_while_executing_command', '_while_renaming', '_while_resizing', '_while_setting_state', 'after_execute', 'before_execute', 'child_names', 'command_names', 'enabled', 'find_object', 'flproxy', 'fluent_name', 'get_active_child_names', 'get_active_command_names', 'get_active_query_names', 'get_attr', 'get_attrs', 'get_completer_info', 'get_state', 'inlet_diffusion', 'is_active', 'is_read_only', 'kinetic_energy', 'obj_name', 'parent', 'path', 'pressure_work', 'print_state', 'python_name', 'python_path', 'query_names', 'set_flproxy', 'set_state', 'settings_source', 'state_with_units', 'to_python_keys', 'to_scheme_keys', 'two_temperature', 'version', 'viscous_dissipation']
>>> energy.enabled = False
>>> energy()
{'enabled': False}
```