### PR TITLE
feat: codegen for datamodel command arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,7 @@ jobs:
 
   test:
     name: Unit Testing
+    if: ${{ always() }}
     needs: build
     runs-on: [public-ubuntu-latest-8-cores]
     strategy:

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -40,7 +40,7 @@ def _get_file_path(folder_name: str, file_name: str):
 
 
 hierarchy = {
-    "file_reader": ["case_file", "data_file", "lispy"],
+    "filereader": ["case_file", "data_file", "lispy"],
     "launcher": [
         "container_launcher",
         "error_handler",
@@ -127,7 +127,7 @@ hierarchy = {
         "session_solver",
         "session",
         "system_coupling",
-        "warnings",
+        "warning",
         "workflow",
     ],
 }

--- a/doc/changelog.d/3865.added.md
+++ b/doc/changelog.d/3865.added.md
@@ -1,0 +1,1 @@
+codegen for datamodel command arguments

--- a/doc/source/api/api_contents.rst
+++ b/doc/source/api/api_contents.rst
@@ -30,7 +30,7 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     :hidden:
     :caption: ansys.fluent.core
 
-    file_reader/file_reader_contents
+    filereader/filereader_contents
     launcher/launcher_contents
     meshing/meshing_contents
     post_objects/post_objects_contents
@@ -56,5 +56,5 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     session_solver
     session
     system_coupling
-    warnings
+    warning
     workflow

--- a/doc/source/api/api_contents.rst
+++ b/doc/source/api/api_contents.rst
@@ -56,5 +56,5 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     session_solver
     session
     system_coupling
-    warning
+    pyfluent_warnings
     workflow

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -58,7 +58,7 @@ Windows
     quarto install tinytex --no-prompt --update-path
     cd doc
     set BUILD_ALL_DOCS=1
-    set FLUENT_IMAGE_TAG=v0.25.1
+    set FLUENT_IMAGE_TAG=v25.1.0
     make html
 
 Linux
@@ -72,7 +72,7 @@ Linux
     quarto install tinytex --no-prompt --update-path
     cd doc
     set BUILD_ALL_DOCS=1
-    set FLUENT_IMAGE_TAG=v0.25.1
+    set FLUENT_IMAGE_TAG=v25.1.0
     make html
 
 After the build completes, the HTML documentation is located in the

--- a/src/ansys/fluent/core/codegen/datamodelgen.py
+++ b/src/ansys/fluent/core/codegen/datamodelgen.py
@@ -463,10 +463,10 @@ class DataModelGenerator:
                 f"{indent}        class _{k}CommandArguments(PyCommandArguments):\n"
             )
             f.write(
-                f"{indent}            def __init__(self, service, rules, command, path, id, static_info):\n"
+                f"{indent}            def __init__(self, service, rules, command, path, id):\n"
             )
             f.write(
-                f"{indent}                super().__init__(service, rules, command, path, id, static_info)\n"
+                f"{indent}                super().__init__(service, rules, command, path, id)\n"
             )
             args_info = command_info.get("args", [])
             for arg_info in args_info:

--- a/src/ansys/fluent/core/codegen/datamodelgen.py
+++ b/src/ansys/fluent/core/codegen/datamodelgen.py
@@ -327,17 +327,19 @@ class DataModelGenerator:
             f.write(
                 f"{indent}        super().__init__(parent, attr, service, rules, path)\n"
             )
-            parameters_info = arg_info["info"]["parameters"]
-            for name, parameter_info in parameters_info.items():
-                py_name = name.translate(_ttable)
-                f.write(
-                    f'{indent}        self.{py_name} = self._{py_name}(self, "{name}", service, rules, path)\n'
-                )
-            f.write("\n")
-            for name, parameter_info in parameters_info.items():
-                self._write_arg_class(
-                    f, parameter_info | {"name": name}, f"{indent}    "
-                )
+            info = arg_info.get("info")
+            if info:
+                parameters_info = info["parameters"]
+                for name, parameter_info in parameters_info.items():
+                    py_name = name.translate(_ttable)
+                    f.write(
+                        f'{indent}        self.{py_name} = self._{py_name}(self, "{name}", service, rules, path)\n'
+                    )
+                f.write("\n")
+                for name, parameter_info in parameters_info.items():
+                    self._write_arg_class(
+                        f, parameter_info | {"name": name}, f"{indent}    "
+                    )
 
     def _write_static_info(self, name: str, info: Any, f: FileIO, level: int = 0):
         api_tree = {}

--- a/src/ansys/fluent/core/codegen/datamodelgen.py
+++ b/src/ansys/fluent/core/codegen/datamodelgen.py
@@ -485,7 +485,10 @@ class DataModelGenerator:
                 f"{indent}        def create_instance(self) -> _{k}CommandArguments:\n"
             )
             f.write(f"{indent}            args = self._get_create_instance_args()\n")
