### PR TITLE
fix: interior zones are inactive in the latest Fluent image

### DIFF
--- a/doc/changelog.d/4217.fixed.md
+++ b/doc/changelog.d/4217.fixed.md
@@ -1,0 +1,1 @@
+interior zones are inactive in the latest Fluent image

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -175,10 +175,6 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         == solver.setup.boundary_conditions.interior
     )
     assert (
-        InteriorBoundary(settings_source=solver, name="interior--elbow-fluid")
-        == solver.setup.boundary_conditions.interior["interior--elbow-fluid"]
-    )
-    assert (
         PressureOutlets(settings_source=solver)
         == solver.setup.boundary_conditions.pressure_outlet
     )
@@ -547,9 +543,9 @@ def test_builtin_settings(mixing_elbow_case_data_session):
     else:
         with pytest.raises(RuntimeError):
             CustomVectors(settings_source=solver)
-    tmp_save_path = Path(tempfile.mkdtemp(dir=pyfluent.EXAMPLES_PATH))
-    project_file = Path(tmp_save_path.parts[-1]) / "mixing_elbow_param.flprj"
-    solver.settings.parametric_studies.initialize(project_filename=str(project_file))
+    solver.settings.parametric_studies.initialize(
+        project_filename="mixing_elbow_param.flprj"
+    )
     assert ParametricStudies(settings_source=solver) == solver.parametric_studies
     assert (
         ParametricStudy(settings_source=solver, name="mixing_elbow-Solve")

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -38,7 +38,6 @@ def _test_locn_extraction(solver1, solver2):
     all_bcs = solver1_boundary_conditions
     locns = _locn_names_and_objs(all_bcs)
     assert locns == [
-        ["interior--fluid", all_bcs],
         ["outlet", all_bcs],
         ["inlet1", all_bcs],
         ["inlet2", all_bcs],
@@ -52,12 +51,10 @@ def _test_locn_extraction(solver1, solver2):
     all_bcs2 = solver2_boundary_conditions
     locns = _locn_names_and_objs([all_bcs, all_bcs2])
     assert locns == [
-        ["interior--fluid", all_bcs],
         ["outlet", all_bcs],
         ["inlet1", all_bcs],
         ["inlet2", all_bcs],
         ["wall", all_bcs],
-        ["interior--fluid", all_bcs2],
         ["outlet", all_bcs2],
         ["inlet1", all_bcs2],
         ["inlet2", all_bcs2],


### PR DESCRIPTION
Updating tests based on Fluent PR 599405 changes.

Nightly test CI passed - https://github.com/ansys/pyfluent/actions/runs/15906604497