### PR TITLE
fix: Fix deprecated behaviour

### DIFF
--- a/doc/changelog.d/3948.fixed.md
+++ b/doc/changelog.d/3948.fixed.md
@@ -1,0 +1,1 @@
+Fix deprecated behaviour

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -410,6 +410,8 @@ class Base:
     def _is_deprecated(self) -> bool:
         """Whether the object is deprecated in a specific Fluent version.'"""
         deprecated_version = self.get_attrs(["deprecated-version"])
+        if deprecated_version:
+            deprecated_version = deprecated_version.get("attrs", deprecated_version)
         deprecated_version = (
             deprecated_version.get("deprecated-version") if deprecated_version else None
         )
@@ -419,7 +421,7 @@ class Base:
 
     def is_active(self) -> bool:
         """Whether the object is active."""
-        attr = self.get_attr(_InlineConstants.is_active) and not self._is_deprecated()
+        attr = self.get_attr(_InlineConstants.is_active)
         return False if attr is False else True
 
     def _check_stable(self) -> None:
@@ -955,7 +957,7 @@ def _command_query_name_filter(
     for name in names:
         if name not in excluded and name.startswith(prefix):
             child = getattr(parent, name)
-            if child.is_active():
+            if child.is_active() and not child._is_deprecated():
                 ret.append([name, child.__class__.__bases__[0].__name__, child.__doc__])
     return ret
 
@@ -1111,7 +1113,7 @@ class Group(SettingsBase[DictStateType]):
         for child_name in self.child_names:
             if child_name not in excluded and child_name.startswith(prefix):
                 child = getattr(self, child_name)
-                if child.is_active():
+                if child.is_active() and not child._is_deprecated():
                     ret.append(
                         [
                             child_name,
@@ -1667,7 +1669,7 @@ class Action(Base):
         for argument_name in self.argument_names:
             if argument_name not in excluded and argument_name.startswith(prefix):
                 argument = getattr(self, argument_name)
-                if argument.is_active():
+                if argument.is_active() and not argument._is_deprecated():
                     ret.append(
                         [
                             argument_name,

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1069,25 +1069,28 @@ class Group(SettingsBase[DictStateType]):
     def get_active_child_names(self):
         """Names of children that are currently active."""
         ret = []
-        for child in self.child_names:
-            if getattr(self, child).is_active():
-                ret.append(child)
+        for child_name in self.child_names:
+            child = getattr(self, child_name)
+            if child.is_active() and not child._is_deprecated():
+                ret.append(child_name)
         return ret
 
     def get_active_command_names(self):
         """Names of commands that are currently active."""
         ret = []
-        for command in self.command_names:
-            if getattr(self, command).is_active():
-                ret.append(command)
+        for command_name in self.command_names:
+            command = getattr(self, command_name)
+            if command.is_active() and not command._is_deprecated():
+                ret.append(command_name)
         return ret
 
     def get_active_query_names(self):
         """Names of queries that are currently active."""
         ret = []
-        for query in self.query_names:
-            if getattr(self, query).is_active():
-                ret.append(query)
+        for query_name in self.query_names:
+            query = getattr(self, query_name)
+            if query.is_active() and not query._is_deprecated():
+                ret.append(query_name)
         return ret
 
     def __dir__(self):

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -678,7 +678,6 @@ def test_return_types_of_operations_on_named_objects(mixing_elbow_settings_sessi
     assert var3.obj_name == "air-copied"
 
 
-@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/3813")
 @pytest.mark.fluent_version(">=25.1")
 def test_settings_with_deprecated_flag(mixing_elbow_settings_session):
     solver = mixing_elbow_settings_session
@@ -703,23 +702,23 @@ def test_settings_with_deprecated_flag(mixing_elbow_settings_session):
         == "25.1"
     )
 
-    # Deprecated objects should not be active
-    assert not graphics.contour["contour-velocity"].range_option.is_active()
+    # User won't normally find deprecated objects in the settings API, so it is OK to leave them active.
     assert graphics.contour["contour-velocity"].range_options.is_active()
 
+    # https://github.com/ansys/pyfluent/issues/3813
     # in 'get_state'
-    if solver.get_fluent_version() >= FluentVersion.v252:
-        # From v252 'get_state' behaviour is to be corrected in Fluent.
-        assert not {"range_option", "coloring"}.issubset(
-            set(graphics.contour["contour-velocity"].get_state())
-        )
-        assert {"range_options", "colorings"}.issubset(
-            set(graphics.contour["contour-velocity"].get_state())
-        )
-    else:
-        assert {"range_option", "range_options", "coloring", "colorings"}.issubset(
-            set(graphics.contour["contour-velocity"].get_state())
-        )
+    # if solver.get_fluent_version() >= FluentVersion.v252:
+    #     # From v252 'get_state' behaviour is to be corrected in Fluent.
+    #     assert not {"range_option", "coloring"}.issubset(
+    #         set(graphics.contour["contour-velocity"].get_state())
+    #     )
+    #     assert {"range_options", "colorings"}.issubset(
+    #         set(graphics.contour["contour-velocity"].get_state())
+    #     )
+    # else:
+    #     assert {"range_option", "range_options", "coloring", "colorings"}.issubset(
+    #         set(graphics.contour["contour-velocity"].get_state())
+    #     )
 
     # in 'child_names'
     # 'child_names', 'command_names' and 'query_names' will remain unchanged.
@@ -762,6 +761,12 @@ def test_settings_with_deprecated_flag(mixing_elbow_settings_session):
         solver.settings.solution.report_definitions.surface["report-def-1"],
         "create_output_parameter",
     )
+
+    v1 = solver.settings.results.graphics.vector.create()
+    assert v1.scale.scale_f() == 1.0
+    v1.scale.scale_f = 2.0
+    assert v1.scale.scale_f() == 2.0
+    assert "scale" not in dir(v1)
 
 
 @pytest.fixture


### PR DESCRIPTION
For "deprecated" settings, we should hide the exposure, but not block the access. With the current PR changes, we get the following behaviour in both pyfluent and pyconsole:
```
>>> v1 = solver.settings.results.graphics.vector.create()
>>> v1.scale.scale_f = 4
>>> "scale" in dir(v1)
False
```
Nightly dev doc run - https://github.com/ansys/pyfluent/actions/runs/14606954687
