### PR TITLE
chore: Do not sync labels [skip tests]

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+        sync-labels: false
 
     # Label based on branch name
     - uses: actions-ecosystem/action-add-labels@v1

--- a/doc/changelog.d/3840.maintenance.md
+++ b/doc/changelog.d/3840.maintenance.md
@@ -1,0 +1,1 @@
+Do not sync labels [skip tests]


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3839.

This prevents the action from removing labels that no longer match the configuration file or changes in the pull request.