### PR TITLE
feat: add settings named objects

### DIFF
--- a/doc/changelog.d/4232.added.md
+++ b/doc/changelog.d/4232.added.md
@@ -1,0 +1,1 @@
+add settings named objects

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1470,9 +1470,14 @@ class CombinedNamedObject:
 
     def __init__(self, objects: list[NamedObject]):
         """__init__ of CombinedNamedObject."""
-        self.objects = objects
+        self.objects = []
         self._items = []
         for obj in objects:
+            if isinstance(obj, CombinedNamedObject):
+                self.objects.extend(obj.objects)
+            else:
+                self.objects.append(obj)
+        for obj in self.objects:
             self._items.extend(obj.items())
 
     def items(self):
@@ -1482,6 +1487,11 @@ class CombinedNamedObject:
     def __iter__(self):
         for obj in self.objects:
             yield from obj
+
+    def __add__(self, other):
+        if not isinstance(other, NamedObject):
+            raise TypeError(f"Cannot add {type(self)} to NamedObject")
+        return CombinedNamedObject(self.objects + [other])
 
     def __call__(self):
         temp_dict = {}

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1457,6 +1457,38 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
         else:
             return getattr(super(), name)
 
+    def __add__(self, other):
+        if not isinstance(other, NamedObject):
+            raise TypeError(
+                f"Can only add NamedObject to NamedObject, not {type(other).__name__}"
+            )
+        return CombinedNamedObject([self, other])
+
+
+class CombinedNamedObject:
+    """A ``CombinedNamedObject`` contains the concatenated named-objects."""
+
+    def __init__(self, objects: list[NamedObject]):
+        """__init__ of CombinedNamedObject."""
+        self.objects = objects
+        self._items = []
+        for obj in objects:
+            self._items.extend(obj.items())
+
+    def items(self):
+        """Return items like a dictionary."""
+        return self._items
+
+    def __iter__(self):
+        for obj in self.objects:
+            yield from obj
+
+    def __call__(self):
+        temp_dict = {}
+        for obj in self.objects:
+            temp_dict.update(obj())
+        return temp_dict
+
 
 def _rename(obj: NamedObject | _Alias, new: str, old: str):
     """Rename a named object.

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -167,7 +167,7 @@ def test_field_data_transactions(new_solver_session) -> None:
     transaction = field_data.new_transaction()
 
     su1 = SurfaceFieldDataRequest(
-        surfaces=[1, "hot-inlet"],
+        surfaces=[1, VelocityInlet(settings_source=solver, name="hot-inlet")],
         data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesCentroid],
     )
     sux = SurfaceFieldDataRequest(
@@ -179,7 +179,7 @@ def test_field_data_transactions(new_solver_session) -> None:
         data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesCentroid],
     )
     sc1 = ScalarFieldDataRequest(
-        surfaces=[1, "cold-inlet", "hot-inlet"],
+        surfaces=[1, VelocityInlets(settings_source=solver)],
         field_name="temperature",
         node_value=True,
         boundary_value=True,
@@ -187,12 +187,12 @@ def test_field_data_transactions(new_solver_session) -> None:
     sc2 = sc1._replace(surfaces=[2], boundary_value=False)
     vc1 = VectorFieldDataRequest(surfaces=[3, "hot-inlet"], field_name="velocity")
     pt1 = PathlinesFieldDataRequest(
-        surfaces=[1, "hot-inlet"],
+        surfaces=[1, VelocityInlet(settings_source=solver, name="hot-inlet")],
         field_name="temperature",
         provide_particle_time_field=True,
     )
     pt2 = PathlinesFieldDataRequest(
-        surfaces=[1, "hot-inlet"],
+        surfaces=[1, VelocityInlet(settings_source=solver, name="hot-inlet")],
         field_name="temperature",
         provide_particle_time_field=False,
     )

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1323,3 +1323,36 @@ def test_get_completer_info(static_mixer_settings_session):
         "list",
         "python_name",
     } < set([x[0] for x in completer_info])
+
+
+@pytest.mark.fluent_version(">=25.2")
+def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
+    solver = mixing_elbow_case_data_session
+
+    assert list(solver.settings.setup.boundary_conditions.velocity_inlet) == [
+        "hot-inlet",
+        "cold-inlet",
+    ]
+    assert list(solver.settings.setup.boundary_conditions.wall) == [
+        "wall-inlet",
+        "wall-elbow",
+    ]
+
+    concatenated_named_objects = (
+        solver.settings.setup.boundary_conditions.velocity_inlet
+        + solver.settings.setup.boundary_conditions.wall
+    )
+    assert list(concatenated_named_objects) == [
+        "hot-inlet",
+        "cold-inlet",
+        "wall-inlet",
+        "wall-elbow",
+    ]
+
+    assert list(concatenated_named_objects()) == list(
+        solver.settings.setup.boundary_conditions.velocity_inlet()
+    ) + list(solver.settings.setup.boundary_conditions.wall())
+
+    assert concatenated_named_objects.items() == list(
+        solver.settings.setup.boundary_conditions.velocity_inlet.items()
+    ) + list(solver.settings.setup.boundary_conditions.wall.items())

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1362,3 +1362,22 @@ def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
             solver.settings.setup.boundary_conditions.velocity_inlet
             + solver.settings.setup.boundary_conditions.wall["wall-inlet"]
         )
+
+    chained_named_objects = (
+        solver.settings.setup.boundary_conditions.velocity_inlet
+        + solver.settings.setup.boundary_conditions.wall
+        + solver.settings.setup.boundary_conditions.pressure_outlet
+    )
+
+    assert list(chained_named_objects) == [
+        "hot-inlet",
+        "cold-inlet",
+        "wall-inlet",
+        "wall-elbow",
+        "outlet",
+    ]
+
+    assert (
+        list(solver.settings.setup.boundary_conditions.pressure_outlet.items())[0]
+        in chained_named_objects.items()
+    )

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1356,3 +1356,9 @@ def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
     assert concatenated_named_objects.items() == list(
         solver.settings.setup.boundary_conditions.velocity_inlet.items()
     ) + list(solver.settings.setup.boundary_conditions.wall.items())
+
+    with pytest.raises(TypeError):
+        (
+            solver.settings.setup.boundary_conditions.velocity_inlet
+            + solver.settings.setup.boundary_conditions.wall["wall-inlet"]
+        )


### PR DESCRIPTION
The below is possible now:
```python
solver.settings.setup.boundary_conditions.velocity_inlet + solver.settings.setup.boundary_conditions.wall
```

Please see test for detailed usage.