### PR TITLE
fix: No warning for None values and remove a doc dependency

### DIFF
--- a/doc/changelog.d/4197.fixed.md
+++ b/doc/changelog.d/4197.fixed.md
@@ -1,0 +1,1 @@
+No warning for None values and remove a doc dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ docs = [
     "quarto-cli==1.7.32",
     "pdf2image==1.17.0",
     "seaborn>=0.13.2",
-    "tensorflow>=2.17.0",
 ]
 
 [tool.flit.module]

--- a/src/ansys/fluent/core/launcher/launch_options.py
+++ b/src/ansys/fluent/core/launcher/launch_options.py
@@ -295,7 +295,7 @@ def _get_graphics_driver(
     ui_mode_ = UIMode(ui_mode)
     if graphics_driver is not None and ui_mode_ not in {UIMode.GUI, UIMode.HIDDEN_GUI}:
         warnings.warn(
-            "The 'graphics_driver' parameter is only applicable when the 'ui_mode' is set to 'gui' or 'hidden_gui'.",
+            "User-specified value for graphics driver is ignored while launching Fluent without GUI or without graphics.",
             PyFluentUserWarning,
         )
     if isinstance(

--- a/src/ansys/fluent/core/launcher/launch_options.py
+++ b/src/ansys/fluent/core/launcher/launch_options.py
@@ -286,19 +286,6 @@ def _should_add_driver_null(ui_mode: UIMode | None = None) -> bool:
     return ui_mode not in {UIMode.GUI, UIMode.HIDDEN_GUI}
 
 
-def _is_graphics_driver_setting_ignored(
-    ui_mode, graphics_driver_, graphics_driver, ui_mode_
-):
-    """Return True if user-specified graphics driver setting is ignored based on UI mode and driver."""
-    is_ui_mode_set = ui_mode is not None
-    is_graphics_driver_set = (
-        graphics_driver_ is not None and graphics_driver.value != "null"
-    )
-    is_ui_mode_not_gui = ui_mode_ not in {UIMode.GUI, UIMode.HIDDEN_GUI}
-
-    return is_ui_mode_set and is_graphics_driver_set and is_ui_mode_not_gui
-
-
 def _get_graphics_driver(
     graphics_driver: (
         FluentWindowsGraphicsDriver | FluentLinuxGraphicsDriver | str | None
@@ -306,7 +293,11 @@ def _get_graphics_driver(
     ui_mode: UIMode | None = None,
 ):
     ui_mode_ = UIMode(ui_mode)
-    graphics_driver_ = graphics_driver
+    if graphics_driver is not None and ui_mode_ not in {UIMode.GUI, UIMode.HIDDEN_GUI}:
+        warnings.warn(
+            "The 'graphics_driver' parameter is only applicable when the 'ui_mode' is set to 'gui' or 'hidden_gui'.",
+            PyFluentUserWarning,
+        )
     if isinstance(
         graphics_driver, (FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver)
     ):
@@ -316,13 +307,6 @@ def _get_graphics_driver(
         if is_windows()
         else FluentLinuxGraphicsDriver(graphics_driver)
     )
-    if _is_graphics_driver_setting_ignored(
-        ui_mode, graphics_driver_, graphics_driver, ui_mode_
-    ):
-        warnings.warn(
-            "User-specified value for graphics driver is ignored while launching Fluent without GUI or without graphics.",
-            PyFluentUserWarning,
-        )
     if _should_add_driver_null(ui_mode_):
         return (
             FluentWindowsGraphicsDriver.NULL

--- a/src/ansys/fluent/core/launcher/launch_options.py
+++ b/src/ansys/fluent/core/launcher/launch_options.py
@@ -286,7 +286,7 @@ def _should_add_driver_null(ui_mode: UIMode | None = None) -> bool:
     return ui_mode not in {UIMode.GUI, UIMode.HIDDEN_GUI}
 
 
-def is_graphics_driver_setting_ignored(
+def _is_graphics_driver_setting_ignored(
     ui_mode, graphics_driver_, graphics_driver, ui_mode_
 ):
     """Return True if user-specified graphics driver setting is ignored based on UI mode and driver."""
@@ -316,7 +316,7 @@ def _get_graphics_driver(
         if is_windows()
         else FluentLinuxGraphicsDriver(graphics_driver)
     )
-    if is_graphics_driver_setting_ignored(
+    if _is_graphics_driver_setting_ignored(
         ui_mode, graphics_driver_, graphics_driver, ui_mode_
     ):
         warnings.warn(

--- a/src/ansys/fluent/core/launcher/launch_options.py
+++ b/src/ansys/fluent/core/launcher/launch_options.py
@@ -286,6 +286,19 @@ def _should_add_driver_null(ui_mode: UIMode | None = None) -> bool:
     return ui_mode not in {UIMode.GUI, UIMode.HIDDEN_GUI}
 
 
+def is_graphics_driver_setting_ignored(
+    ui_mode, graphics_driver_, graphics_driver, ui_mode_
+):
+    """Return True if user-specified graphics driver setting is ignored based on UI mode and driver."""
+    is_ui_mode_set = ui_mode is not None
+    is_graphics_driver_set = (
+        graphics_driver_ is not None and graphics_driver.value != "null"
+    )
+    is_ui_mode_not_gui = ui_mode_ not in {UIMode.GUI, UIMode.HIDDEN_GUI}
+
+    return is_ui_mode_set and is_graphics_driver_set and is_ui_mode_not_gui
+
+
 def _get_graphics_driver(
     graphics_driver: (
         FluentWindowsGraphicsDriver | FluentLinuxGraphicsDriver | str | None
@@ -293,6 +306,7 @@ def _get_graphics_driver(
     ui_mode: UIMode | None = None,
 ):
     ui_mode_ = UIMode(ui_mode)
+    graphics_driver_ = graphics_driver
     if isinstance(
         graphics_driver, (FluentWindowsGraphicsDriver, FluentLinuxGraphicsDriver)
     ):
@@ -302,10 +316,9 @@ def _get_graphics_driver(
         if is_windows()
         else FluentLinuxGraphicsDriver(graphics_driver)
     )
-    if graphics_driver.value != "null" and ui_mode_ not in {
-        UIMode.GUI,
-        UIMode.HIDDEN_GUI,
-    }:
+    if is_graphics_driver_setting_ignored(
+        ui_mode, graphics_driver_, graphics_driver, ui_mode_
+    ):
         warnings.warn(
             "User-specified value for graphics driver is ignored while launching Fluent without GUI or without graphics.",
             PyFluentUserWarning,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -706,3 +706,12 @@ def test_warning_in_linux():
             ui_mode=UIMode.NO_GUI_OR_GRAPHICS,
         )
         assert driver == FluentLinuxGraphicsDriver.NULL
+
+
+def test_no_warning_for_none_values(caplog):
+    driver = _get_graphics_driver(graphics_driver=None, ui_mode=None)  # noqa: F841
+    assert "PyFluentUserWarning" not in caplog.text
+    caplog.clear()
+    driver = _get_graphics_driver(graphics_driver=None, ui_mode=None)  # noqa: F841
+    assert "PyFluentUserWarning" not in caplog.text
+    caplog.clear()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -712,6 +712,3 @@ def test_no_warning_for_none_values(caplog):
     driver = _get_graphics_driver(graphics_driver=None, ui_mode=None)  # noqa: F841
     assert "PyFluentUserWarning" not in caplog.text
     caplog.clear()
-    driver = _get_graphics_driver(graphics_driver=None, ui_mode=None)  # noqa: F841
-    assert "PyFluentUserWarning" not in caplog.text
-    caplog.clear()


### PR DESCRIPTION
1. Remove tensorflow dependency as it is supported for Python version <= 3.10.
2. quarto-cli works fine after updating ansys-sphinx-theme.
3. Do not show a warning if graphics_drivers or ui_mode are None.

We will merge this PR before creating a release.

Earlier -

```
solver = launch_fluent(start_container=True, dry_run=True)
/home/hpohekar/pyfluent/src/ansys/fluent/core/launcher/launch_options.py:309: PyFluentUserWarning: User-specified value for graphics driver is ignored while launching Fluent without GUI or without graphics.
  warnings.warn(
pyfluent.launcher WARNING: Configuring Fluent container to mount to /home/hpohekar/pyfluent, with this path available as /home/container/workdir for the Fluent session running inside the container.
```

Now - 

```
solver = launch_fluent(start_container=True, dry_run=True)
pyfluent.launcher WARNING: Configuring Fluent container to mount to /home/hpohekar/pyfluent, with this path available as /home/container/workdir for the Fluent session running inside the container.
```

