### PR TITLE
refactor: Update allowed_values interface for field_data.

### DIFF
--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -107,6 +107,7 @@ hierarchy = {
     "other": [
         "exceptions",
         "file_session",
+        "field_data_interfaces",
         "fluent_connection",
         "journaling",
         "logger",

--- a/doc/changelog.d/4286.miscellaneous.md
+++ b/doc/changelog.d/4286.miscellaneous.md
@@ -1,0 +1,1 @@
+Update allowed_values interface for field_data.

--- a/doc/source/api/api_contents.rst
+++ b/doc/source/api/api_contents.rst
@@ -42,6 +42,7 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     data_model_cache
     exceptions
     file_session
+    field_data_interfaces
     fluent_connection
     journaling
     logger

--- a/doc/source/user_guide/fields/field_data.rst
+++ b/doc/source/user_guide/fields/field_data.rst
@@ -224,12 +224,12 @@ Some sample use cases are demonstrated below:
 
 .. code-block:: python
 
-  >>> sorted(field_data.scalar_fields.field_name.allowed_values())
+  >>> sorted(field_data.scalar_fields.allowed_values())
   ['abs-angular-coordinate', 'absolute-pressure', 'angular-coordinate',
   'anisotropic-adaption-cells', 'aspect-ratio', 'axial-coordinate', 'axial-velocity',
   'boundary-cell-dist', 'boundary-layer-cells', 'boundary-normal-dist', ...]
 
-  >>> field_data.vector_fields.field_name.allowed_values()
+  >>> field_data.vector_fields.allowed_values()
   ['velocity', 'relative-velocity']
 
   >>> from ansys.units import VariableCatalog

--- a/doc/source/user_guide/fields/field_data.rst
+++ b/doc/source/user_guide/fields/field_data.rst
@@ -224,21 +224,26 @@ Some sample use cases are demonstrated below:
 
 .. code-block:: python
 
-  >>> field_data.get_scalar_field_data.field_name.allowed_values()
+  >>> sorted(field_data.scalar_fields.field_name.allowed_values())
   ['abs-angular-coordinate', 'absolute-pressure', 'angular-coordinate',
   'anisotropic-adaption-cells', 'aspect-ratio', 'axial-coordinate', 'axial-velocity',
   'boundary-cell-dist', 'boundary-layer-cells', 'boundary-normal-dist', ...]
 
-  >>> batch = field_data.new_batch()
-  >>> batch.add_scalar_fields_request.field_name.allowed_values()
-  ['abs-angular-coordinate', 'absolute-pressure', 'angular-coordinate',
-  'anisotropic-adaption-cells', 'aspect-ratio', 'axial-coordinate', 'axial-velocity',
-  'boundary-cell-dist', 'boundary-layer-cells', 'boundary-normal-dist', ...]
+  >>> field_data.vector_fields.field_name.allowed_values()
+  ['velocity', 'relative-velocity']
 
-  >>> field_data.get_scalar_field_data.surface_name.allowed_values()
+  >>> from ansys.units import VariableCatalog
+  >>> field_data.vector_fields.is_active(VariableCatalog.VELOCITY)
+  True
+  >>> field_data.vector_fields.is_active(VariableCatalog.VELOCITY_MAGNITUDE)
+  False
+  >>> field_data.scalar_fields.is_active(VariableCatalog.VELOCITY_MAGNITUDE)
+  True
+
+  >>> field_data.surfaces.allowed_values()
   ['in1', 'in2', 'in3', 'inlet', 'inlet1', 'inlet2', 'out1', 'outlet', 'solid_up:1', 'solid_up:1:830', 'solid_up:1:830-shadow']
 
-  >>> field_data.get_surface_data.surface_ids.allowed_values()
+  >>> field_data.surface_ids.allowed_values()
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -314,15 +314,6 @@ class _SurfaceIds:
         return self._allowed_surface_ids()
 
 
-class _FieldName:
-    def __init__(self, allowed_names):
-        self._allowed_names = allowed_names
-
-    def allowed_values(self):
-        """Lists available scalar or vector field names."""
-        return list(self._allowed_names())
-
-
 class _Fields:
     def __init__(self, available_field_names):
         self._available_field_names = available_field_names
@@ -333,10 +324,9 @@ class _Fields:
             return True
         return False
 
-    @property
-    def field_name(self):
-        """Name of the scalar or vector field."""
-        return _FieldName(self._available_field_names)
+    def allowed_values(self):
+        """Lists available scalar or vector field names."""
+        return list(self._available_field_names())
 
     def __call__(self):
         return self._available_field_names()
@@ -359,6 +349,30 @@ class _FieldMethod:
 
         def allowed_values(self):
             """Returns set of allowed values."""
+            if self._accessor.__class__.__name__ == "_AllowedScalarFieldNames":
+                warnings.warn(
+                    "This usage is deprecated and will be removed in a future release. "
+                    "Please use 'scalar_fields.allowed_values' instead",
+                    PyFluentDeprecationWarning,
+                )
+            elif self._accessor.__class__.__name__ == "_AllowedVectorFieldNames":
+                warnings.warn(
+                    "This usage is deprecated and will be removed in a future release. "
+                    "Please use 'vector_fields.allowed_values' instead",
+                    PyFluentDeprecationWarning,
+                )
+            elif self._accessor.__class__.__name__ == "_AllowedSurfaceNames":
+                warnings.warn(
+                    "This usage is deprecated and will be removed in a future release. "
+                    "Please use 'field_data.surfaces.allowed_values' instead",
+                    PyFluentDeprecationWarning,
+                )
+            elif self._accessor.__class__.__name__ == "_AllowedSurfaceIDs":
+                warnings.warn(
+                    "This usage is deprecated and will be removed in a future release. "
+                    "Please use 'field_data.surface_ids.allowed_values' instead",
+                    PyFluentDeprecationWarning,
+                )
             return sorted(self._accessor())
 
     def __init__(self, field_data_accessor, args_allowed_values_accessors):

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -290,6 +290,68 @@ class FieldInfo(BaseFieldInfo):
             _AllowedSurfaceNames(info=self.get_surfaces_info()).valid_name(surface)
 
 
+class _SurfaceNames:
+    def __init__(self, allowed_surface_names):
+        self._allowed_surface_names = allowed_surface_names
+
+    def allowed_values(self):
+        """Lists available surface names."""
+        return list(self._allowed_surface_names())
+
+    def __call__(self):
+        return self._allowed_surface_names()
+
+
+class _SurfaceIds:
+    def __init__(self, allowed_surface_ids):
+        self._allowed_surface_ids = allowed_surface_ids
+
+    def allowed_values(self):
+        """Lists available surface ids."""
+        return self._allowed_surface_ids()
+
+    def __call__(self):
+        return self._allowed_surface_ids()
+
+
+class _FieldName:
+    def __init__(self, allowed_names):
+        self._allowed_names = allowed_names
+
+    def allowed_values(self):
+        """Lists available scalar or vector field names."""
+        return list(self._allowed_names())
+
+
+class _Fields:
+    def __init__(self, available_field_names):
+        self._available_field_names = available_field_names
+
+    def is_active(self, field_name):
+        """Check whether a field is active in the given context."""
+        if _to_field_name_str(field_name) in self._available_field_names():
+            return True
+        return False
+
+    @property
+    def field_name(self):
+        """Name of the scalar or vector field."""
+        return _FieldName(self._available_field_names)
+
+    def __call__(self):
+        return self._available_field_names()
+
+
+class _ScalarFields(_Fields):
+    def __init__(self, available_field_names):
+        super().__init__(available_field_names)
+
+
+class _VectorFields(_Fields):
+    def __init__(self, available_field_names):
+        super().__init__(available_field_names)
+
+
 class _FieldMethod:
     class _Arg:
         def __init__(self, accessor):
@@ -1334,6 +1396,14 @@ class LiveFieldData(BaseFieldData, FieldDataSource):
                 args_allowed_values_accessors=scalar_field_args,
             ),
             self.get_pathlines_field_data,
+        )
+        self.surfaces = _SurfaceNames(allowed_surface_names=self._allowed_surface_names)
+        self.surface_ids = _SurfaceIds(allowed_surface_ids=self._allowed_surface_ids)
+        self.scalar_fields = _ScalarFields(
+            available_field_names=self._allowed_scalar_field_names
+        )
+        self.vector_fields = _VectorFields(
+            available_field_names=self._allowed_vector_field_names
         )
         self._returned_data = _ReturnFieldData()
         self._fetched_data = _FetchFieldData()

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -121,7 +121,7 @@ def test_field_data_batches_deprecated_interface(new_solver_session) -> None:
     # multiple surface *names* batches
     batch2 = field_data.new_batch()
     fields_request = batch2.add_scalar_fields_request
