### PR TITLE
docs: Corrected a typo in Ablation example [skip tests]

### DIFF
--- a/doc/changelog.d/4494.documentation.md
+++ b/doc/changelog.d/4494.documentation.md
@@ -1,0 +1,1 @@
+Corrected a typo in Ablation example [skip tests]

--- a/examples/00-fluent/modeling_ablation.py
+++ b/examples/00-fluent/modeling_ablation.py
@@ -34,7 +34,7 @@ Modeling Ablation
 # the damaging effects of external high temperatures caused by shock wave and viscous
 # heating. The ablative material is chipped away due to surface reactions that remove a
 # significant amount of heat and keep the vehicle surface temperature below the melting
-# point. In this tutorial, Fluent ablation model is demonstrated for a reendtry vehicle
+# point. In this tutorial, Fluent ablation model is demonstrated for a re-entry vehicle
 # geometry simplified as a 3D wedge.
 #
 # This tutorial demonstrates how to do the following:


### PR DESCRIPTION
Corrected a typo in Ablation example