### PR TITLE
chore: Minor update to Makefile to clean the example directory.

### DIFF
--- a/doc/changelog.d/4354.maintenance.md
+++ b/doc/changelog.d/4354.maintenance.md
@@ -1,0 +1,1 @@
+Minor update to Makefile to clean the example directory.

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -47,7 +47,7 @@ goto end
 :clean
 echo Cleaning build directories...
 rmdir /s /q %BUILDDIR% > NUL 2>&1
-del /q %SOURCEDIR%\examples\* > NUL 2>&1
+rmdir /s /q %SOURCEDIR%\examples > NUL 2>&1
 rmdir /s /q %SOURCEDIR%\api\meshing\datamodel > NUL 2>&1
 rmdir /s /q %SOURCEDIR%\api\meshing\tui > NUL 2>&1
 rmdir /s /q %SOURCEDIR%\api\solver\datamodel > NUL 2>&1


### PR DESCRIPTION
This update addresses the issue of cleaning documentation-generated files. 

Previously, 'make clean' did not remove all content generated by 'make html'. 

Additionally, references to these files in flake8 during pre-commit checks have been removed as they are unnecessary and confusing.