### PR TITLE
fix: Builtin commands should execute the command without any additional call.

### DIFF
--- a/doc/changelog.d/4285.fixed.md
+++ b/doc/changelog.d/4285.fixed.md
@@ -1,0 +1,1 @@
+Builtin commands should execute the command without any additional call.

--- a/src/ansys/fluent/core/codegen/builtin_settingsgen.py
+++ b/src/ansys/fluent/core/codegen/builtin_settingsgen.py
@@ -88,26 +88,32 @@ def generate(version: str):
             f.write(f"class {name}(_{kind}Setting):\n")
             doc_kind = "command" if kind == "Command" else "setting"
             f.write(f'    """{name} {doc_kind}."""\n\n')
-            f.write("    def __init__(self")
-            for named_object in named_objects:
-                f.write(f", {named_object}: str")
-            f.write(", settings_source: SettingsBase | Solver | None = None")
-            if kind == "NonCreatableNamedObject":
-                f.write(", name: str = None")
-            elif kind == "CreatableNamedObject":
-                f.write(", name: str = None, new_instance_name: str = None")
             if kind == "Command":
-                f.write(", **kwargs")
-            f.write("):\n")
-            f.write("        super().__init__(settings_source=settings_source")
-            if kind == "NonCreatableNamedObject":
-                f.write(", name=name")
-            elif kind == "CreatableNamedObject":
-                f.write(", name=name, new_instance_name=new_instance_name")
-            for named_object in named_objects:
-                f.write(f", {named_object}={named_object}")
-            if kind == "Command":
-                f.write(", **kwargs")
+                f.write(
+                    "    def __new__(cls, settings_source: SettingsBase | Solver | None = None, **kwargs):\n"
+                )
+                f.write("       instance = super().__new__(cls)\n")
+                f.write(
+                    "       instance.__init__(settings_source=settings_source, **kwargs)\n"
+                )
+                f.write("       return instance(**kwargs")
+            else:
+                f.write("    def __init__(self")
+                for named_object in named_objects:
+                    f.write(f", {named_object}: str")
+                f.write(", settings_source: SettingsBase | Solver | None = None")
+                if kind == "NonCreatableNamedObject":
+                    f.write(", name: str = None")
+                elif kind == "CreatableNamedObject":
+                    f.write(", name: str = None, new_instance_name: str = None")
+                f.write("):\n")
+                f.write("        super().__init__(settings_source=settings_source")
+                if kind == "NonCreatableNamedObject":
+                    f.write(", name=name")
+                elif kind == "CreatableNamedObject":
+                    f.write(", name=name, new_instance_name=new_instance_name")
+                for named_object in named_objects:
+                    f.write(f", {named_object}={named_object}")
             f.write(")\n\n")
 
     with open(_PYI_FILE, "w") as f:

--- a/src/ansys/fluent/core/solver/settings_builtin_data.py
+++ b/src/ansys/fluent/core/solver/settings_builtin_data.py
@@ -748,4 +748,6 @@ DATA = {
     ),
     "Initialize": ("Command", "solution.initialization.initialize"),
     "Calculate": ("Command", "solution.run_calculation.calculate"),
+    "Iterate": ("Command", "solution.run_calculation.iterate"),
+    "DualTimeIterate": ("Command", "solution.run_calculation.dual_time_iterate"),
 }

--- a/src/ansys/fluent/core/solver/settings_builtin_data.py
+++ b/src/ansys/fluent/core/solver/settings_builtin_data.py
@@ -729,19 +729,19 @@ DATA = {
     "ReadData": ("Command", "file.read_data"),
     "ReadCaseData": ("Command", "file.read_case_data"),
     "WriteCase": (
-        "Singleton",
+        "Command",
         {
             since(FluentVersion.v241): "file.write_case",
         },
     ),
     "WriteData": (
-        "Singleton",
+        "Command",
         {
             since(FluentVersion.v241): "file.write_data",
         },
     ),
     "WriteCaseData": (
-        "Singleton",
+        "Command",
         {
             since(FluentVersion.v241): "file.write_case_data",
         },

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -727,4 +727,4 @@ def test_context_manager_2(new_solver_session):
 
     with using(solver):
         ReadCase(file_name=import_filename)
-        assert Viscous().model() == "laminar"
+        assert Viscous().model() == "k-omega"

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -563,26 +563,6 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         )
         == solver.parametric_studies["mixing_elbow-Solve"].design_points["Base DP"]
     )
-    assert ReadCase(settings_source=solver) == solver.file.read_case
-    assert ReadData(settings_source=solver) == solver.file.read_data
-    assert ReadCaseData(settings_source=solver) == solver.file.read_case_data
-    if fluent_version >= FluentVersion.v241:
-        assert WriteCase(settings_source=solver) == solver.file.write_case
-        assert WriteData(settings_source=solver) == solver.file.write_data
-        assert WriteCaseData(settings_source=solver) == solver.file.write_case_data
-    else:
-        with pytest.raises(RuntimeError):
-            WriteCase(settings_source=solver)
-        with pytest.raises(RuntimeError):
-            WriteData(settings_source=solver)
-        with pytest.raises(RuntimeError):
-            WriteCaseData(settings_source=solver)
-    assert (
-        Initialize(settings_source=solver) == solver.solution.initialization.initialize
-    )
-    assert (
-        Calculate(settings_source=solver) == solver.solution.run_calculation.calculate
-    )
 
 
 @pytest.mark.codegen_required


### PR DESCRIPTION
Following code will directly read the case:
```
with using(solver):
    ReadCase(file_name=import_filename)
```