### PR TITLE
fix: Fix server-side error in builtin settings objects

### DIFF
--- a/doc/changelog.d/3996.fixed.md
+++ b/doc/changelog.d/3996.fixed.md
@@ -1,0 +1,1 @@
+Fix server-side error in builtin settings objects

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1164,6 +1164,10 @@ class Group(SettingsBase[DictStateType]):
             raise
 
     def __setattr__(self, name: str, value):
+        # 'settings_source' will be set to settings object when they are created from builtin settings classes.
+        # We don't allow overwriting it.
+        if name == "settings_source":
+            raise AttributeError("Cannot overwrite settings_source after it is set.")
         attr = None
         try:
             attr = getattr(self, name)

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -707,8 +707,7 @@ def test_builtin_singleton_setting_assign_session(
     )
     assert models.is_active()
     assert models == solver.setup.models
-    # TODO: Ideally an AttributeError should be raised here from flobject.py
-    with pytest.raises(RuntimeError):  # re-assignment is not allowed
+    with pytest.raises(AttributeError):  # re-assignment is not allowed
         models.settings_source = solver
 
     models = Models()
@@ -733,8 +732,7 @@ def test_builtin_non_creatable_named_object_setting_assign_session(
     inlet.settings_source = solver
     assert inlet == solver.settings.setup.boundary_conditions["inlet1"]
     assert inlet.settings_source == solver.settings
-    # TODO: Ideally an AttributeError should be raised here from flobject.py
-    with pytest.raises(RuntimeError):  # re-assignment is not allowed
+    with pytest.raises(AttributeError):  # re-assignment is not allowed
         inlet.settings_source = solver
 
     inlet = BoundaryCondition(name="inlet1")
@@ -759,8 +757,7 @@ def test_builtin_creatable_named_object_setting_assign_session(
     report_file.settings_source = solver
     assert report_file == solver.solution.monitor.report_files["report-file-1"]
     assert report_file.settings_source == solver.settings
-    # TODO: Ideally an AttributeError should be raised here from flobject.py
-    with pytest.raises(RuntimeError):  # re-assignment is not allowed
+    with pytest.raises(AttributeError):  # re-assignment is not allowed
         report_file.settings_source = solver
 
     report_file = ReportFile(name="report-file-1")


### PR DESCRIPTION
Fluent bug 1258060

Avoid server-side error by raising an early AttributeError on client-side when `settings_source` attribute of builtin settings object is overwritten.

Builtin settings objects are instantiated from builtin base classes (in settings_builtin_bases.py), and later morphed into instances  of flobject classes. We need to modify flobject class behaviour to get a custom `__setattr__` behaviour of builtin settings objects at runtime.