### PR TITLE
fix: Decorator warning message

### DIFF
--- a/doc/changelog.d/4021.fixed.md
+++ b/doc/changelog.d/4021.fixed.md
@@ -1,0 +1,1 @@
+Decorator warning message

--- a/src/ansys/fluent/core/utils/deprecate.py
+++ b/src/ansys/fluent/core/utils/deprecate.py
@@ -64,11 +64,12 @@ def all_deprecators(
 
         @wraps(decorated)
         def wrapper(*args, **kwargs):
-            warnings.warn(
-                warn_message,
-                PyFluentDeprecationWarning,
-                stacklevel=2,
-            )
+            if warn_message:
+                warnings.warn(
+                    warn_message,
+                    PyFluentDeprecationWarning,
+                    stacklevel=2,
+                )
             return decorated(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/4020

Earlier:

```
>>> import ansys.fluent.core as pf
>>> solver = pf.launch_fluent()
<stdin>:1: PyFluentDeprecationWarning:
>>> solver.exit()
```

Corrected:

```
>>> import ansys.fluent.core as pf
>>> solver = pf.launch_fluent()
>>> solver.exit()
```