### PR TITLE
chore: Add a new warning category for Fluent development version usage.

### DIFF
--- a/src/ansys/fluent/core/pyfluent_warnings.py
+++ b/src/ansys/fluent/core/pyfluent_warnings.py
@@ -38,6 +38,12 @@ class PyFluentUserWarning(UserWarning):
     pass
 
 
+class FluentDevVersionWarning(PyFluentUserWarning):
+    """Warning raised when a released PyFluent version is used with a development version of Fluent."""
+
+    pass
+
+
 def warning_for_fluent_dev_version(version):
     """Provides warning if Fluent develop branch is used."""
     from ansys.fluent.core import FLUENT_RELEASE_VERSION, FluentVersion
@@ -47,7 +53,7 @@ def warning_for_fluent_dev_version(version):
             "⚠️ Warning: You are using PyFluent with an unreleased or development version of Fluent.\n"
             "Compatibility is not guaranteed, and unexpected behavior may occur. Please use a released "
             "version of Fluent that is officially supported by this version of PyFluent.",
-            PyFluentUserWarning,
+            FluentDevVersionWarning,
         )
 
 


### PR DESCRIPTION
Created a new warning category for Fluent development version usage, so we can easily filter them out in Fluent's Python console.