### PR TITLE
fix: Avoid file name as native Python package

### DIFF
--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -115,7 +115,7 @@ hierarchy = {
         "file_session",
         "fluent_connection",
         "journaling",
-        "logging",
+        "logger",
         "parametric",
         "rpvars",
         "search",

--- a/doc/changelog.d/3861.fixed.md
+++ b/doc/changelog.d/3861.fixed.md
@@ -1,0 +1,1 @@
+Avoid file name as native Python package

--- a/doc/source/cheatsheet/cheat_sheet.qmd
+++ b/doc/source/cheatsheet/cheat_sheet.qmd
@@ -1030,15 +1030,15 @@ solver.journal.stop()
 
 ```{python}
 import ansys.fluent.core as pyfluent
-config_dict = pyfluent.logging.get_default_config()
+config_dict = pyfluent.logger.get_default_config()
 config_dict['handlers']['pyfluent_file'][
     'filename'] = 'test.log'
-pyfluent.logging.enable(custom_config=config_dict)
-pyfluent.logging.list_loggers()
-logger = pyfluent.logging.get_logger(
+pyfluent.logger.enable(custom_config=config_dict)
+pyfluent.logger.list_loggers()
+logger = pyfluent.logger.get_logger(
     'pyfluent.networking')
 logger.setLevel('ERROR')
-pyfluent.logging.set_global_level('DEBUG')
+pyfluent.logger.set_global_level('DEBUG')
 ```
 
 ### API search

--- a/src/ansys/fluent/core/launcher/watchdog_exec
+++ b/src/ansys/fluent/core/launcher/watchdog_exec
@@ -27,17 +27,17 @@ if __name__ == "__main__":
         launcher_pid = int(sys.argv[1])
 
         # Configure logger for Watchdog process
-        log_config = pyfluent.logging.get_default_config()
+        log_config = pyfluent.logger.get_default_config()
         log_config["handlers"]["pyfluent_file"][
             "filename"
         ] = f"pyfluent_watchdog_{watchdog_id}.log"
 
-        logger = pyfluent.logging.get_logger("pyfluent.watchdog")
+        logger = pyfluent.logger.get_logger("pyfluent.watchdog")
 
         if os.getenv("PYFLUENT_WATCHDOG_DEBUG", "OFF").upper() in ("1", "ON"):
-            pyfluent.logging.enable(custom_config=log_config)
+            pyfluent.logger.enable(custom_config=log_config)
             logger.setLevel("DEBUG")
-            logger.handlers = pyfluent.logging.get_logger(
+            logger.handlers = pyfluent.logger.get_logger(
                 "pyfluent.general"
             ).handlers  # using same handlers as already defined
 


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3860

Avoid file name as native Python package, it creates conflicts during imports.