### PR TITLE
refactor: Run each test in its own directory

### DIFF
--- a/doc/changelog.d/4115.miscellaneous.md
+++ b/doc/changelog.d/4115.miscellaneous.md
@@ -1,0 +1,1 @@
+Run each test in its own directory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,12 +170,18 @@ def pytest_collection_finish(session):
 
 @pytest.fixture(autouse=True)
 def run_before_each_test(
-    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
-) -> None:
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+):
     monkeypatch.setenv("PYFLUENT_TEST_NAME", request.node.name)
     monkeypatch.setenv("PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS", "1")
     pyfluent.CONTAINER_MOUNT_SOURCE = pyfluent.EXAMPLES_PATH
     pyfluent.CONTAINER_MOUNT_TARGET = pyfluent.EXAMPLES_PATH
+    original_cwd = os.getcwd()
+    monkeypatch.chdir(tmp_path)
+    yield
+    os.chdir(original_cwd)
 
 
 class Helpers:


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/915

Each test should create its own working directory. I think this will help to avoid hang issue.

All tests passed - https://github.com/ansys/pyfluent/actions/runs/15485733732