### PR TITLE
fix: Release CI [skip tests]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,15 +660,15 @@ jobs:
       - name: "Download the library artifacts from build-library step"
         uses: actions/download-artifact@v4.3.0
         with:
-          name: ${{ env.PACKAGE_NAME }}-artifacts
-          path: ${{ env.PACKAGE_NAME }}-artifacts
+          name: PyFluent-packages
+          path: PyFluent-packages
 
       - name: "Upload artifacts to PyPI using trusted publisher"
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: "https://upload.pypi.org/legacy/"
           print-hash: true
-          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          packages-dir: PyFluent-packages
           skip-existing: false
 
       - name: Release

--- a/doc/changelog.d/4423.fixed.md
+++ b/doc/changelog.d/4423.fixed.md
@@ -1,0 +1,1 @@
+Release CI [skip tests]


### PR DESCRIPTION
Release CI is broken - https://github.com/ansys/pyfluent/actions/runs/17295108997/job/49117558886
```
Run actions/download-artifact@v4.3.0
Downloading single artifact
Error: Unable to download artifact(s): Artifact not found for name: ansys-fluent-core-artifacts
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```