### PR TITLE
fix: Fix missing field-level help at various levels

### DIFF
--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -127,7 +127,7 @@ hierarchy = {
         "session_solver",
         "session",
         "system_coupling",
-        "warning",
+        "pyfluent_warnings",
         "workflow",
     ],
 }

--- a/doc/changelog.d/3879.fixed.md
+++ b/doc/changelog.d/3879.fixed.md
@@ -1,0 +1,1 @@
+Fix missing field-level help at various levels

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -839,7 +839,7 @@ def test_dynamic_dependency(new_meshing_session):
     assert d == cd
 
 
-@pytest.mark.fluent_version(">=24.2")
+@pytest.mark.fluent_version(">=25.2")
 def test_field_level_help(new_meshing_session):
     meshing = new_meshing_session
     meshing.PartManagement.AssemblyNode["node-1"] = {}


### PR DESCRIPTION
Ensure field-level is received from gRPC for all the following type of entities:

- Parameter
- Singleton/NamedObject (currently no Singleton/NamedObject contains field-level help)
- Command/Query
- Parameter-type command/query argument
- Singleton-type command/query argument

Corresponding Fluent PR - 574286