### PR TITLE
refactor: set default version to latest release and use max grpc limit

### DIFF
--- a/doc/changelog.d/4327.miscellaneous.md
+++ b/doc/changelog.d/4327.miscellaneous.md
@@ -1,0 +1,1 @@
+Set default version to latest release and use max grpc limit

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -40,7 +40,7 @@ import logging
 import os
 from typing import Any, Dict
 
-from ansys.fluent.core.fluent_connection import FluentConnection
+from ansys.fluent.core.fluent_connection import FluentConnection, _get_max_c_int_limit
 from ansys.fluent.core.launcher.launch_options import (
     Dimension,
     FluentLinuxGraphicsDriver,
@@ -240,7 +240,12 @@ def launch_remote_fluent(
 
     instance.wait_for_ready()
 
-    channel = instance.build_grpc_channel()
+    channel = instance.build_grpc_channel(
+        options=[
+            ("grpc.max_send_message_length", _get_max_c_int_limit()),
+            ("grpc.max_receive_message_length", _get_max_c_int_limit()),
+        ],
+    )
 
     fluent_connection = create_fluent_connection(
         channel=channel,

--- a/src/ansys/fluent/core/launcher/pim_launcher.py
+++ b/src/ansys/fluent/core/launcher/pim_launcher.py
@@ -174,7 +174,9 @@ class PIMLauncher:
                 FluentVersion(self.argvals["product_version"]).number
             )
         else:
-            fluent_product_version = None
+            fluent_product_version = str(
+                FluentVersion(FluentVersion.current_release()).number
+            )
 
         return launch_remote_fluent(
             session_cls=self.new_session,


### PR DESCRIPTION
This pull request introduces enhancements to the `pim_launcher.py` file in the `ansys.fluent.core.launcher` module. The changes improve version handling and gRPC channel configuration, ensuring better compatibility and performance.

### Version Handling Improvements:
* Updated the fallback logic in the `__call__` method to use the current release version when no product version is specified, ensuring a consistent and reliable default behavior.

### gRPC Channel Configuration:
* Modified the `launch_remote_fluent` function to set gRPC channel options for maximum send and receive message lengths using `_get_max_c_int_limit()`, enhancing the robustness of remote communication.

### Code Imports:
* Added `_get_max_c_int_limit` to the imports from `fluent_connection`, enabling its use for gRPC configuration.

Earlier:

<img width="883" height="512" alt="image" src="https://github.com/user-attachments/assets/d35ee792-ab94-4420-a129-9d201abab2b1" />

Now:

<img width="593" height="405" alt="image" src="https://github.com/user-attachments/assets/88002a72-b9f1-44ca-8506-7ae7f9439b97" />
