### PR TITLE
style: fix codespell issue causing action failures

### DIFF
--- a/doc/changelog.d/4348.fixed.md
+++ b/doc/changelog.d/4348.fixed.md
@@ -1,1 +1,0 @@
-Codespell error

--- a/doc/changelog.d/4348.miscellaneous.md
+++ b/doc/changelog.d/4348.miscellaneous.md
@@ -1,0 +1,1 @@
+Fix codespell issue causing action failures


### PR DESCRIPTION
As the title states
Example of failing workflow: https://github.com/ansys/pyfluent/actions/runs/16752015810/job/47424457871?pr=4344