-            f.write(f"{indent}            return self._{k}CommandArguments(*args)\n\n")
+            f.write(f"{indent}            if args is not None:\n")
+            f.write(
+                f"{indent}                return self._{k}CommandArguments(*args)\n\n"
+            )
             api_tree[k] = "Command"
         for k in queries:
             f.write(f"{indent}    class {k}(PyQuery):\n")

--- a/src/ansys/fluent/core/codegen/datamodelgen.py
+++ b/src/ansys/fluent/core/codegen/datamodelgen.py
@@ -93,7 +93,27 @@ _SOLVER_DM_DOC_DIR = os.path.normpath(
     )
 )
 
-_ttable = str.maketrans(string.punctuation, "_" * len(string.punctuation))
+
+digits = {
+    0: "Zero",
+    1: "One",
+    2: "Two",
+    3: "Three",
+    4: "Four",
+    5: "Five",
+    6: "Six",
+    7: "Seven",
+    8: "Eight",
+    9: "Nine",
+}
+
+
+def _convert_to_py_name(name: str) -> str:
+    ttable = str.maketrans(string.punctuation, "_" * len(string.punctuation))
+    name = name.translate(ttable)
+    if name[0].isdigit():
+        name = f"{digits[int(name[0])]}{name[1:]}"
+    return name
 
 
 def _write_command_query_stub(name: str, info: Any, f: FileIO):
@@ -314,7 +334,7 @@ class DataModelGenerator:
         arg_type = arg_info["type"]
         arg_doc = arg_info.get("helpstring", f"Argument {arg_name}.")
         arg_class = arg_class_by_type[arg_type]
-        py_name = arg_name.translate(_ttable)
+        py_name = _convert_to_py_name(arg_name)
         f.write(f"{indent}class _{py_name}({arg_class.__name__}):\n")
         f.write(f'{indent}    """\n')
         for line in arg_doc.splitlines():
@@ -331,7 +351,7 @@ class DataModelGenerator:
             if info:
                 parameters_info = info["parameters"]
                 for name, parameter_info in parameters_info.items():
-                    py_name = name.translate(_ttable)
+                    py_name = _convert_to_py_name(name)
                     f.write(
                         f'{indent}        self.{py_name} = self._{py_name}(self, "{name}", service, rules, path)\n'
                     )
@@ -473,7 +493,7 @@ class DataModelGenerator:
             args_info = command_info.get("args", [])
             for arg_info in args_info:
                 arg_name = arg_info["name"]
-                py_name = arg_name.translate(_ttable)
+                py_name = _convert_to_py_name(arg_name)
                 f.write(
                     f'{indent}                self.{py_name} = self._{py_name}(self, "{arg_name}", service, rules, path)\n'
                 )

--- a/src/ansys/fluent/core/meshing/meshing_workflow.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow.py
@@ -80,10 +80,12 @@ class MeshingWorkflow(Workflow):
             self._new_workflow(name=self._name)
         else:
             self._activate_dynamic_interface(dynamic_interface=True)
