### PR TITLE
fix: Skip test_reduction_does_not_modify_case [skip tests]

### DIFF
--- a/doc/changelog.d/3939.fixed.md
+++ b/doc/changelog.d/3939.fixed.md
@@ -1,0 +1,1 @@
+Skip test_reduction_does_not_modify_case [skip tests]

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -442,6 +442,7 @@ def test_reductions(
     _test_centroid_2_sources(solver1, solver2)
 
 
+@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/3938")
 @pytest.mark.fluent_version(">=24.2")
 def test_reduction_does_not_modify_case(static_mixer_case_session: Any):
     solver = static_mixer_case_session


### PR DESCRIPTION
`test_reduction_does_not_modify_case` is failing for latest 25R2 image.