### PR TITLE
refactor: Rename meshing_rule_file_names [skip tests]

### DIFF
--- a/src/ansys/fluent/core/codegen/datamodelgen.py
+++ b/src/ansys/fluent/core/codegen/datamodelgen.py
@@ -179,7 +179,7 @@ def _build_command_query_docstring(
     return doc.getvalue()
 
 
-meshing_rule_file_names = {
+datamodel_file_name_map = {
     "workflow": "workflow",
     "meshing": "meshing",
     "PartManagement": "part_management",
@@ -213,7 +213,7 @@ class DataModelStaticInfo:
         datamodel_dir = (pyfluent.CODEGEN_OUTDIR / f"datamodel_{version}").resolve()
         datamodel_dir.mkdir(exist_ok=True)
         self.file_name = (
-            datamodel_dir / f"{meshing_rule_file_names[rules_save_name]}.py"
+            datamodel_dir / f"{datamodel_file_name_map[rules_save_name]}.py"
         ).resolve()
         if rules == "MeshingUtilities":
             self.stub_file = (datamodel_dir / "meshing_utilities.pyi").resolve()

--- a/src/ansys/fluent/core/session_shared.py
+++ b/src/ansys/fluent/core/session_shared.py
@@ -63,9 +63,9 @@ def _make_tui_module(session, module_name):
 def _make_datamodel_module(session, module_name):
     try:
         from ansys.fluent.core import CODEGEN_OUTDIR
-        from ansys.fluent.core.codegen.datamodelgen import meshing_rule_file_names
+        from ansys.fluent.core.codegen.datamodelgen import datamodel_file_name_map
 
-        file_name = meshing_rule_file_names[module_name]
+        file_name = datamodel_file_name_map[module_name]
         module = pyfluent.utils.load_module(
             f"{module_name}_{session._version}",
             CODEGEN_OUTDIR / f"datamodel_{session._version}" / f"{file_name}.py",

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -31,7 +31,7 @@ import pytest
 
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core.codegen import StaticInfoType, allapigen
-from ansys.fluent.core.codegen.datamodelgen import meshing_rule_file_names
+from ansys.fluent.core.codegen.datamodelgen import datamodel_file_name_map
 from ansys.fluent.core.search import get_api_tree_file_name
 from ansys.fluent.core.utils.fluent_version import get_version_for_file_name
 
@@ -388,12 +388,12 @@ def test_codegen_with_datamodel_static_info(monkeypatch, rules):
     datamodel_paths = list((codegen_outdir / f"datamodel_{version}").iterdir())
     assert len(datamodel_paths) == 1 or 2
     assert set(p.name for p in datamodel_paths) == {
-        f"{meshing_rule_file_names[rules]}.py"
-    } or {f"{meshing_rule_file_names[rules]}.pyi"}
+        f"{datamodel_file_name_map[rules]}.py"
+    } or {f"{datamodel_file_name_map[rules]}.pyi"}
     with open(
         codegen_outdir
         / f"datamodel_{version}"
-        / f"{meshing_rule_file_names[rules]}.py",
+        / f"{datamodel_file_name_map[rules]}.py",
         "r",
     ) as f:
         assert f.read().strip() == _expected_datamodel_api_output


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/3894

Rename `meshing_rule_file_names` to `datamodel_file_name_map`.