### PR TITLE
fix: chown server-info file by client user in compose mode

### DIFF
--- a/doc/changelog.d/4483.fixed.md
+++ b/doc/changelog.d/4483.fixed.md
@@ -1,0 +1,1 @@
+Chown server-info file by client user in compose mode

--- a/src/ansys/fluent/core/docker/docker_compose.py
+++ b/src/ansys/fluent/core/docker/docker_compose.py
@@ -46,7 +46,9 @@ class ComposeBasedLauncher:
         self._container_source = self._set_compose_cmds()
         self._container_source.remove("compose")
 
-        container_dict["command"].append(f"""-command="(system \\\"chown {os.getuid()}:{os.getgid()} {container_dict["container_server_info_file"]}\\\")" """)
+        container_dict["command"].append(
+            f"""-command="(system \\\"chown {os.getuid()}:{os.getgid()} {container_dict["container_server_info_file"]}\\\")" """
+        )
 
         self._compose_file = self._get_compose_file(container_dict)
 

--- a/src/ansys/fluent/core/docker/docker_compose.py
+++ b/src/ansys/fluent/core/docker/docker_compose.py
@@ -32,7 +32,7 @@ from .utils import get_ghcr_fluent_image_name
 class ComposeBasedLauncher:
     """Launch Fluent through docker or Podman compose."""
 
-    def __init__(self, compose_config, container_dict):
+    def __init__(self, compose_config, container_dict, container_server_info_file):
         from ansys.fluent.core import config
 
         self._compose_config = compose_config
@@ -47,7 +47,7 @@ class ComposeBasedLauncher:
         self._container_source.remove("compose")
 
         container_dict["command"].append(
-            f"""-command="(system \\\"chown {os.getuid()}:{os.getgid()} {container_dict["container_server_info_file"]}\\\")" """
+            f"""-command="(system \\\"chown {os.getuid()}:{os.getgid()} {container_server_info_file}\\\")" """
         )
 
         self._compose_file = self._get_compose_file(container_dict)

--- a/src/ansys/fluent/core/docker/docker_compose.py
+++ b/src/ansys/fluent/core/docker/docker_compose.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
 import subprocess
 import uuid
 
@@ -44,6 +45,8 @@ class ComposeBasedLauncher:
         )
         self._container_source = self._set_compose_cmds()
         self._container_source.remove("compose")
+
+        container_dict["command"].append(f"""-command="(system \\\"chown {os.getuid()}:{os.getgid()} {container_dict["container_server_info_file"]}\\\")" """)
 
         self._compose_file = self._get_compose_file(container_dict)
 

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -353,8 +353,6 @@ def configure_container_dict(
                 "FLUENT_ALLOW_REMOTE_GRPC_CONNECTION": "1",
             }
         )
-        if compose_config.is_compose:
-            container_dict["environment"]["FLUENT_SERVER_INFO_PERMISSION_SYSTEM"] = "1"
 
     if "labels" not in container_dict:
         test_name = pyfluent.config.test_name
@@ -389,6 +387,7 @@ def configure_container_dict(
     logger.debug(
         f"Using server info file '{container_server_info_file}' for Fluent container."
     )
+    container_dict["container_server_info_file"] = container_server_info_file
 
     # If the 'command' had already been specified in the 'container_dict',
     # maintain other 'command' arguments but update the '-sifile' argument,

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -172,7 +172,7 @@ def configure_container_dict(
     file_transfer_service: Any | None = None,
     compose_config: ComposeConfig | None = None,
     **container_dict,
-) -> (dict, int, int, Path, bool):
+) -> (dict, int, int, Path, str, bool):
     """Parses the parameters listed below, and sets up the container configuration file.
 
     Parameters
@@ -218,6 +218,7 @@ def configure_container_dict(
     timeout : int
     port : int
     host_server_info_file : Path
+    container_server_info_file: str
     remove_server_info_file: bool
 
     Raises
@@ -387,7 +388,6 @@ def configure_container_dict(
     logger.debug(
         f"Using server info file '{container_server_info_file}' for Fluent container."
     )
-    container_dict["container_server_info_file"] = container_server_info_file
 
     # If the 'command' had already been specified in the 'container_dict',
     # maintain other 'command' arguments but update the '-sifile' argument,
@@ -467,6 +467,7 @@ def configure_container_dict(
         timeout,
         container_grpc_port,
         host_server_info_file,
+        container_server_info_file,
         remove_server_info_file,
     )
 
@@ -527,6 +528,7 @@ def start_fluent_container(
         timeout,
         port,
         host_server_info_file,
+        container_server_info_file,
         remove_server_info_file,
     ) = container_vars
     launch_string = " ".join(config_dict["command"])
@@ -545,6 +547,7 @@ def start_fluent_container(
             compose_container = ComposeBasedLauncher(
                 compose_config=compose_config,
                 container_dict=config_dict,
+                container_server_info_file=container_server_info_file,
             )
 
             if not compose_container.check_image_exists():

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -59,13 +59,24 @@ logger = logging.getLogger("pyfluent.general")
 
 
 def _parse_server_info_file(file_name: str):
-    with open(file_name, encoding="utf-8") as f:
-        lines = f.readlines()
-    ip_and_port = lines[0].strip().split(":")
-    ip = ip_and_port[0]
-    port = int(ip_and_port[1])
-    password = lines[1].strip()
-    return ip, port, password
+    max_retries = 5
+    retry_delay = 1  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            with open(file_name, encoding="utf-8") as f:
+                lines = f.readlines()
+            ip_and_port = lines[0].strip().split(":")
+            ip = ip_and_port[0]
+            port = int(ip_and_port[1])
+            password = lines[1].strip()
+            return ip, port, password
+        except PermissionError as e:
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay)
+                continue
+            else:
+                raise RuntimeError(f"Failed to parse server info file: {e}") from e
 
 
 class _IsDataValid:

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -25,6 +25,7 @@
 from enum import Enum
 import json
 import logging
+import time
 from typing import Any, Callable, Dict
 import warnings
 import weakref


### PR DESCRIPTION
This PR removes the `FLUENT_SERVER_INFO_PERMISSION_SYSTEM` env var for compose launch. The server writes the server-info file with the default 600 permission. The file is then owned by client-user via a subsequent scheme command, so it can be read in the client side.