### PR TITLE
ci: Use the stable image id in PR CI

### DIFF
--- a/.ci/pull_fluent_image.py
+++ b/.ci/pull_fluent_image.py
@@ -11,12 +11,10 @@ from ansys.fluent.core.docker.utils import get_ghcr_fluent_image_name
 def pull_fluent_image():
     """Pull Fluent Docker image and clean up dangling images."""
     fluent_image_tag = os.getenv("FLUENT_IMAGE_TAG", "latest")
-    image_name = (
-        f"ghcr.io/ansys/fluent@{fluent_image_tag}"
-        if fluent_image_tag.startswith("sha256")
-        else f"{get_ghcr_fluent_image_name(fluent_image_tag)}:{fluent_image_tag}"
-    )
-    subprocess.run(["docker", "pull", image_name], check=True)
+    image_name = get_ghcr_fluent_image_name(fluent_image_tag)
+    separator = "@" if fluent_image_tag.startswith("sha256") else ":"
+    full_image_name = f"{image_name}{separator}{fluent_image_tag}"
+    subprocess.run(["docker", "pull", full_image_name], check=True)
     subprocess.run(["docker", "image", "prune", "-f"], check=True)
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,17 +429,13 @@ jobs:
         if: steps.cache-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
         env:
-          # FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
-          # Temporary until the stable image tag is update for the new image path
-          FLUENT_IMAGE_TAG: v26.1.latest
+          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Run 26.1 API codegen
         if: steps.cache-api-code.outputs.cache-hit != 'true'
         run: make api-codegen
         env:
-          # FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
-          # Temporary until the stable image tag is update for the new image path
-          FLUENT_IMAGE_TAG: v26.1.latest
+          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Print 26.1 Fluent version info
         run: |
@@ -494,9 +490,7 @@ jobs:
             version: 261
     timeout-minutes: 60
     env:
-      # FLUENT_IMAGE_TAG: ${{ matrix.version == 261 && vars.FLUENT_STABLE_IMAGE_DEV || matrix.image-tag }}
-      # Temporary until the stable image tag is update for the new image path
-      FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+      FLUENT_IMAGE_TAG: ${{ matrix.version == 261 && vars.FLUENT_STABLE_IMAGE_DEV || matrix.image-tag }}
 
     steps:
       - uses: actions/checkout@v4

--- a/doc/changelog.d/4305.maintenance.md
+++ b/doc/changelog.d/4305.maintenance.md
@@ -1,0 +1,1 @@
+Use the stable image id in pr ci

--- a/src/ansys/fluent/core/docker/utils.py
+++ b/src/ansys/fluent/core/docker/utils.py
@@ -29,7 +29,7 @@ def get_ghcr_fluent_image_name(image_tag: str):
     """
     Get the Fluent image name from GitHub registry based on the image tag.
     """
-    if image_tag >= "v26.1":
+    if image_tag.startswith("sha256:") or image_tag >= "v26.1":
         return "ghcr.io/ansys/fluent"
     else:
         return "ghcr.io/ansys/pyfluent"


### PR DESCRIPTION
As a stable image revision at the new image path has now been pushed to the gh variables, reinstating the usage of that stable revision in CI.