+        self._initialized = True
 
     def __getattribute__(self, item: str):
         if (
             not item.startswith("_")
+            and super().__getattribute__("_initialized")
             and not getattr(self._meshing.GlobalSettings, self._identifier)()
         ):
             raise RuntimeError(

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1978,7 +1978,8 @@ class PyCommand:
     def create_instance(self) -> "PyCommandArguments":
         """Create a command instance."""
         args = self._get_create_instance_args()
-        return PyCommandArguments(*args)
+        if args is not None:
+            return PyCommandArguments(*args)
 
 
 class _InputFile:

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -2254,19 +2254,17 @@ class PySingletonCommandArgumentsSubItem(PyCommandArgumentsSubItem):
 
 
 arg_class_by_type = {
-    "String": PyTextualCommandArgumentsSubItem,
-    "ListString": PyTextualCommandArgumentsSubItem,
-    "String List": PyTextualCommandArgumentsSubItem,
-    "Real": PyNumericalCommandArgumentsSubItem,
-    "Int": PyNumericalCommandArgumentsSubItem,
-    "ListReal": PyNumericalCommandArgumentsSubItem,
-    "Real List": PyNumericalCommandArgumentsSubItem,
-    "Integer": PyNumericalCommandArgumentsSubItem,
-    "ListInt": PyNumericalCommandArgumentsSubItem,
+    **dict.fromkeys(
+        ["String", "ListString", "String List"], PyTextualCommandArgumentsSubItem
+    ),
+    **dict.fromkeys(
+        ["Real", "Int", "ListReal", "Real List", "Integer", "ListInt"],
+        PyNumericalCommandArgumentsSubItem,
+    ),
     "Dict": PyDictionaryCommandArgumentsSubItem,
-    "Bool": PyParameterCommandArgumentsSubItem,
-    "Logical": PyParameterCommandArgumentsSubItem,
-    "Logical List": PyParameterCommandArgumentsSubItem,
+    **dict.fromkeys(
+        ["Bool", "Logical", "Logical List"], PyParameterCommandArgumentsSubItem
+    ),
     "ModelObject": PySingletonCommandArgumentsSubItem,
 }
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -1866,8 +1866,6 @@ class PyCommand:
         Print the command help string.
     """
 
-    _full_static_info: dict[str, dict[str, Any]] = {}
-
     def __init__(
         self,
         service: DatamodelService,

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -2089,7 +2089,7 @@ class PyCommandArgumentsSubItem(PyCallableStateObject):
 
     def help(self) -> None:
         """Get help."""
-        print(self.parent_arg["helpstring"])
+        print(self.__doc__.strip())
 
     def __setattr__(self, key, value):
         if isinstance(value, PyCommandArgumentsSubItem):

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -127,6 +127,7 @@ class BaseMeshing:
                     self._se_service, "MeshingUtilities", []
                 )
         except (ImportError, FileNotFoundError):
+            datamodel_logger.warning("Generated API not found for MeshingUtilities.")
             datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
             if self.get_fluent_version() >= FluentVersion.v242:
                 meshing_utilities_root = PyMenuGeneric(

--- a/src/ansys/fluent/core/session_shared.py
+++ b/src/ansys/fluent/core/session_shared.py
@@ -63,12 +63,15 @@ def _make_tui_module(session, module_name):
 def _make_datamodel_module(session, module_name):
     try:
         from ansys.fluent.core import CODEGEN_OUTDIR
+        from ansys.fluent.core.codegen.datamodelgen import meshing_rule_file_names
 
+        file_name = meshing_rule_file_names[module_name]
         module = pyfluent.utils.load_module(
             f"{module_name}_{session._version}",
-            CODEGEN_OUTDIR / f"datamodel_{session._version}" / f"{module_name}.py",
+            CODEGEN_OUTDIR / f"datamodel_{session._version}" / f"{file_name}.py",
         )
         return module.Root(session._se_service, module_name, [])
     except (ImportError, FileNotFoundError):
+        datamodel_logger.warning("Generated API not found for %s.", module_name)
         datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
         return PyMenuGeneric(session._se_service, module_name)

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1394,6 +1394,7 @@ class Workflow:
                     "rename",
                 },
                 _fluent_version=fluent_version,
+                _initialized=False,
             )
         )
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -306,7 +306,8 @@ class Root(PyMenu):
 
             def create_instance(self) -> _C2CommandArguments:
                 args = self._get_create_instance_args()
-                return self._C2CommandArguments(*args)
+                if args is not None:
+                    return self._C2CommandArguments(*args)
 
     class P1(PyTextual):
         """
@@ -338,7 +339,8 @@ class Root(PyMenu):
 
         def create_instance(self) -> _C1CommandArguments:
             args = self._get_create_instance_args()
-            return self._C1CommandArguments(*args)'''
+            if args is not None:
+                return self._C1CommandArguments(*args)'''
 
 
 @pytest.mark.parametrize(

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -216,7 +216,13 @@ from ansys.fluent.core.services.datamodel_se import (
     PyDictionary,
     PyNamedObjectContainer,
     PyCommand,
-    PyQuery
+    PyQuery,
+    PyCommandArguments,
+    PyTextualCommandArgumentsSubItem,
+    PyNumericalCommandArgumentsSubItem,
+    PyDictionaryCommandArgumentsSubItem,
+    PyParameterCommandArgumentsSubItem,
+    PySingletonCommandArgumentsSubItem
 )
 
 
@@ -288,7 +294,19 @@ class Root(PyMenu):
             -------
             bool
             """
-            pass
+            class _C2CommandArguments(PyCommandArguments):
+                def __init__(self, service, rules, command, path, id):
+                    super().__init__(service, rules, command, path, id)
+                    self.A2 = self._A2(self, "A2", service, rules, path)
+
+                class _A2(PyNumericalCommandArgumentsSubItem):
+                    """
+                    Argument A2.
+                    """
+
+            def create_instance(self) -> _C2CommandArguments:
+                args = self._get_create_instance_args()
+                return self._C2CommandArguments(*args)
 
     class P1(PyTextual):
         """
@@ -308,7 +326,19 @@ class Root(PyMenu):
         -------
         bool
         """
-        pass'''
+        class _C1CommandArguments(PyCommandArguments):
+            def __init__(self, service, rules, command, path, id):
+                super().__init__(service, rules, command, path, id)
+                self.A1 = self._A1(self, "A1", service, rules, path)
+
+            class _A1(PyTextualCommandArgumentsSubItem):
+                """
+                Argument A1.
+                """
+
+        def create_instance(self) -> _C1CommandArguments:
+            args = self._get_create_instance_args()
+            return self._C1CommandArguments(*args)'''
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -837,7 +837,7 @@ def test_dynamic_dependency(new_meshing_session):
 
 
 @pytest.mark.fluent_version(">=24.2")
-def test_field_level_help(new_meshing_session, capsys):
+def test_field_level_help(new_meshing_session):
     meshing = new_meshing_session
     import_geometry = meshing.meshing.ImportGeometry.create_instance()
     assert isinstance(import_geometry.FileFormat, PyCommandArgumentsSubItem)

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -841,15 +841,11 @@ def test_field_level_help(new_meshing_session, capsys):
     meshing = new_meshing_session
     import_geometry = meshing.meshing.ImportGeometry.create_instance()
     assert isinstance(import_geometry.FileFormat, PyCommandArgumentsSubItem)
-    import_geometry.FileFormat.help()
-    captured = capsys.readouterr()
     assert (
-        "Indicate whether the imported geometry is a CAD File or a Mesh (either a surface or volume mesh)."
-        in captured.out
+        import_geometry.FileFormat.__doc__.strip()
+        == "Indicate whether the imported geometry is a CAD File or a Mesh (either a surface or volume mesh)."
     )
-    import_geometry.ImportType.help()
-    captured = capsys.readouterr()
     assert (
-        "When the File Format is set to CAD, use the Import Type field to import a Single File (the default), or Multiple Files."
-        in captured.out
+        import_geometry.ImportType.__doc__.strip()
+        == "When the File Format is set to CAD, use the Import Type field to import a Single File (the default), or Multiple Files. When importing multiple files, the Select File dialog allows you to make multiple selections, as long as the files are in the same directory and are of the same CAD format."
     )

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1719,25 +1719,18 @@ def test_accessors_for_argument_sub_items(new_meshing_session):
     with pytest.raises(AttributeError) as msg:
         assert feat_angle.allowed_values()
     assert (
-        msg.value.args[0]
-        == "'PyNumericalCommandArgumentsSubItem' object has no attribute 'allowed_values'"
+        msg.value.args[0] == "'_FeatureAngle' object has no attribute 'allowed_values'"
     )
 
     # Test intended to fail in numerical type (allowed_values() only available in string types)
     with pytest.raises(AttributeError) as msg:
         assert import_geom.arguments.num_parts.allowed_values()
-    assert (
-        msg.value.args[0]
-        == "'PyNumericalCommandArgumentsSubItem' object has no attribute 'allowed_values'"
-    )
+    assert msg.value.args[0] == "'_NumParts' object has no attribute 'allowed_values'"
 
     # Test intended to fail in string type (min() only available in numerical types)
     with pytest.raises(AttributeError) as msg:
         assert import_geom.arguments.length_unit.min()
-    assert (
-        msg.value.args[0]
-        == "'PyTextualCommandArgumentsSubItem' object has no attribute 'min'"
-    )
+    assert msg.value.args[0] == "'_LengthUnit' object has no attribute 'min'"
 
 
 @pytest.mark.codegen_required

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1199,7 +1199,8 @@ def test_switch_between_workflows(new_meshing_session):
 
     # 'import_geometry' is a watertight workflow command which is not available now
     # since we have changed to fault-tolerant in the backend.
-    with pytest.raises(RuntimeError):
+    # It seems to throw either RuntimeError or ValueError randomly.
+    with pytest.raises((RuntimeError, ValueError)):
         watertight.import_geometry.arguments()
 
     # Re-initialize watertight
@@ -1207,7 +1208,7 @@ def test_switch_between_workflows(new_meshing_session):
 
     # 'import_cad_and_part_management' is a fault-tolerant workflow command which is not
     # available now since we have changed to watertight in the backend.
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, ValueError)):
         fault_tolerant.import_cad_and_part_management.arguments()
 
     assert watertight.import_geometry.arguments()
@@ -1216,14 +1217,14 @@ def test_switch_between_workflows(new_meshing_session):
 
     # 'import_geometry' is a watertight workflow command which is not available now
     # since we have changed to fault-tolerant in the backend.
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, ValueError)):
         watertight.import_geometry.arguments()
 
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
 
     # 'import_cad_and_part_management' is a fault-tolerant workflow command which is not
     # available now since we have changed to watertight in the backend.
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, ValueError)):
         fault_tolerant.import_cad_and_part_management.arguments()
 
     # Re-initialize fault-tolerant


### PR DESCRIPTION
Generate the derived classes of the following types in the generated datamodel code:
`PyCommandArguments`
`PyTextualCommandArgumentsSubItem`
`PyNumericalCommandArgumentsSubItem`
`PyDictionaryCommandArgumentsSubItem`
`PyParameterCommandArgumentsSubItem`
`PySingletonCommandArgumentsSubItem`