### PR TITLE
feat: Remove lxml

### DIFF
--- a/doc/changelog.d/3832.added.md
+++ b/doc/changelog.d/3832.added.md
@@ -1,0 +1,1 @@
+Remove lxml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "grpcio>=1.30.0",
     "grpcio-health-checking>=1.30.0",
     "grpcio-status>=1.26.0",
-    "lxml>=4.9.2",
     "nltk>=3.9.1",
     "numpy>=1.14.0,<3.0.0",
     "pandas>=1.1.0,<2.3",

--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -46,7 +46,6 @@ from pathlib import Path
 from typing import Dict, List
 import xml.etree.ElementTree as ET
 
-from lxml import etree
 import numpy as np
 
 from ansys.fluent.core.solver.error_message import allowed_name_error_message
@@ -732,8 +731,7 @@ def _get_processed_string(input_string: bytes) -> str:
 
 
 def _get_case_file_name_from_flprj(flprj_file):
-    parser = etree.XMLParser(recover=True)
-    tree = ET.parse(flprj_file, parser)
+    tree = ET.parse(flprj_file)
     root = tree.getroot()
     folder_name = root.find("Metadata").find("CurrentSimulation").get("value")[5:-1]
     # If the project file name begins with a digit then the node to find will be prepended

--- a/src/ansys/fluent/core/filereader/data_file.py
+++ b/src/ansys/fluent/core/filereader/data_file.py
@@ -40,7 +40,6 @@ from os.path import dirname
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-from lxml import etree
 import numpy as np
 
 from . import lispy
@@ -225,8 +224,7 @@ class DataFile:
 
 
 def _get_data_file_name_from_flprj(flprj_file):
-    parser = etree.XMLParser(recover=True)
-    tree = ET.parse(flprj_file, parser)
+    tree = ET.parse(flprj_file)
     root = tree.getroot()
     folder_name = root.find("Metadata").find("CurrentSimulation").get("value")[5:-1]
     return root.find(folder_name).find("Input").find("Case").find("Target").get("value")

--- a/src/ansys/fluent/core/report.py
+++ b/src/ansys/fluent/core/report.py
@@ -64,7 +64,6 @@ dependencies = {
     "grpcio-health-checking": "1.30.0",
     "grpcio-status": "1.30.0",
     "h5py": "3.12.1",
-    "lxml": "4.9.2",
     "nltk": "3.9.1",
     "numpy": "1.14.0,<3.0.0",
     "pandas": "1.1.0,<2.3",


### PR DESCRIPTION
Replace use of a module, `lxml` with `xml` from the standard library. The `lxml` package has a known vulnerability.