### PR TITLE
fix: Some config and env var cleanup

### DIFF
--- a/doc/changelog.d/4380.fixed.md
+++ b/doc/changelog.d/4380.fixed.md
@@ -1,0 +1,1 @@
+Some config and env var cleanup

--- a/doc/source/user_guide/file_transfer.rst
+++ b/doc/source/user_guide/file_transfer.rst
@@ -47,8 +47,6 @@ Depending on how Fluent is launched, different file transfer strategies are avai
 
    .. code-block:: python
 
-      >>> import os
-      >>> os.environ["PYFLUENT_LAUNCH_CONTAINER"] = "1"
       >>> import ansys.fluent.core as pyfluent
       >>> from ansys.fluent.core import examples
       >>> from ansys.fluent.core.utils.file_transfer_service import ContainerFileTransferStrategy

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -54,9 +54,6 @@ Use this method when:
 
 .. code-block:: python
 
-  import os
-  os.environ["PYFLUENT_LAUNCH_CONTAINER"] = "1"
-
   import ansys.fluent.core as pyfluent
   from ansys.fluent.core.utils.networking import get_free_port
 
@@ -453,21 +450,13 @@ Pass ``use_docker_compose=True`` or ``use_podman_compose=True`` to use Docker Co
 
 Example:
 
-Set environment variables to select the container engine:
-
-.. code:: python
-
-  >>> import os
-  >>> os.environ["PYFLUENT_LAUNCH_CONTAINER"] = "1"
-
-
-Then launch:
+Launch Fluent in container mode via PyFluent:
 
 .. code:: python
 
   >>> import ansys.fluent.core as pyfluent
   >>> from ansys.fluent.core import examples
-  >>> solver_session = pyfluent.launch_fluent(use_docker_compose=True)
+  >>> solver_session = pyfluent.launch_fluent(start_container=True, use_docker_compose=True)
   >>> case_file_name = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
   >>> solver_session.file.read(file_name=case_file_name, file_type="case")
   >>> solver_session.exit()

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -137,7 +137,7 @@ def download_file(
     save_path : str, optional
         Path to download the specified file to.
     return_without_path : bool, optional
-        When unspecified, defaults to False, unless the PYFLUENT_LAUNCH_CONTAINER=1 environment variable is specified,
+        When unspecified, defaults to False, unless the launch_fluent_container config is set to True,
         in which case defaults to True.
         Relevant when using Fluent Docker container images, as the full path for the imported file from
         the host side is not necessarily going to be the same as the one for Fluent inside the container.

--- a/src/ansys/fluent/core/launcher/launch_options.py
+++ b/src/ansys/fluent/core/launcher/launch_options.py
@@ -23,6 +23,7 @@
 """Provides a module for enums used in the PyFluent."""
 
 from enum import Enum
+import os
 import warnings
 
 from ansys.fluent.core.exceptions import DisallowedValuesError
@@ -344,7 +345,6 @@ def _get_standalone_launch_fluent_version(argvals) -> FluentVersion | None:
     FluentVersion, optional
         Fluent version or ``None``
     """
-    from ansys.fluent.core import config
 
     # Look for Fluent version in the following order:
     # 1. product_version parameter passed with launch_fluent
@@ -358,7 +358,7 @@ def _get_standalone_launch_fluent_version(argvals) -> FluentVersion | None:
 
     # (DEV) if "PYFLUENT_FLUENT_ROOT" environment variable is defined, we cannot
     # determine the Fluent version, so returning None.
-    if config.fluent_root:
+    if "PYFLUENT_FLUENT_ROOT" in os.environ:
         return None
 
     # 2. the latest ANSYS version from AWP_ROOT environment variables

--- a/src/ansys/fluent/core/launcher/process_launch_string.py
+++ b/src/ansys/fluent/core/launcher/process_launch_string.py
@@ -149,7 +149,6 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
     Path
         Fluent executable path
     """
-    from ansys.fluent.core import config
 
     def get_exe_path(fluent_root: Path) -> Path:
         if launcher_utils.is_windows():
@@ -171,7 +170,7 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
         return FluentVersion(product_version).get_fluent_exe_path()
 
     # (DEV) "PYFLUENT_FLUENT_ROOT" environment variable
-    fluent_root = config.fluent_root
+    fluent_root = os.getenv("PYFLUENT_FLUENT_ROOT")
     if fluent_root:
         return get_exe_path(Path(fluent_root))
 

--- a/src/ansys/fluent/core/launcher/slurm_launcher.py
+++ b/src/ansys/fluent/core/launcher/slurm_launcher.py
@@ -460,7 +460,7 @@ class SlurmLauncher:
         launch_cmd += _build_journal_argument(
             self._argvals["topy"], self._argvals["journal_file_names"]
         )
-        launch_cmd += ' --setenv="FLUENT_ALLOW_REMOTE_GRPC_CONNECTION=1"'
+        launch_cmd += ' -setenv="FLUENT_ALLOW_REMOTE_GRPC_CONNECTION=1"'
 
         logger.debug(f"Launching Fluent with command: {launch_cmd}")
         proc = subprocess.Popen(launch_cmd, **kwargs)

--- a/src/ansys/fluent/core/module_config.py
+++ b/src/ansys/fluent/core/module_config.py
@@ -300,11 +300,6 @@ class Config:
         lambda instance: instance._env.get("PYFLUENT_HIDE_LOG_SECRETS") == "1"
     )
 
-    #: The Fluent root directory to be used for PyFluent, defaults to the value of ``PYFLUENT_FLUENT_ROOT`` environment variable.
-    fluent_root = _ConfigDescriptor["Config"](
-        lambda instance: instance._env.get("PYFLUENT_FLUENT_ROOT")
-    )
-
     #: The remoting server address to be used in Fluent, defaults to the value of ``REMOTING_SERVER_ADDRESS`` environment variable.
     remoting_server_address = _ConfigDescriptor["Config"](
         lambda instance: instance._env.get("REMOTING_SERVER_ADDRESS")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,7 +196,7 @@ class Helpers:
             version = FluentVersion.current_release()
         elif not isinstance(version, FluentVersion):
             version = FluentVersion(version)
-        self.monkeypatch.setattr(pyfluent.config, "fluent_root", None)
+        self.monkeypatch.delenv("PYFLUENT_FLUENT_ROOT", raising=False)
         for fv in FluentVersion:
             if fv <= version:
                 self.monkeypatch.setenv(fv.awp_var, f"ansys_inc/{fv.name}")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -374,7 +374,7 @@ def test_get_fluent_exe_path_from_product_version_launcher_arg(helpers):
 
 def test_get_fluent_exe_path_from_pyfluent_fluent_root(helpers, monkeypatch):
     helpers.mock_awp_vars()
-    monkeypatch.setattr(pyfluent.config, "fluent_root", "dev/vNNN/fluent")
+    monkeypatch.setenv("PYFLUENT_FLUENT_ROOT", "dev/vNNN/fluent")
     if platform.system() == "Windows":
         expected_path = Path("dev/vNNN/fluent") / "ntbin" / "win64" / "fluent.exe"
     else:


### PR DESCRIPTION
1. Remove the config equivalent to `PYFLUENT_FLUENT_ROOT` environment variable. That environment variable is only for development use.
2. Remove the mentions of the environment `PYFLUENT_LAUNCH_CONTAINER` from user documentation. That environment variable is only for CI use.
3. Fix a typo in slurm launcher.