### PR TITLE
feat: Check if fluent exe exists in AWP_ROOT path while determining the Fluent version to launch

### DIFF
--- a/doc/changelog.d/4024.added.md
+++ b/doc/changelog.d/4024.added.md
@@ -1,0 +1,1 @@
+Check if fluent exe exists in AWP_ROOT path while determining the Fluent version to launch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ tests = [
     "pytest-cov==6.1.1",
     "pytest-mock==3.14.0",
     "pytest-xdist==3.6.1",
+    "pyfakefs==5.8.0"
 ]
 docs = [
     "Sphinx==8.1.3",

--- a/src/ansys/fluent/core/codegen/tuigen.py
+++ b/src/ansys/fluent/core/codegen/tuigen.py
@@ -58,7 +58,6 @@ from ansys.fluent.core.services.datamodel_tui import (
 )
 from ansys.fluent.core.utils.fix_doc import escape_wildcards
 from ansys.fluent.core.utils.fluent_version import (
-    AnsysVersionNotFound,
     FluentVersion,
     get_version_for_file_name,
 )
@@ -130,7 +129,7 @@ def _copy_tui_help_xml_file(version: str):
                 shutil.copy(str(xml_source), _XML_HELP_FILE)
             else:
                 logger.warning("fluent_gui_help.xml is not found.")
-        except AnsysVersionNotFound:
+        except FileNotFoundError:
             logger.warning("fluent_gui_help.xml is not found.")
 
 

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -184,6 +184,12 @@ def launch_fluent(
         Version of Ansys Fluent to launch. To use Fluent version 2025 R1, pass
         any of  ``FluentVersion.v251``, ``"25.1.0"``, ``"25.1"``, ``25.1``or ``251``.
         The default is ``None``, in which case the newest installed version is used.
+        PyFluent uses the ``AWP_ROOT<ver>`` environment variable to locate the Fluent
+        installation, where ``<ver>`` is the Ansys release number such as ``251``.
+        The ``AWP_ROOT<ver>`` environment variable is automatically configured on Windows
+        system when Fluent is installed. On Linux systems, ``AWP_ROOT<ver>`` must be
+        configured to point to the absolute path of an Ansys installation such as
+        ``/apps/ansys_inc/v251``.
     dimension : Dimension or int, optional
         Geometric dimensionality of the Fluent simulation. The default is ``None``,
         in which case ``Dimension.THREE`` is used. Options are either the values of the

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -150,10 +150,6 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
         Fluent executable path
     """
 
-    def get_fluent_root(version: FluentVersion) -> Path:
-        awp_root = os.environ[version.awp_var]
-        return Path(awp_root) / "fluent"
-
     def get_exe_path(fluent_root: Path) -> Path:
         if launcher_utils.is_windows():
             return fluent_root / "ntbin" / "win64" / "fluent.exe"
@@ -171,7 +167,7 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
     # 2. product_version parameter passed with launch_fluent
     product_version = launch_argvals.get("product_version")
     if product_version:
-        return get_exe_path(get_fluent_root(FluentVersion(product_version)))
+        return FluentVersion(product_version).get_fluent_exe_path()
 
     # (DEV) "PYFLUENT_FLUENT_ROOT" environment variable
     fluent_root = os.getenv("PYFLUENT_FLUENT_ROOT")
@@ -179,4 +175,4 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
         return get_exe_path(Path(fluent_root))
 
     # 3. the latest ANSYS version from AWP_ROOT environment variables
-    return get_exe_path(get_fluent_root(FluentVersion.get_latest_installed()))
+    return FluentVersion.get_latest_installed().get_fluent_exe_path()

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -25,6 +25,8 @@
 from enum import Enum
 from functools import total_ordering
 import os
+from pathlib import Path
+import platform
 
 import ansys.fluent.core as pyfluent
 
@@ -114,8 +116,22 @@ class FluentVersion(Enum):
         AnsysVersionNotFound
             If an Ansys version cannot be found.
         """
+
+        def fluent_exe_exists(awp_var):
+            awp_root = os.getenv(awp_var)
+            if awp_root is None:
+                return False
+
+            fluent_root = Path(awp_root) / "fluent"
+            fluent_exe = (
+                fluent_root / "ntbin" / "win64" / "fluent.exe"
+                if platform.system() == "Windows"
+                else fluent_root / "bin" / "fluent"
+            )
+            return fluent_exe.exists()
+
         for member in cls:
-            if member.awp_var in os.environ:
+            if fluent_exe_exists(member.awp_var):
                 return member
 
         raise AnsysVersionNotFound(

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -116,26 +116,28 @@ class FluentVersion(Enum):
         AnsysVersionNotFound
             If an Ansys version cannot be found.
         """
-
-        def fluent_exe_exists(awp_var):
-            awp_root = os.getenv(awp_var)
-            if awp_root is None:
-                return False
-
-            fluent_root = Path(awp_root) / "fluent"
-            fluent_exe = (
-                fluent_root / "ntbin" / "win64" / "fluent.exe"
-                if platform.system() == "Windows"
-                else fluent_root / "bin" / "fluent"
-            )
-            return fluent_exe.exists()
-
         for member in cls:
-            if fluent_exe_exists(member.awp_var):
+            if member.awp_var in os.environ and member.get_fluent_exe_path().exists():
                 return member
 
         raise AnsysVersionNotFound(
-            "Verify the value of the 'AWP_ROOT' environment variable."
+            "Unable to locate a compatible Ansys Fluent installation. Ensure that an environment variable like 'AWP_ROOT242' or 'AWP_ROOT251' points to a supported Ansys version, and that Fluent is included in the installation."
+        )
+
+    def get_fluent_exe_path(self) -> Path:
+        """Get the path for the Fluent executable file.
+
+        Returns
+        -------
+        Path
+            Fluent executable path.
+        """
+        awp_root = os.environ[self.awp_var]
+        fluent_root = Path(awp_root) / "fluent"
+        return (
+            fluent_root / "ntbin" / "win64" / "fluent.exe"
+            if platform.system() == "Windows"
+            else fluent_root / "bin" / "fluent"
         )
 
     @classmethod

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -121,7 +121,9 @@ class FluentVersion(Enum):
                 return member
 
         raise AnsysVersionNotFound(
-            "Unable to locate a compatible Ansys Fluent installation. Ensure that an environment variable like 'AWP_ROOT242' or 'AWP_ROOT251' points to a supported Ansys version, and that Fluent is included in the installation."
+            "Unable to locate a compatible Ansys Fluent installation. "
+            "Ensure that an environment variable like 'AWP_ROOT242' or 'AWP_ROOT251' "
+            "points to a supported Ansys version, and that Fluent is included in the installation."
         )
 
     def get_fluent_exe_path(self) -> Path:

--- a/tests/test_fluent_version.py
+++ b/tests/test_fluent_version.py
@@ -47,8 +47,11 @@ def test_version_not_found():
         FluentVersion(22)
 
 
-def test_get_latest_installed(helpers):
+def test_get_latest_installed(helpers, fs):
     helpers.mock_awp_vars()
+    with pytest.raises(FileNotFoundError):
+        assert FluentVersion.get_latest_installed() == FluentVersion.current_release()
+    fs.create_file(FluentVersion.current_release().get_fluent_exe_path())
     assert FluentVersion.get_latest_installed() == FluentVersion.current_release()
 
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -55,7 +55,7 @@ from ansys.fluent.core.launcher.pyfluent_enums import (
     LaunchMode,
     UIMode,
 )
-from ansys.fluent.core.utils.fluent_version import AnsysVersionNotFound, FluentVersion
+from ansys.fluent.core.utils.fluent_version import FluentVersion
 import ansys.platform.instancemanagement as pypim
 
 
@@ -256,49 +256,31 @@ def test_gpu_launch_arg_additional_arg():
 
 def test_get_fluent_exe_path_when_nothing_is_set(helpers):
     helpers.delete_all_awp_vars()
-    with pytest.raises(AnsysVersionNotFound):
+    with pytest.raises(FileNotFoundError):
         get_fluent_exe_path()
-    with pytest.raises(AnsysVersionNotFound):
+    with pytest.raises(FileNotFoundError):
         FluentVersion.get_latest_installed()
 
 
-def test_get_fluent_exe_path_from_awp_root_222(helpers):
-    helpers.mock_awp_vars(version="222")
+@pytest.mark.parametrize(
+    "fluent_version",
+    [version for version in FluentVersion],
+)
+def test_get_fluent_exe_path_from_awp_root(fluent_version, helpers, fs):
+    helpers.mock_awp_vars(version=str(fluent_version.number))
+    fs.create_file(fluent_version.get_fluent_exe_path())
     if platform.system() == "Windows":
-        expected_path = Path("ansys_inc/v222/fluent") / "ntbin" / "win64" / "fluent.exe"
+        expected_path = (
+            Path(f"ansys_inc/v{fluent_version.number}/fluent")
+            / "ntbin"
+            / "win64"
+            / "fluent.exe"
+        )
     else:
-        expected_path = Path("ansys_inc/v222/fluent") / "bin" / "fluent"
-    assert FluentVersion.get_latest_installed() == FluentVersion.v222
-    assert get_fluent_exe_path() == expected_path
-
-
-def test_get_fluent_exe_path_from_awp_root_231(helpers):
-    helpers.mock_awp_vars(version="231")
-    if platform.system() == "Windows":
-        expected_path = Path("ansys_inc/v231/fluent") / "ntbin" / "win64" / "fluent.exe"
-    else:
-        expected_path = Path("ansys_inc/v231/fluent") / "bin" / "fluent"
-    assert FluentVersion.get_latest_installed() == FluentVersion.v231
-    assert get_fluent_exe_path() == expected_path
-
-
-def test_get_fluent_exe_path_from_awp_root_232(helpers):
-    helpers.mock_awp_vars(version="232")
-    if platform.system() == "Windows":
-        expected_path = Path("ansys_inc/v232/fluent") / "ntbin" / "win64" / "fluent.exe"
-    else:
-        expected_path = Path("ansys_inc/v232/fluent") / "bin" / "fluent"
-    assert FluentVersion.get_latest_installed() == FluentVersion.v232
-    assert get_fluent_exe_path() == expected_path
-
-
-def test_get_fluent_exe_path_from_awp_root_241(helpers):
-    helpers.mock_awp_vars(version="241")
-    if platform.system() == "Windows":
-        expected_path = Path("ansys_inc/v241/fluent") / "ntbin" / "win64" / "fluent.exe"
-    else:
-        expected_path = Path("ansys_inc/v241/fluent") / "bin" / "fluent"
-    assert FluentVersion.get_latest_installed() == FluentVersion.v241
+        expected_path = (
+            Path(f"ansys_inc/v{fluent_version.number}/fluent") / "bin" / "fluent"
+        )
+    assert FluentVersion.get_latest_installed() == fluent_version
     assert get_fluent_exe_path() == expected_path
 
 


### PR DESCRIPTION
This is to handle the scenario when a later version of Ansys is installed without Fluent (#4023)