### PR TITLE
fix: container launch issues

### DIFF
--- a/doc/changelog.d/4163.fixed.md
+++ b/doc/changelog.d/4163.fixed.md
@@ -1,0 +1,1 @@
+container launch issues

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -44,6 +44,7 @@ from typing import Any
 from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.launcher.fluent_container import (
     configure_container_dict,
+    dict_to_str,
     start_fluent_container,
 )
 from ansys.fluent.core.launcher.launch_options import (
@@ -199,22 +200,20 @@ class DockerLauncher:
             self._args.append(" -meshing")
 
     def __call__(self):
+
         if self.argvals["dry_run"]:
             config_dict, *_ = configure_container_dict(
                 self._args, **self.argvals["container_dict"]
             )
-            from pprint import pprint
-
+            dict_str = dict_to_str(config_dict)
             print("\nDocker container run configuration:\n")
             print("config_dict = ")
-            if os.getenv("PYFLUENT_HIDE_LOG_SECRETS") != "1":
-                pprint(config_dict)
-            else:
-                config_dict_h = config_dict.copy()
-                config_dict_h.pop("environment")
-                pprint(config_dict_h)
-                del config_dict_h
+            print(dict_str)
+            logger.debug(f"Docker container config_dict:\n{dict_str}")
             return config_dict
+
+        logger.debug(f"Fluent container launcher args: {self._args}")
+        logger.debug(f"Fluent container launcher argvals:\n{dict_to_str(self.argvals)}")
 
         if is_compose():
             port, config_dict, container = start_fluent_container(

--- a/src/ansys/fluent/core/launcher/container_launcher.py
+++ b/src/ansys/fluent/core/launcher/container_launcher.py
@@ -209,7 +209,6 @@ class DockerLauncher:
             print("\nDocker container run configuration:\n")
             print("config_dict = ")
             print(dict_str)
-            logger.debug(f"Docker container config_dict:\n{dict_str}")
             return config_dict
 
         logger.debug(f"Fluent container launcher args: {self._args}")

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -182,9 +182,12 @@ def configure_container_dict(
     args : List[str]
         List of Fluent launch arguments.
     mount_source : str | Path, optional
-        Existing path in the host operating system that will be mounted to ``mount_target``.
+        Path on the host system to mount into the container. This directory will serve as the working directory
+        for the Fluent process inside the container. If not specified, PyFluent's current working directory will
+        be used.
     mount_target : str | Path, optional
-        Path inside the container where ``mount_source`` will be mounted to.
+        Path inside the container where ``mount_source`` will be mounted. This will be the working directory path
+        visible to the Fluent process running inside the container.
     timeout : int, optional
         Time limit  for the Fluent container to start, in seconds. By default, 30 seconds.
     port : int, optional

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -123,15 +123,6 @@ def dict_to_str(dict: dict) -> str:
     """Converts the dict to string while hiding the 'environment' argument from the dictionary,
     if the environment variable 'PYFLUENT_HIDE_LOG_SECRETS' is '1'.
     This is useful for logging purposes, to avoid printing sensitive information such as license server details.
-
-    Parameters
-    ----------
-    dict : dict
-        The container dictionary to be converted to string.
-    Returns
-    -------
-    string
-        Nicely formatted string representation of the dictionary, with the 'environment' key removed if hiding secrets.
     """
 
     if "environment" in dict and os.getenv("PYFLUENT_HIDE_LOG_SECRETS") == "1":

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -452,7 +452,12 @@ def configure_container_dict(
         container_dict["mount_source"] = mount_source
         container_dict["mount_target"] = mount_target
 
-    logger.debug(f"Fluent container dict command: {container_dict['command']}")
+    logger.debug(
+        f"Fluent container timeout: {timeout}, container_grpc_port: {container_grpc_port}, "
+        f"host_server_info_file: '{host_server_info_file}', "
+        f"remove_server_info_file: {remove_server_info_file}"
+    )
+    logger.debug(f"container_dict after processing:\n{dict_to_str(container_dict)}")
 
     return (
         container_dict,
@@ -507,21 +512,6 @@ def start_fluent_container(
         host_server_info_file,
         remove_server_info_file,
     ) = container_vars
-
-    if os.getenv("PYFLUENT_HIDE_LOG_SECRETS") != "1":
-        logger.debug(f"container_vars: {container_vars}")
-    else:
-        config_dict_h = config_dict.copy()
-        config_dict_h.pop("environment")
-        container_vars_tmp = (
-            config_dict_h,
-            timeout,
-            port,
-            host_server_info_file,
-            remove_server_info_file,
-        )
-        logger.debug(f"container_vars: {container_vars_tmp}")
-        del container_vars_tmp
 
     try:
         if is_compose():

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -131,7 +131,7 @@ def dict_to_str(dict: dict) -> str:
     Returns
     -------
     string
-        Nicely formatted string representation of the dictionary, with the 'environment' argument removed.
+        Nicely formatted string representation of the dictionary, with the 'environment' key removed if hiding secrets.
     """
 
     if "environment" in dict and os.getenv("PYFLUENT_HIDE_LOG_SECRETS") == "1":
@@ -307,7 +307,8 @@ def configure_container_dict(
         container_dict["volumes"][0] = f"{mount_source}:{mount_target}"
 
     logger.warning(
-        f"Configuring Fluent container to mount to {mount_source}, with this path available as {mount_target} for the Fluent session running inside the container."
+        f"Configuring Fluent container to mount to {mount_source}, "
+        f"with this path available as {mount_target} for the Fluent session running inside the container."
     )
 
     if "working_dir" not in container_dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,6 @@ def run_before_each_test(
     monkeypatch.setenv("PYFLUENT_TEST_NAME", request.node.name)
     monkeypatch.setenv("PYFLUENT_CODEGEN_SKIP_BUILTIN_SETTINGS", "1")
     pyfluent.CONTAINER_MOUNT_SOURCE = pyfluent.EXAMPLES_PATH
-    pyfluent.CONTAINER_MOUNT_TARGET = pyfluent.EXAMPLES_PATH
     original_cwd = os.getcwd()
     monkeypatch.chdir(tmp_path)
     yield

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -661,8 +661,8 @@ def test_builtin_settings(mixing_elbow_case_data_session):
     else:
         with pytest.raises(RuntimeError):
             CustomVectors(settings_source=solver)
-    tmp_save_path = tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH)
-    project_file = Path(tmp_save_path) / "mixing_elbow_param.flprj"
+    tmp_save_path = Path(tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH))
+    project_file = Path(tmp_save_path.parts[-1]) / "mixing_elbow_param.flprj"
     solver.settings.parametric_studies.initialize(project_filename=str(project_file))
     assert ParametricStudies(settings_source=solver) == solver.parametric_studies
     assert (

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -151,6 +151,15 @@ def test_container_launcher():
     assert session.is_server_healthy()
 
 
+def test_container_launcher_working_dir():
+    container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True)
+    container_dict.update(
+        volumes=[f"{os.getcwd()}:/mnt/pyfluent"], working_dir="/mnt/pyfluent"
+    )
+    session = pyfluent.launch_fluent(container_dict=container_dict)
+    assert session.is_server_healthy()
+
+
 @pytest.mark.standalone
 def test_case_load():
     # Test that launch_fluent() works with a case file as an argument

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -494,17 +494,18 @@ def test_processor_count():
     #     assert get_processor_count(solver) == 2
 
 
-def test_container_warning_for_mount_source(caplog):
+def test_container_mount_source_target(caplog):
     container_dict = {
         "mount_source": os.getcwd(),
         "mount_target": "/mnt/pyfluent/tests",
     }
-    _ = pyfluent.launch_fluent(container_dict=container_dict)
+    session = pyfluent.launch_fluent(container_dict=container_dict)
+    assert session.is_server_healthy()
     assert container_dict["mount_source"] in caplog.text
     assert container_dict["mount_target"] in caplog.text
 
 
-# runs only in container till cwd is supported for container launch
+# runs only in container till cwd is supported for standalone launch
 def test_fluent_automatic_transcript(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -554,10 +554,10 @@ def test_fluent_automatic_transcript(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(pyfluent, "FLUENT_AUTOMATIC_TRANSCRIPT", True)
         with TemporaryDirectory(dir=pyfluent.EXAMPLES_PATH) as tmp_dir:
-            with pyfluent.launch_fluent(container_dict=dict(working_dir=tmp_dir)):
+            with pyfluent.launch_fluent(container_dict=dict(mount_source=tmp_dir)):
                 assert list(Path(tmp_dir).glob("*.trn"))
     with TemporaryDirectory(dir=pyfluent.EXAMPLES_PATH) as tmp_dir:
-        with pyfluent.launch_fluent(container_dict=dict(working_dir=tmp_dir)):
+        with pyfluent.launch_fluent(container_dict=dict(mount_source=tmp_dir)):
             assert not list(Path(tmp_dir).glob("*.trn"))
 
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -151,12 +151,56 @@ def test_container_launcher():
     assert session.is_server_healthy()
 
 
-def test_container_launcher_working_dir():
+def test_container_working_dir():
+    pyfluent.CONTAINER_MOUNT_SOURCE = None
+
     container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True)
-    container_dict.update(
-        volumes=[f"{os.getcwd()}:/mnt/pyfluent"], working_dir="/mnt/pyfluent"
+    assert container_dict["volumes"][0].startswith(os.getcwd())
+    assert container_dict["volumes"][0].endswith(pyfluent.CONTAINER_MOUNT_TARGET)
+    assert container_dict["working_dir"] == pyfluent.CONTAINER_MOUNT_TARGET
+    server_info_matches = [
+        arg
+        for arg in container_dict["command"]
+        if arg.startswith(f"-sifile={pyfluent.CONTAINER_MOUNT_TARGET}/serverinfo")
+    ]
+    assert len(server_info_matches) == 1, "Expected one server info file in command"
+
+    target_mount1 = "/mnt/test1"
+    container_dict.update(working_dir=target_mount1)
+    container_dict2 = pyfluent.launch_fluent(
+        container_dict=container_dict, dry_run=True
     )
-    session = pyfluent.launch_fluent(container_dict=container_dict)
+    del container_dict
+    assert container_dict2["volumes"][0].startswith(os.getcwd())
+    assert container_dict2["volumes"][0].endswith(target_mount1)
+    assert container_dict2["working_dir"] == target_mount1
+    server_info_matches2 = [
+        arg
+        for arg in container_dict2["command"]
+        if arg.startswith(f"-sifile={target_mount1}/serverinfo")
+    ]
+    assert len(server_info_matches2) == 1, "Expected one server info file in command"
+
+    target_mount2 = "/mnt/test2"
+    container_dict2.update(
+        volumes=[f"{pyfluent.EXAMPLES_PATH}:{target_mount2}"], working_dir=target_mount2
+    )
+    container_dict3 = pyfluent.launch_fluent(
+        container_dict=container_dict2, dry_run=True
+    )
+    del container_dict2
+    assert container_dict3["volumes"][0].startswith(pyfluent.EXAMPLES_PATH)
+    assert container_dict3["volumes"][0].endswith(target_mount2)
+    assert container_dict3["working_dir"] == target_mount2
+    server_info_matches3 = [
+        arg
+        for arg in container_dict3["command"]
+        if arg.startswith(f"-sifile={target_mount2}/serverinfo")
+    ]
+    assert len(server_info_matches3) == 1, "Expected one server info file in command"
+
+    # after all these 'working_dir' changes, the container should still launch
+    session = pyfluent.launch_fluent(container_dict=container_dict3)
     assert session.is_server_healthy()
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -594,7 +594,6 @@ def test_general_exception_behaviour_in_session(new_solver_session):
     case_file = examples.download_file(
         "mixing_elbow.cas.h5",
         "pyfluent/mixing_elbow",
-        return_without_path=False,
     )
     solver.settings.file.read(file_type="case", file_name=case_file)
     solver.file.write(file_name="sample.cas.h5", file_type="case")
@@ -660,14 +659,18 @@ def test_app_utilities_new_and_old(mixing_elbow_settings_session):
 
     tmp_dir = tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH)
 
-    solver.chdir(tmp_dir)
+    # when running in a container, only the randomly generated folder name will be seen
+    # the full paths will be different between host and container
+    tmp_folder = Path(tmp_dir).parts[-1]
+
+    solver.chdir(tmp_folder)
 
     cortex_info = solver._app_utilities.get_controller_process_info()
     solver_info = solver._app_utilities.get_solver_process_info()
 
-    assert Path(cortex_info.working_directory) == Path(tmp_dir)
+    assert Path(cortex_info.working_directory).parts[-1] == tmp_folder
 
-    assert Path(solver_info.working_directory) == Path(tmp_dir)
+    assert Path(solver_info.working_directory).parts[-1] == tmp_folder
 
 
 @pytest.mark.standalone

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -657,11 +657,11 @@ def test_app_utilities_new_and_old(mixing_elbow_settings_session):
 
     assert not solver._app_utilities.is_solution_data_available()
 
-    tmp_dir = tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH)
+    tmp_path = tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH)
 
     # when running in a container, only the randomly generated folder name will be seen
     # the full paths will be different between host and container
-    tmp_folder = Path(tmp_dir).parts[-1]
+    tmp_folder = Path(tmp_path).parts[-1]
 
     solver.chdir(tmp_folder)
 


### PR DESCRIPTION
There were issues running Fluent containers through PyFluent introduced at some point since version 0.30.5 (after which the `simba-plugin-fluent` tests started failing). The mount_source/mount_target/working_dir logic  was not working properly, see first commit below for test that was showing the failure: https://github.com/ansys/pyfluent/pull/4163/commits/270495dd0be9453e728699e14b017e401874fd6c

Notes:
- Main change: revised mount_source/mount_target logic, see code comments in `fluent_container.py` for more details
- Took the opportunity to do some refactoring:
  - New `dict_to_str` utility function to provide "pretty printed" string for dicts, also aware of hide log secrets env var for CI runs
  - Revised docstring for mount_source/mount_target
- New test, and test fixes related to this. In summary: we should not assume that the full paths that Fluent sees inside the container match exactly the full paths that PyFluent sees on the host system