### PR TITLE
ci: Add CI_RUN env to all workflows using 25.2 image [skip tests]

### DIFF
--- a/.github/workflows/doc-build-dev-nightly.yml
+++ b/.github/workflows/doc-build-dev-nightly.yml
@@ -16,6 +16,7 @@ env:
   PYFLUENT_HIDE_LOG_SECRETS: 1
   PYFLUENT_SKIP_API_UPGRADE_ADVICE: 1
   PYFLUENT_CONTAINER_MOUNT_SOURCE: "/home/ansys/Downloads/ansys_fluent_core_examples"
+  CI_RUN: 1
 
 jobs:
   build_dev_docs:

--- a/.github/workflows/execute-examples-weekly.yml
+++ b/.github/workflows/execute-examples-weekly.yml
@@ -15,6 +15,7 @@ env:
   MAIN_PYTHON_VERSION: '3.12'
   PYFLUENT_SKIP_API_UPGRADE_ADVICE: 1
   PYFLUENT_CONTAINER_MOUNT_SOURCE: "/home/ansys/Downloads/ansys_fluent_core_examples"
+  CI_RUN: 1
 
 jobs:
 

--- a/.github/workflows/test-fluent-journals.yml
+++ b/.github/workflows/test-fluent-journals.yml
@@ -18,6 +18,7 @@ env:
   MAIN_PYTHON_VERSION: '3.10'
   FLUENT_IMAGE_TAG: v25.2.0
   FLUENT_VERSION: 252
+  CI_RUN: 1
 
 jobs:
   test:

--- a/.github/workflows/test-run-dev-version-nightly.yml
+++ b/.github/workflows/test-run-dev-version-nightly.yml
@@ -15,6 +15,7 @@ env:
   MAIN_PYTHON_VERSION: '3.10'
   FLUENT_IMAGE_TAG: v25.2.0
   FLUENT_VERSION: 252
+  CI_RUN: 1
 
 jobs:
   test:


### PR DESCRIPTION
Add CI_RUN env to all workflows using 25.2 image to provide a temporary fix for #3926

Related #3927