### PR TITLE
fix: ui_mode key error in Ansys lab

### DIFF
--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -47,6 +47,7 @@ from ansys.fluent.core.launcher.launch_options import (
     FluentMode,
     FluentWindowsGraphicsDriver,
     Precision,
+    UIMode,
     _get_argvals_and_session,
 )
 from ansys.fluent.core.session_meshing import Meshing
@@ -68,6 +69,7 @@ class PIMLauncher:
     def __init__(
         self,
         mode: FluentMode | str | None = None,
+        ui_mode: UIMode | str | None = None,
         graphics_driver: (
             FluentWindowsGraphicsDriver | FluentLinuxGraphicsDriver | str | None
         ) = None,
@@ -90,6 +92,8 @@ class PIMLauncher:
         ----------
         mode : FluentMode
             Specifies the launch mode of Fluent for targeting a specific session type.
+        ui_mode : UIMode
+            Defines the user interface mode for Fluent. Options correspond to values in the ``UIMode`` enum.
         graphics_driver : FluentWindowsGraphicsDriver or FluentLinuxGraphicsDriver
             Specifies the graphics driver for Fluent. Options are from the ``FluentWindowsGraphicsDriver`` enum
             (for Windows) or the ``FluentLinuxGraphicsDriver`` enum (for Linux).


### PR DESCRIPTION
This pull request introduces a new `ui_mode` parameter in the `PIMLauncher` class to allow specifying the user interface mode for Fluent. The changes include updates to the class constructor, parameter documentation, and imports.

### Addition of `ui_mode` parameter:

* [`src/ansys/fluent/core/launcher/pim_launcher.py`](diffhunk://#diff-f3eafcfd5d76de366b9e3a94065320abf7c555ddd71c6fc2a1b6542ab8fd330bR50): Added `UIMode` to the imports to support the new parameter.
* `class PIMLauncher` in `src/ansys/fluent/core/launcher/pim_launcher.py`: Added `ui_mode` as an optional parameter in the constructor, allowing users to define the user interface mode for Fluent.
* `def __init__` in `src/ansys/fluent/core/launcher/pim_launcher.py`: Updated the docstring to include a description of the new `ui_mode` parameter, which corresponds to values in the `UIMode` enum.