-    surface_names = fields_request.surface_names.allowed_values()
+    surface_names = field_data.surfaces.allowed_values()
     fields_request(surfaces=surface_names, field_name="temperature")
     data2 = batch2.get_fields()
     assert data2
@@ -323,14 +323,12 @@ def test_field_data_allowed_values(new_solver_session) -> None:
 
     field_data = solver.fields.field_data
     field_info = solver.fields.field_info
-    batch = field_data.new_batch()
-    fields_request = batch.add_scalar_fields_request
 
-    assert [] == field_data.get_scalar_field_data.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.field_name.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.get_scalar_field_data.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -340,34 +338,26 @@ def test_field_data_allowed_values(new_solver_session) -> None:
     assert field_data.is_data_valid()
 
     expected_allowed_args = sorted(field_info.get_scalar_fields_info())
-    allowed_args = field_data.get_scalar_field_data.field_name.allowed_values()
+    allowed_args = sorted(field_data.scalar_fields.field_name.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
     assert len(allowed_args) > len(allowed_args_no_init)
-    allowed_args = fields_request.field_name.allowed_values()
     assert expected_allowed_args == allowed_args
 
     expected_allowed_args = sorted(field_info.get_surfaces_info())
-    allowed_args = field_data.get_scalar_field_data.surface_name.allowed_values()
+    allowed_args = sorted(field_data.surfaces.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
-    allowed_args = fields_request.surface_names.allowed_values()
     assert expected_allowed_args == allowed_args
 
     expected_allowed_args = sorted(field_info.get_surfaces_info())
-    allowed_args = field_data.get_surface_data.surface_name.allowed_values()
+    allowed_args = sorted(field_data.surfaces.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
-    allowed_args = fields_request.surface_names.allowed_values()
-    assert expected_allowed_args == allowed_args
 
-    allowed_args = field_data.get_surface_data.surface_ids.allowed_values()
-    assert len(expected_allowed_args) == len(allowed_args)
-    allowed_args = fields_request.surface_ids.allowed_values()
+    allowed_args = field_data.surface_ids.allowed_values()
     assert len(expected_allowed_args) == len(allowed_args)
 
     expected_allowed_args = sorted(field_info.get_vector_fields_info())
-    allowed_args = field_data.get_vector_field_data.field_name.allowed_values()
+    allowed_args = sorted(field_data.vector_fields.field_name.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
-    allowed_args = batch.add_vector_fields_request.field_name.allowed_values()
-    assert expected_allowed_args == allowed_args
 
 
 @pytest.mark.fluent_version(">=23.2")
@@ -379,11 +369,11 @@ def test_field_data_objects_3d_deprecated_interface(new_solver_session) -> None:
 
     field_data = solver.fields.field_data
 
-    assert [] == field_data.get_scalar_field_data.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.field_name.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.get_scalar_field_data.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -492,11 +482,11 @@ def test_field_data_objects_3d(new_solver_session) -> None:
 
     field_data = solver.fields.field_data
 
-    assert [] == field_data.get_scalar_field_data.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.field_name.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.get_scalar_field_data.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -628,7 +618,7 @@ def test_field_data_objects_2d(disk_case_session) -> None:
 
     field_data = solver.fields.field_data
 
-    allowed_args_no_init = field_data.get_scalar_field_data.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -324,11 +324,11 @@ def test_field_data_allowed_values(new_solver_session) -> None:
     field_data = solver.fields.field_data
     field_info = solver.fields.field_info
 
-    assert [] == field_data.scalar_fields.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -338,7 +338,7 @@ def test_field_data_allowed_values(new_solver_session) -> None:
     assert field_data.is_data_valid()
 
     expected_allowed_args = sorted(field_info.get_scalar_fields_info())
-    allowed_args = sorted(field_data.scalar_fields.field_name.allowed_values())
+    allowed_args = sorted(field_data.scalar_fields.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
     assert len(allowed_args) > len(allowed_args_no_init)
     assert expected_allowed_args == allowed_args
@@ -356,7 +356,7 @@ def test_field_data_allowed_values(new_solver_session) -> None:
     assert len(expected_allowed_args) == len(allowed_args)
 
     expected_allowed_args = sorted(field_info.get_vector_fields_info())
-    allowed_args = sorted(field_data.vector_fields.field_name.allowed_values())
+    allowed_args = sorted(field_data.vector_fields.allowed_values())
     assert expected_allowed_args and (expected_allowed_args == allowed_args)
 
 
@@ -369,11 +369,11 @@ def test_field_data_objects_3d_deprecated_interface(new_solver_session) -> None:
 
     field_data = solver.fields.field_data
 
-    assert [] == field_data.scalar_fields.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -482,11 +482,11 @@ def test_field_data_objects_3d(new_solver_session) -> None:
 
     field_data = solver.fields.field_data
 
-    assert [] == field_data.scalar_fields.field_name.allowed_values()
+    assert [] == field_data.scalar_fields.allowed_values()
 
     solver.file.read(file_type="case", file_name=import_file_name)
 
-    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()
@@ -618,7 +618,7 @@ def test_field_data_objects_2d(disk_case_session) -> None:
 
     field_data = solver.fields.field_data
 
-    allowed_args_no_init = field_data.scalar_fields.field_name.allowed_values()
+    allowed_args_no_init = field_data.scalar_fields.allowed_values()
     assert len(allowed_args_no_init) != 0
 
     assert not field_data.is_data_valid()


### PR DESCRIPTION
Current usage:

```python

  >>> sorted(field_data.scalar_fields.allowed_values())
  ['abs-angular-coordinate', 'absolute-pressure', 'angular-coordinate',
  'anisotropic-adaption-cells', 'aspect-ratio', 'axial-coordinate', 'axial-velocity',
  'boundary-cell-dist', 'boundary-layer-cells', 'boundary-normal-dist', ...]

  >>> field_data.vector_fields.allowed_values()
  ['velocity', 'relative-velocity']

  >>> from ansys.units import VariableCatalog
  >>> field_data.vector_fields.is_active(VariableCatalog.VELOCITY)
  True
  >>> field_data.vector_fields.is_active(VariableCatalog.VELOCITY_MAGNITUDE)
  False
  >>> field_data.scalar_fields.is_active(VariableCatalog.VELOCITY_MAGNITUDE)
  True

  >>> field_data.surfaces.allowed_values()
  ['in1', 'in2', 'in3', 'inlet', 'inlet1', 'inlet2', 'out1', 'outlet', 'solid_up:1', 'solid_up:1:830', 'solid_up:1:830-shadow']

  >>> field_data.surface_ids.allowed_values()
  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

Added deprecation message for the previous usage patterns