### PR TITLE
fix: deprecated flag for flobject.py

### DIFF
--- a/doc/changelog.d/3953.fixed.md
+++ b/doc/changelog.d/3953.fixed.md
@@ -1,0 +1,1 @@
+deprecated flag for flobject.py

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -415,8 +415,9 @@ class Base:
         deprecated_version = (
             deprecated_version.get("deprecated-version") if deprecated_version else None
         )
-        return deprecated_version and FluentVersion(self._version) >= FluentVersion(
-            deprecated_version
+        return deprecated_version and (
+            float(deprecated_version) <= 22.2
+            or FluentVersion(self._version) >= FluentVersion(deprecated_version)
         )
 
     def is_active(self) -> bool:


### PR DESCRIPTION
In deprecated version check we did not consider the version can be less than 22.2 (minimum version form which we support PyFluent). However recently, a deprecated version was introduced as 21.1. That's why this fix.