### PR TITLE
chore: Add a way to extract Fluent launch command and subprocess arguments from StandaloneLauncher

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -312,8 +312,6 @@ def launch_fluent(
     The allocated machines and core counts are queried from the scheduler environment and
     passed to Fluent.
     """
-    if env is None:
-        env = {}
 
     def _mode_to_launcher_type(fluent_launch_mode: LaunchMode):
         launcher_mode_type = {

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -416,6 +416,7 @@ class SlurmLauncher:
         """
         if not _SlurmWrapper.is_available():
             raise RuntimeError("Slurm is not available.")
+        env = env or {}
         locals_ = locals().copy()
         argvals = {
             arg: locals_.get(arg)

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -184,7 +184,7 @@ class StandaloneLauncher:
         In job scheduler environments (e.g., SLURM, LSF, PBS), resources and compute nodes are allocated,
         and core counts are queried from these environments before being passed to Fluent.
         """
-        import ansys.fluent.core as pyfluent
+        env = env or {}
 
         locals_ = locals().copy()
         argvals = {
@@ -234,6 +234,8 @@ class StandaloneLauncher:
         )
 
         if is_windows():
+            import ansys.fluent.core as pyfluent
+
             if pyfluent.LAUNCH_FLUENT_STDOUT or pyfluent.LAUNCH_FLUENT_STDERR:
                 self._launch_cmd = self._launch_string
             else:
@@ -245,6 +247,16 @@ class StandaloneLauncher:
                 self._launch_cmd = "nohup " + self._launch_string + " &"
             else:
                 self._launch_cmd = self._launch_string
+
+    @property
+    def command(self) -> str:
+        """Return the command for launching Fluent."""
+        return self._launch_string
+
+    @property
+    def subprocess_keywords(self) -> Dict[str, Any]:
+        """Return the keyword arguments for launching Fluent via Python subprocess."""
+        return self._kwargs
 
     def __call__(self):
         if self.argvals["dry_run"]:


### PR DESCRIPTION
```
import subprocess
from ansys.fluent.core.launcher.standalone_launcher import StandaloneLauncher
launcher = StandaloneLauncher(ui_mode="gui", dimension=2)
subprocess.run(launcher.command, **launcher.subprocess_keywords)
```