### PR TITLE
fix: Unavaialble field data for some surfaces.

### DIFF
--- a/doc/changelog.d/4345.fixed.md
+++ b/doc/changelog.d/4345.fixed.md
@@ -1,0 +1,1 @@
+Unavaialble field data for some surfaces.

--- a/doc/changelog.d/4345.fixed.md
+++ b/doc/changelog.d/4345.fixed.md
@@ -1,1 +1,1 @@
-Unavailable field data for some surfaces.
+Unavaialble field data for some surfaces.

--- a/doc/changelog.d/4345.fixed.md
+++ b/doc/changelog.d/4345.fixed.md
@@ -1,1 +1,1 @@
-Unavaialble field data for some surfaces.
+Unavailable field data for some surfaces.

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -186,7 +186,20 @@ class BatchFieldData:
             | PathlinesFieldDataRequest
         ),
     ) -> Dict[int | str, Dict | np.array]:
-        """Get the surface, scalar, vector or path-lines field data on a surface."""
+        """Get the surface, scalar, vector or path-lines field data on a surface.
+
+        Returns
+        -------
+        Dict[int | str, Dict | np.array]
+            Field data for the requested surface. If field data is unavailable for the surface,
+            an empty array is returned and a warning is issued. Users should always check
+            the array size before using the data.
+
+            Example:
+                data = get_field_data(field_data_request)[surface_id]
+                if data.size == 0:
+                    # Handle missing data
+        """
         if isinstance(obj, SurfaceFieldDataRequest):
             return self._get_surface_data(**obj._asdict())
         elif isinstance(obj, ScalarFieldDataRequest):
@@ -973,7 +986,20 @@ class FileFieldData(FieldDataSource):
             | PathlinesFieldDataRequest
         ),
     ) -> Dict[int | str, Dict | np.array]:
-        """Get the surface, scalar, vector or path-lines field data on a surface."""
+        """Get the surface, scalar, vector or path-lines field data on a surface.
+
+        Returns
+        -------
+        Dict[int | str, Dict | np.array]
+            Field data for the requested surface. If field data is unavailable for the surface,
+            an empty array is returned and a warning is issued. Users should always check
+            the array size before using the data.
+
+            Example:
+                data = get_field_data(field_data_request)[surface_id]
+                if data.size == 0:
+                    # Handle missing data
+        """
         if isinstance(obj, SurfaceFieldDataRequest):
             return self._get_surface_data(**obj._asdict())
         elif isinstance(obj, ScalarFieldDataRequest):

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -577,7 +577,20 @@ class BaseFieldData:
             | PathlinesFieldDataRequest
         ),
     ) -> Dict[int | str, Dict | np.array]:
-        """Get the surface, scalar, vector or path-lines field data on a surface."""
+        """Get the surface, scalar, vector or path-lines field data on a surface.
+
+        Returns
+        -------
+        Dict[int | str, Dict | np.array]
+            Field data for the requested surface. If field data is unavailable for the surface,
+            an empty array is returned and a warning is issued. Users should always check
+            the array size before using the data.
+
+            Example:
+                data = get_field_data(field_data_request)[surface_id]
+                if data.size == 0:
+                    # Handle missing data
+        """
         if isinstance(obj, SurfaceFieldDataRequest):
             return self._get_surface_data(**obj._asdict())
         elif isinstance(obj, ScalarFieldDataRequest):

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -1185,13 +1185,19 @@ class ChunkParser:
                     payload_tag_id = None
             field = None
             if payload_tag_id is not None:
-                field = _extract_field(
-                    _FieldDataConstants.proto_field_type_to_np_data_type[
-                        payload_info.fieldType
-                    ],
-                    payload_info.fieldSize,
-                    chunk_iterator,
-                )
+                if payload_info.fieldSize > 0:
+                    field = _extract_field(
+                        _FieldDataConstants.proto_field_type_to_np_data_type[
+                            payload_info.fieldType
+                        ],
+                        payload_info.fieldSize,
+                        chunk_iterator,
+                    )
+                else:
+                    warnings.warn(
+                        f"Field data is not available for surface: {surface_id}"
+                    )
+                    field = np.array([])
 
             if self._callbacks_provider is not None:
                 for callback_data in self._callbacks_provider.callbacks():


### PR DESCRIPTION
Sometimes some surfaces might be created but field data on them might not be available. For example please refer the issue: https://github.com/ansys/pyfluent-visualization/issues/552

Now we are getting and returning the field data as empty array for these surfaces, just like Fluent does. We are additionally providing an warning that theses surfaces does not have field data.


<img width="479" height="275" alt="image" src="https://github.com/user-attachments/assets/85c39d3b-70ae-4cd5-a8cc-2ce4d1b21746" />


We need to patch this with v0.34 to address an user bug.