### PR TITLE
fix: Remove a runtime attribute query for argument-aliases

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1635,15 +1635,11 @@ def _get_new_keywords(obj, *args, **kwds):
             newkwds[argName] = arg
     if kwds:
         # Convert deprecated keywords through aliases
-        # We don't get arguments-aliases from static-info yet.
-        argument_aliases_scm = obj.get_attr("arguments-aliases") or {}
-        argument_aliases = {}
-        for k, v in argument_aliases_scm.items():
-            argument_aliases[to_python_name(k)] = to_python_name(v.removeprefix("'"))
+        child_aliases = obj._child_aliases
         for k, v in kwds.items():
-            alias = argument_aliases.get(k)
+            alias = child_aliases.get(k)
             if alias:
-                newkwds[alias] = v
+                newkwds[alias[0]] = v
             elif k in obj.argument_names:
                 newkwds[k] = v
             else:


### PR DESCRIPTION
`arguments-aliases` is now available in the generated APi class definition on the client side, we do not need to query it from server.