### PR TITLE
fix: removing invalid pyproject.toml entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ style:
 
 install:
 	@pip install -r requirements/requirements_build.txt
+	@git clean -fd
 	@flit build
 	@pip install -q --force-reinstall dist/*.whl
 	@pip install packaging

--- a/doc/changelog.d/4148.fixed.md
+++ b/doc/changelog.d/4148.fixed.md
@@ -1,0 +1,1 @@
+removing invalid pyproject.toml entry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.10,<3.14"
 license = {file = "LICENSE"}
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
-repository = "https://github.com/ansys/pyfluent"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
@@ -80,9 +79,9 @@ docs = [
 name = "ansys.fluent.core"
 
 [project.urls]
-"Documentation" = "https://fluent.docs.pyansys.com/"
-"Source" = "https://github.com/ansys/pyfluent"
-"Tracker" = "https://github.com/ansys/pyfluent/issues"
+Documentation = "https://fluent.docs.pyansys.com/"
+Source = "https://github.com/ansys/pyfluent"
+Tracker = "https://github.com/ansys/pyfluent/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Reported by @prmukherj as seen in https://github.com/ansys/pyfluent/actions/runs/15600856694/job/43940344673

The logs are mentioning it here:

Unexpected names under [project]: repository        W-flit_core.config
Unexpected names under [project]: repository        W-flit_core.config

The repository entry shouldn't be there. You already have a Source entry in [project.urls] which is what PyPI needs =)