### PR TITLE
ci: Remove docker images after any job that consumes Fluent image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,10 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
   build:
     name: Build
     if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
@@ -325,6 +329,10 @@ jobs:
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v23.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v23.2.0
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
       - name: Pull 23.2 Fluent docker image
         if: steps.cache-232-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
@@ -355,6 +363,10 @@ jobs:
             doc/source/api/core/solver/datamodel
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v24.1.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v24.1.0
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
       - name: Pull 24.1 Fluent docker image
         if: steps.cache-241-api-code.outputs.cache-hit != 'true'
@@ -387,6 +399,10 @@ jobs:
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v24.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v24.2.0
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
       - name: Pull 24.2 Fluent docker image
         if: steps.cache-242-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
@@ -417,6 +433,10 @@ jobs:
             doc/source/api/core/solver/datamodel
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.1.0
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
       - name: Pull 25.1 Fluent docker image
         if: steps.cache-251-api-code.outputs.cache-hit != 'true'
@@ -449,6 +469,10 @@ jobs:
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v25.2.0
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
       - name: Pull 25.2 Fluent docker image
         if: steps.cache-252-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
@@ -479,6 +503,10 @@ jobs:
             doc/source/api/core/solver/datamodel
           key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}-${{ hashFiles('src/ansys/fluent/core/codegen/**') }}
           restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
       - name: Pull 26.1 Fluent docker image
         if: steps.cache-261-api-code.outputs.cache-hit != 'true'
@@ -515,6 +543,10 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
           retention-days: 7
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
   test:
     name: Unit Testing
@@ -600,6 +632,10 @@ jobs:
           name: coverage_report
           path: ./htmlcov
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
   nightly-dev-test:
     name: Release Testing
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -671,6 +707,10 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
   clean-up:
     name: Remove docker image

--- a/.github/workflows/doc-build-dev-nightly.yml
+++ b/.github/workflows/doc-build-dev-nightly.yml
@@ -112,6 +112,10 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
   deploy_dev_docs:
     runs-on: ubuntu-latest
     needs: [build_dev_docs]

--- a/.github/workflows/doc-build-release.yml
+++ b/.github/workflows/doc-build-release.yml
@@ -79,6 +79,10 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
   deploy_release_docs:
     runs-on: ubuntu-latest
     needs: [build_release_docs]

--- a/.github/workflows/execute-examples-weekly.yml
+++ b/.github/workflows/execute-examples-weekly.yml
@@ -182,3 +182,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/force-update-stable-Fluent-image-version.yml
+++ b/.github/workflows/force-update-stable-Fluent-image-version.yml
@@ -47,6 +47,11 @@ jobs:
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ansys/pyfluent:${{ env.FLUENT_IMAGE_TAG }} | sed 's/.*@//')
           gh variable set FLUENT_STABLE_IMAGE_DEV --body $DIGEST
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
+# TODO: Remove the following job
   clean-up:
     name: Remove docker image
     runs-on: [self-hosted, pyfluent]

--- a/.github/workflows/test-fluent-journals.yml
+++ b/.github/workflows/test-fluent-journals.yml
@@ -89,3 +89,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/test-run-custom.yml
+++ b/.github/workflows/test-run-custom.yml
@@ -117,3 +117,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/test-run-dev-version-nightly.yml
+++ b/.github/workflows/test-run-dev-version-nightly.yml
@@ -96,6 +96,11 @@ jobs:
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ansys/pyfluent:${{ env.FLUENT_IMAGE_TAG }} | sed 's/.*@//')
           gh variable set FLUENT_STABLE_IMAGE_DEV --body $DIGEST
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
+# TODO: Remove the following job
   clean-up:
     name: Remove docker image
     runs-on: [self-hosted, pyfluent]

--- a/.github/workflows/test-run-nightly.yml
+++ b/.github/workflows/test-run-nightly.yml
@@ -99,3 +99,7 @@ jobs:
         with:
           name: coverage_report
           path: ./htmlcov
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/test-run-old-versions-weekly.yml
+++ b/.github/workflows/test-run-old-versions-weekly.yml
@@ -69,6 +69,10 @@ jobs:
           cat src/ansys/fluent/core/generated/fluent_version_222.py
           python -c "from ansys.fluent.core.generated.solver.settings_222 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
       - name: Pull 23.1 Fluent docker image
         run: make docker-pull
         env:
@@ -83,6 +87,10 @@ jobs:
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_231.py
           python -c "from ansys.fluent.core.generated.solver.settings_231 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
       - name: Pull 23.2 Fluent docker image
         run: make docker-pull
@@ -99,6 +107,10 @@ jobs:
           cat src/ansys/fluent/core/generated/fluent_version_232.py
           python -c "from ansys.fluent.core.generated.solver.settings_232 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
+
       - name: Pull 24.1 Fluent docker image
         run: make docker-pull
         env:
@@ -113,6 +125,10 @@ jobs:
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_241.py
           python -c "from ansys.fluent.core.generated.solver.settings_241 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
       - name: Pull 25.1 Fluent docker image
         run: make docker-pull
@@ -144,6 +160,10 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
           retention-days: 7
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images
 
   test:
     name: Unit Testing
@@ -212,3 +232,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/test-run-solvermode-weekly.yml
+++ b/.github/workflows/test-run-solvermode-weekly.yml
@@ -81,3 +81,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/.github/workflows/test-run-wo-codegen-weekly.yml
+++ b/.github/workflows/test-run-wo-codegen-weekly.yml
@@ -132,3 +132,7 @@ jobs:
       - name: Cleanup previous docker containers
         if: always()
         run: make cleanup-previous-docker-containers
+
+      - name: Remove all docker images
+        if: always()
+        run: make docker-clean-images

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ version-info:
 docker-pull:
 	@bash .ci/pull_fluent_image.sh
 
+docker-clean-images:
+	@docker image prune -a -f
+
 test-import:
 	@python -c "import ansys.fluent.core as pyfluent"
 


### PR DESCRIPTION
Cleanup docker images after use to avoid the disk-space issue in self-hosted runners.

I'll push similar changes to other repos that consumes Fluent images.