### PR TITLE
fix: Preprocess xml content before sending it to ElementTree parser

### DIFF
--- a/doc/changelog.d/3951.fixed.md
+++ b/doc/changelog.d/3951.fixed.md
@@ -1,0 +1,1 @@
+Preprocess xml content before sending it to ElementTree parser

--- a/src/ansys/fluent/core/filereader/data_file.py
+++ b/src/ansys/fluent/core/filereader/data_file.py
@@ -39,10 +39,11 @@ import os
 from os.path import dirname
 from pathlib import Path
 
-from defusedxml.ElementTree import parse
+import defusedxml.ElementTree as ET
 import numpy as np
 
 from . import lispy
+from .pre_processor import remove_unsupported_xml_chars
 
 try:
     import h5py
@@ -224,7 +225,15 @@ class DataFile:
 
 
 def _get_data_file_name_from_flprj(flprj_file):
-    tree = parse(flprj_file)
-    root = tree.getroot()
-    folder_name = root.find("Metadata").find("CurrentSimulation").get("value")[5:-1]
-    return root.find(folder_name).find("Input").find("Case").find("Target").get("value")
+    with open(flprj_file, "r") as file:
+        content = file.read()
+        content = remove_unsupported_xml_chars(content)
+        root = ET.fromstring(content)
+        folder_name = root.find("Metadata").find("CurrentSimulation").get("value")[5:-1]
+        return (
+            root.find(folder_name)
+            .find("Input")
+            .find("Case")
+            .find("Target")
+            .get("value")
+        )

--- a/src/ansys/fluent/core/filereader/pre_processor.py
+++ b/src/ansys/fluent/core/filereader/pre_processor.py
@@ -1,0 +1,13 @@
+"""
+Pre-processor for XML content from Fluent project files.
+"""
+
+import re
+
+
+def remove_unsupported_xml_chars(content: str):
+    """Remove unsupported XML characters from the content."""
+    # Replace double colons in tag names with double underscores
+    content = re.sub(r"</?([^> ]+)::", r"<\1__", content)
+
+    return content

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from os.path import dirname, join
-import pathlib
+from pathlib import Path
 import shutil
 
 import defusedxml.ElementTree as ET
@@ -35,6 +35,7 @@ from ansys.fluent.core.filereader.case_file import (
     MeshType,
     _get_processed_string,
 )
+from ansys.fluent.core.filereader.case_file import CaseFile
 from ansys.fluent.core.filereader.case_file import CaseFile as CaseReader
 from ansys.fluent.core.filereader.pre_processor import remove_unsupported_xml_chars
 
@@ -147,7 +148,7 @@ def create_dir_structure_locally(copy_1: bool = False, copy_2: bool = False):
         return_without_path=False,
     )
     prj_dir = join(dirname(case_file_name), case_file_dir)
-    pathlib.Path(prj_dir).mkdir(parents=True, exist_ok=True)
+    Path(prj_dir).mkdir(parents=True, exist_ok=True)
     if copy_1:
         shutil.copy2(case_file_name, prj_dir)
     if copy_2:
@@ -368,3 +369,17 @@ def test_preprocessor():
     pre_processed = remove_unsupported_xml_chars(content)
     assert pre_processed == expected
     assert ET.fromstring(pre_processed)
+
+
+def test_read_flprj_3891():
+    # Read the .flprj file from https://github.com/ansys/pyfluent/issues/3891
+    data_zip = examples.download_file(
+        "data.zip",
+        "pyfluent/flprj_3891",
+        return_without_path=False,
+    )
+    prj_file_name = next(Path(data_zip).with_suffix("").glob("*.flprj"))
+    assert (
+        CaseFile(project_file_name=prj_file_name).get_mesh().get_mesh_type()
+        == MeshType.VOLUME
+    )

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -24,6 +24,7 @@ from os.path import dirname, join
 import pathlib
 import shutil
 
+import defusedxml.ElementTree as ET
 import pytest
 
 from ansys.fluent.core import examples
@@ -35,6 +36,7 @@ from ansys.fluent.core.filereader.case_file import (
     _get_processed_string,
 )
 from ansys.fluent.core.filereader.case_file import CaseFile as CaseReader
+from ansys.fluent.core.filereader.pre_processor import remove_unsupported_xml_chars
 
 
 def call_casereader(
@@ -344,3 +346,25 @@ def test_mesh_reader():
     assert mesh_reader_2d.precision() is None
     assert mesh_reader_3d.precision() is None
     assert case_reader.precision() == 2
+
+
+def test_preprocessor():
+    content = """
+    <Project type="object" class="PFolder">
+    <Metadata type="object" class="ansys::Project::MetadataHoof">
+        <ProjectStoragePolicy::FolderEnabled class="string" value="true"/>
+    </Metadata>
+    </Project>
+    """
+    expected = """
+    <Project type="object" class="PFolder">
+    <Metadata type="object" class="ansys::Project::MetadataHoof">
+        <ProjectStoragePolicy__FolderEnabled class="string" value="true"/>
+    </Metadata>
+    </Project>
+    """
+    with pytest.raises(ET.ParseError):
+        ET.fromstring(content)
+    pre_processed = remove_unsupported_xml_chars(content)
+    assert pre_processed == expected
+    assert ET.fromstring(pre_processed)


### PR DESCRIPTION
XMLParser gives a ParseError if there are colons in the tag name. This PR pro-processes the XML content from FLuent's .flprj file to convert double colons to double underscores. E.g. the XML fragment
```
<ProjectStoragePolicy::FolderEnabled class="string" value="true"/>
```
will be converted to
```
<ProjectStoragePolicy__FolderEnabled class="string" value="true"/>
```