### PR TITLE
fix: Fix an issue in returning parameter units

### DIFF
--- a/doc/changelog.d/4177.fixed.md
+++ b/doc/changelog.d/4177.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue in returning parameter units

--- a/src/ansys/fluent/core/services/scheme_eval.py
+++ b/src/ansys/fluent/core/services/scheme_eval.py
@@ -43,6 +43,7 @@ from ansys.api.fluent.v0.scheme_pointer_pb2 import SchemePointer
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
+    GrpcErrorInterceptor,
     TracingInterceptor,
 )
 from ansys.fluent.core.utils.fluent_version import FluentVersion
@@ -60,6 +61,7 @@ class SchemeEvalService:
         """__init__ method of SchemeEvalService class."""
         intercept_channel = grpc.intercept_channel(
             channel,
+            GrpcErrorInterceptor(),
             ErrorStateInterceptor(fluent_error_state),
             TracingInterceptor(),
             BatchInterceptor(),

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1780,10 +1780,16 @@ def _fix_parameter_list_return(val):
                 # Symbols are not stripped in the command return in PyConsole.
                 # Following code will work in both PyConsole and PyFluent.
                 unit = units[0].lstrip("'")
-                unit_labels = _fix_parameter_list_return.scheme_eval(
-                    f"(units/inquire-available-label-strings-for-quantity '{unit})"
-                )
-                unit_label = unit_labels[0] if len(unit_labels) > 0 else ""
+                if unit != "*null*":
+                    try:
+                        unit_labels = _fix_parameter_list_return.scheme_eval(
+                            f"(units/inquire-available-label-strings-for-quantity '{unit})"
+                        )
+                    except RuntimeError:
+                        unit_labels = []
+                    unit_label = unit_labels[0] if len(unit_labels) > 0 else ""
+                else:
+                    unit_label = ""
             else:
                 unit_label = ""
             new_val[name] = [value, unit_label]


### PR DESCRIPTION
We retrieve the Fluent unit strings via scheme calls from PyFluent at the end of the execution of `parameters.output_parameters.list()` command in PyFluent so we can populate Fluent unit strings in that command's return value. This PR prevents a Fluent-side error which was coming from those scheme calls.

`parameters.output_parameters.list()` will be fixed in 26.1 to contain the Fluent unit strings in the return value. The above PyFluent workaround will still be needed in Fluent versions <= 25.2.