### PR TITLE
test: Enable some tests which are found to be passing locally

### DIFF
--- a/doc/changelog.d/4368.test.md
+++ b/doc/changelog.d/4368.test.md
@@ -1,0 +1,1 @@
+Enable some tests which are found to be passing locally

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -32,7 +32,6 @@ from ansys.fluent.core.utils.file_transfer_service import ContainerFileTransferS
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
-@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/3855")
 @pytest.mark.nightly
 @pytest.mark.fluent_version("latest")
 def test_parametric_workflow():

--- a/tests/test_datamodel_api.py
+++ b/tests/test_datamodel_api.py
@@ -276,7 +276,6 @@ def test_datamodel_api_on_attribute_changed(
     assert value == "xyz"
 
 
-@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/4298")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_command_attribute_changed(
     datamodel_api_version_all, request, new_solver_session
@@ -382,7 +381,6 @@ def test_datamodel_api_update_dict(datamodel_api_version_all, new_solver_session
     assert service.get_state(app_name, "/G/H") == {"X": "abc"}
 
 
-@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/4298")
 @pytest.mark.fluent_version(">=25.2")
 def test_datamodel_api_on_bad_input(
     datamodel_api_version_all, request, new_solver_session

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -287,7 +287,6 @@ def test_add_on_command_executed(new_meshing_session):
     assert data == []
 
 
-@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/2999")
 @pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_datamodel_streaming_full_diff_state(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -47,7 +47,6 @@ def test_fluent_fatal_error(error_code, raises, new_solver_session):
             time.sleep(0.1)
 
 
-@pytest.mark.skip(reason="https://github.com/ansys/pyfluent/issues/4298")
 @pytest.mark.fluent_version(">=25.2")
 def test_custom_python_error_via_grpc(datamodel_api_version_new, new_solver_session):
     solver = new_solver_session

--- a/tests/test_new_meshing_workflow.py
+++ b/tests/test_new_meshing_workflow.py
@@ -1607,7 +1607,6 @@ def test_scenario_with_common_python_names_from_fdl(new_meshing_session):
     assert len(two_dimensional.task_names()) == len(set(two_dimensional.task_names()))
 
 
-@pytest.mark.skip("Failing in GitHub")
 @pytest.mark.codegen_required
 @pytest.mark.fluent_version(">=25.1")
 def test_return_state_changes(new_meshing_session):

--- a/tests/test_pre_post_session.py
+++ b/tests/test_pre_post_session.py
@@ -27,7 +27,6 @@ from ansys.fluent.core import examples
 from ansys.fluent.core.solver.flobject import InactiveObjectError
 
 
-@pytest.mark.skip(reason="This test works fine locally but fails on CI")
 @pytest.mark.fluent_version(">=23.1")
 def test_pre_post_session():
     file_name = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_tui_api.py
+++ b/tests/test_tui_api.py
@@ -29,7 +29,6 @@ from ansys.fluent.core.examples.downloads import download_file
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
 
 
-@pytest.mark.skip("Failing in github")
 def test_report_system_proc_stats_tui(new_solver_session, capsys) -> None:
     new_solver_session.tui.report.system.sys_stats()
     captured = capsys.readouterr()
@@ -52,7 +51,6 @@ def test_python_keyword_menu_name(new_meshing_session):
     meshing.tui.file.import_.cad_options.create_cad_assemblies("yes")
 
 
-@pytest.mark.skip("Failing in github")
 def test_api_upgrade_message(new_solver_session):
     solver = new_solver_session
     case_name = download_file(


### PR DESCRIPTION
Enabling the tests which are passing locally, there could be github specific issues for some of them.. to investigate

Following is the list of the remaining disabled tests:
```
tests/test_datamodel_api.py::test_datamodel_api_on_deleted
tests/test_field_data.py::test_field_data_does_not_modify_case
tests/test_file_transfer_service.py::test_datamodel_execute
tests/test_launcher_remote.py::test_launch_remote_instance
tests/test_new_meshing_workflow.py::test_meshing_workflow_structure
tests/test_new_meshing_workflow.py::test_created_workflow
tests/test_settings_api.py::test_return_types_of_operations_on_named_objects
tests/test_topy.py::test_single_jou
tests/test_topy.py::test_single_scm
tests/test_topy.py::test_2_jou
tests/test_topy.py::test_2_scm
```