### PR TITLE
chore: Update error message for attribute errors from Solver.

### DIFF
--- a/doc/changelog.d/3982.maintenance.md
+++ b/doc/changelog.d/3982.maintenance.md
@@ -1,0 +1,1 @@
+Update error message for attribute errors from Solver.

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -363,7 +363,10 @@ class Solver(BaseSession):
                     f"'{attr}' is deprecated. Use 'settings.{attr}' instead.",
                     DeprecatedSettingWarning,
                 )
-        return getattr(self._settings_api_root, attr)
+        try:
+            return getattr(self._settings_api_root, attr)
+        except AttributeError:
+            return object.__getattribute__(self, attr)
 
     def __dir__(self):
         if self._fluent_connection is None:

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -363,9 +363,13 @@ class Solver(BaseSession):
                     f"'{attr}' is deprecated. Use 'settings.{attr}' instead.",
                     DeprecatedSettingWarning,
                 )
+        # Try forwarding attribute access to the settings API root.
+        # If that fails with AttributeError, fall back to normal attribute lookup.
+        # Using object.__getattribute__ triggers the standard AttributeError with default messaging.
         try:
             return getattr(self._settings_api_root, attr)
         except AttributeError:
+            # Let standard attribute access raise the appropriate error
             return object.__getattribute__(self, attr)
 
     def __dir__(self):

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -357,7 +357,7 @@ class Solver(BaseSession):
 
     def __getattr__(self, attr):
         self._populate_settings_api_root()
-        if attr in [x for x in dir(self._settings_api_root) if not x.startswith("_")]:
+        if not attr.startswith("_") and attr in dir(self._settings_api_root):
             if self.get_fluent_version() > FluentVersion.v242:
                 warnings.warn(
                     f"'{attr}' is deprecated. Use 'settings.{attr}' instead.",


### PR DESCRIPTION
Update error message for attribute errors from Solver. If the attribute is not there in the settings-root, then we should raise the Attribute error from the same class only.