### PR TITLE
docs: Fix search box [skip tests]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ docs = [
     "jupyter_sphinx==0.5.3",
     "numpydoc==1.8.0",
     "matplotlib==3.10.3",
-    "ansys-sphinx-theme==1.5.2",
+    "ansys-sphinx-theme==1.4.2",
     "pypandoc==1.15",
     "pytest-sphinx==0.6.3",
     "sphinx-autobuild==2024.10.3",


### PR DESCRIPTION
closes https://github.com/ansys/pyfluent/issues/4225

Search has disappeared after upgrading ansys-aphinx-theme from 1.4.2 onwards.

We have downgraded it to 1.4.2 as it is working fine.

Local docs - 

![image](https://github.com/user-attachments/assets/cc67ae07-1c70-4c48-84b7-5b7c51b5c384)
