### PR TITLE
fix: flake8 change needed for release [skip tests]

### DIFF
--- a/doc/changelog.d/4470.fixed.md
+++ b/doc/changelog.d/4470.fixed.md
@@ -1,0 +1,1 @@
+Flake8 change needed for release [skip tests]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -303,7 +303,6 @@ def setup(app):
     """Setup function for Sphinx builder."""
     app.connect("autodoc-skip-member", skip)
 
+
 # PyAnsys tags configuration
-html_context = {
-    "pyansys_tags": ['Fluids']
-}
+html_context = {"pyansys_tags": ["Fluids"]}


### PR DESCRIPTION
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

doc\source\conf.py:307:1: E305 expected 2 blank lines after class or function definition, found 1
1     E305 expected 2 blank lines after class or function definition, found 1
1

```