### PR TITLE
feat: Set string settings with allowed values via string constants

### DIFF
--- a/doc/changelog.d/4190.added.md
+++ b/doc/changelog.d/4190.added.md
@@ -1,0 +1,1 @@
+Set string settings with allowed values via string constants

--- a/src/ansys/fluent/core/codegen/settingsgen.py
+++ b/src/ansys/fluent/core/codegen/settingsgen.py
@@ -317,6 +317,7 @@ def _write_data(cls_name: str, python_name: str, data: dict, f: IO, f_stub: IO |
             f"    {to_constant_name(allowed_value)}: Final[str] = {allowed_value!r}\n"
         )
     s.write("\n")
+    s_stub.write("\n")
     for name, (python_name, data, hash_, should_write_stub) in classes_to_write.items():
         if name not in _CLASS_WRITTEN:
             _write_data(

--- a/src/ansys/fluent/core/codegen/settingsgen.py
+++ b/src/ansys/fluent/core/codegen/settingsgen.py
@@ -311,7 +311,7 @@ def _write_data(cls_name: str, python_name: str, data: dict, f: IO, f_stub: IO |
         s_stub.write("    return_type: str\n")
     for allowed_value in data["allowed_values"]:
         s.write(
-            f"    {to_constant_name(allowed_value)} = _FlConstant({allowed_value!r})\n"
+            f"    {to_constant_name(allowed_value)} = _FlStringConstant({allowed_value!r})\n"
         )
         s_stub.write(
             f"    {to_constant_name(allowed_value)}: Final[str] = {allowed_value!r}\n"
@@ -381,7 +381,7 @@ def generate(version: str, static_infos: dict, verbose: bool = False) -> None:
         header.write("    _InputFile,\n")
         header.write("    _OutputFile,\n")
         header.write("    _InOutFile,\n")
-        header.write("    _FlConstant,\n")
+        header.write("    _FlStringConstant,\n")
         header.write(")\n\n")
         f.write(header.getvalue())
         f_stub.write(header.getvalue())

--- a/src/ansys/fluent/core/codegen/settingsgen.py
+++ b/src/ansys/fluent/core/codegen/settingsgen.py
@@ -38,6 +38,7 @@ from ansys.fluent.core.solver.flobject import (
     ListObject,
     NamedObject,
     get_cls,
+    to_constant_name,
     to_python_name,
 )
 from ansys.fluent.core.utils.fix_doc import fix_settings_doc
@@ -151,6 +152,7 @@ def _populate_data(cls, api_tree: dict, version: str) -> dict:
         data["child_object_type"]["doc"] = f"'child_object_type' of {cls.__name__}."
     else:
         data["child_object_type"] = None
+    data["allowed_values"] = getattr(cls, "_allowed_values", [])
     return data
 
 
@@ -307,6 +309,13 @@ def _write_data(cls_name: str, python_name: str, data: dict, f: IO, f_stub: IO |
     if return_type:
         s.write(f"    return_type = {return_type!r}\n")
         s_stub.write("    return_type: str\n")
+    for allowed_value in data["allowed_values"]:
+        s.write(
+            f"    {to_constant_name(allowed_value)} = _FlConstant({allowed_value!r})\n"
+        )
+        s_stub.write(
+            f"    {to_constant_name(allowed_value)}: Final[str] = {allowed_value!r}\n"
+        )
     s.write("\n")
     for name, (python_name, data, hash_, should_write_stub) in classes_to_write.items():
         if name not in _CLASS_WRITTEN:
@@ -371,10 +380,11 @@ def generate(version: str, static_infos: dict, verbose: bool = False) -> None:
         header.write("    _InputFile,\n")
         header.write("    _OutputFile,\n")
         header.write("    _InOutFile,\n")
+        header.write("    _FlConstant,\n")
         header.write(")\n\n")
         f.write(header.getvalue())
         f_stub.write(header.getvalue())
-        f_stub.write("from typing import Any\n\n")
+        f_stub.write("from typing import Any, Final\n\n")
         f.write(f'SHASH = "{shash}"\n\n')
         name = data["name"]
         _NAME_BY_HASH[_gethash(data)] = name

--- a/src/ansys/fluent/core/services/settings.py
+++ b/src/ansys/fluent/core/services/settings.py
@@ -335,6 +335,7 @@ class SettingsService:
         """
         request = SettingsModule.GetStaticInfoRequest()
         request.root = "fluent"
+        request.optional_attrs.append("allowed-values")
         response = self._service_impl.get_static_info(request)
         # The RPC calls no longer raise an exception. Force an exception if
         # type is empty

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -504,6 +504,7 @@ from ansys.fluent.core.solver.flobject import (
     _InputFile,
     _OutputFile,
     _InOutFile,
+    _FlConstant,
 )
 
 SHASH = "3e6d76a4601701388ea8258912d145b7b7c436699a50b6c7fe9a29f41eeff194"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -504,7 +504,7 @@ from ansys.fluent.core.solver.flobject import (
     _InputFile,
     _OutputFile,
     _InOutFile,
-    _FlConstant,
+    _FlStringConstant,
 )
 
 SHASH = "3e6d76a4601701388ea8258912d145b7b7c436699a50b6c7fe9a29f41eeff194"

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -772,6 +772,7 @@ def test_setting_string_constants(mixing_elbow_settings_session):
 
     # viscous.model.INVISCID is a string constant
     assert viscous.model.INVISCID == "inviscid"
+    assert isinstance(viscous.model.INVISCID, str)
     with pytest.raises(AttributeError):
         viscous.model.INVISCID = "invalid"
 
@@ -781,7 +782,9 @@ def test_setting_string_constants(mixing_elbow_settings_session):
     viscous.model = viscous.model.K_EPSILON
     assert viscous.model() == "k-epsilon"
     viscous.k_epsilon_model = viscous.k_epsilon_model.RNG
+    assert viscous.k_epsilon_model.RNG.is_active() is True
     assert viscous.k_epsilon_model() == "rng"
+    assert viscous.k_epsilon_model.EASM.is_active() is False
 
     with pytest.raises(ValueError):
         viscous.k_epsilon_model = viscous.k_epsilon_model.EASM

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -27,6 +27,7 @@ from pytest import WarningsRecorder
 
 from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.pyfluent_warnings import PyFluentUserWarning
+from ansys.fluent.core.solver import Viscous
 from ansys.fluent.core.solver.flobject import (
     DeprecatedSettingWarning,
     _Alias,
@@ -762,3 +763,25 @@ def test_runtime_python_classes(
         ].general.material()
         == "water-liquid"
     )
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_setting_string_constants(mixing_elbow_settings_session):
+    solver = mixing_elbow_settings_session
+    viscous = Viscous(solver)
+
+    # viscous.model.INVISCID is a string constant
+    assert viscous.model.INVISCID == "inviscid"
+    with pytest.raises(AttributeError):
+        viscous.model.INVISCID = "invalid"
+
+    # Setting using string constants
+    viscous.model = viscous.model.INVISCID
+    assert viscous.model() == "inviscid"
+    viscous.model = viscous.model.K_EPSILON
+    assert viscous.model() == "k-epsilon"
+    viscous.k_epsilon_model = viscous.k_epsilon_model.RNG
+    assert viscous.k_epsilon_model() == "rng"
+
+    with pytest.raises(ValueError):
+        viscous.k_epsilon_model = viscous.k_epsilon_model.EASM


### PR DESCRIPTION
The enumerated values are exposed as constant attributes of the instance. Please see the unittest for usage.

There is already an attribute `allowed-values-with-display-text` in settings API to fetch all possible allowed values which has been added to the static-info (Fluent PR 599447).

Below is the fragment of generated class:
```
class model_2(String, AllowedValuesMixin):
    """
    Viscous Model.
    """
    _version = '261'
    fluent_name = 'model'
    _python_name = 'model'
    LAMINAR = _FlConstant('laminar')
    MIXING_LENGTH = _FlConstant('mixing-length')
    KE1E = _FlConstant('ke1e')
    INVISCID = _FlConstant('inviscid')
...
```

TODO: doc update