### PR TITLE
fix: Meshing tests.

### DIFF
--- a/doc/changelog.d/4530.fixed.md
+++ b/doc/changelog.d/4530.fixed.md
@@ -1,0 +1,1 @@
+Meshing tests.

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -387,11 +387,11 @@ def test_get_and_set_state_for_command_arg_instance(new_meshing_session):
 
     assert x.LengthUnit.get_state() == "ft"
 
-    assert x.CadImportOptions.ExtractFeatures()
+    assert not x.ImportCadPreferences.ShowImportCadPreferences()
 
-    x.CadImportOptions.ExtractFeatures.set_state(False)
+    x.ImportCadPreferences.ShowImportCadPreferences.set_state(True)
 
-    assert not x.CadImportOptions.ExtractFeatures()
+    assert x.ImportCadPreferences.ShowImportCadPreferences()
 
     x.set_state({"FileName": "dummy_file_name.dummy_extn"})
 
@@ -813,30 +813,29 @@ def test_set_command_args_and_sub_args(new_meshing_session):
     meshing = new_meshing_session
     ig = meshing.meshing.ImportGeometry.create_instance()
 
+    ig.FileFormat = "Mesh"
+
     # Command Arguments
     assert ig.MeshUnit() == "m"
     ig.MeshUnit = "mm"
     assert ig.MeshUnit() == "mm"
 
     # Command Arguments SubItem
-    assert ig.CadImportOptions.OneZonePer() == "body"
-    ig.CadImportOptions.OneZonePer = "face"
-    assert ig.CadImportOptions.OneZonePer() == "face"
+    assert ig.ImportCadPreferences.ShowImportCadPreferences() is False
+    ig.ImportCadPreferences.ShowImportCadPreferences = True
+    assert ig.ImportCadPreferences.ShowImportCadPreferences() is True
 
 
-@pytest.mark.fluent_version(">=24.1")
+@pytest.mark.fluent_version(">=26.1")
 def test_dynamic_dependency(new_meshing_session):
     meshing = new_meshing_session
     ic = meshing.meshing.LoadCADGeometry.create_instance()
 
-    d = ic.Refaceting.Deviation.get_state()
-    cd = ic.Refaceting.CustomDeviation.get_state()
-    assert d == cd
+    assert ic.Refaceting.FacetResolution() == "Medium"
+    assert ic.Refaceting.NormalAngle() == 8.0
 
-    ic.Refaceting.Deviation.set_state(1.2)
-    d = ic.Refaceting.Deviation.get_state()
-    cd = ic.Refaceting.CustomDeviation.get_state()
-    assert d == cd
+    ic.Refaceting.FacetResolution = "Coarse"
+    assert ic.Refaceting.NormalAngle() == 16.0
 
 
 @pytest.mark.fluent_version(">=25.2")

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -413,6 +413,12 @@ def test_task_object_keys_are_display_names(new_meshing_session):
 
 def test_generic_datamodel(new_solver_session):
     solver = new_solver_session
+    import_file_name = examples.download_file(
+        "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+    )
+    solver.file.read(file_type="case", file_name=import_file_name)
+    solver.setup.general.solver.time = "unsteady-2nd-order"
+    solver.solution.initialization.hybrid_initialize()
     solver.scheme.eval("(init-flserver)")
     flserver = PyMenuGeneric(solver._datamodel_service_se, "flserver")
     assert flserver.Case.Solution.Calculation.TimeStepSize() == 1.0

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1033,6 +1033,7 @@ def _check_vector_units(obj, units):
     assert obj.as_quantity() == ansys.units.Quantity(obj.get_state(), units)
 
 
+@pytest.mark.skip("https://github.com/ansys/pyfluent/issues/4498")
 @pytest.mark.fluent_version(">=24.1")
 def test_ansys_units_integration(mixing_elbow_settings_session):
     solver = mixing_elbow_settings_session

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -43,6 +43,7 @@ def test_solver_preferences(new_solver_session):
     assert preferred_drawing.FaceZoneLimit() == 15000
 
     ansys_logo = solver.preferences.Appearance.AnsysLogo
+    ansys_logo.Visible = True
     ansys_logo.Color = "white"
     assert ansys_logo.Color() == "white"
 

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -463,7 +463,7 @@ def test_reductions(
 def test_reduction_does_not_modify_case(static_mixer_case_session: Any):
     solver = static_mixer_case_session
     solver.solution.initialization.hybrid_initialize()
-    # After reading the static-mixer case in Fluent, case-modifed? flag is somehow True
+    # After reading the static-mixer case in Fluent, case-modified? flag is somehow True
     solver.scheme.eval("(%save-case-id)")
     assert not solver.scheme.eval("(case-modified?)")
     solver.reduction.area_average(


### PR DESCRIPTION
## Context
Recent updates to the server-side datamodel-api and renaming of some entries in meshing FDL file have caused certain PyFluent tests to fail. These updates affected how some settings are exposed and validated through the API.

## Change Summary
This PR updates the affected PyFluent tests to align with the latest server-side datamodel changes and FDL renaming.

## Rationale
The failures were due to changes in the server-side behavior rather than issues in the test logic itself.

- The introduction of the "exposed_state" in the datamodel altered the activation state of some objects, making certain earlier test scenarios invalid (for example, tests expecting inactive objects to be accessible). Those tests have been removed or adjusted accordingly.

- The fixes were verified through manual debugging to ensure the tests now correctly reflect the new datamodel behavior and server API expectations.

## Impact
Only the affected test cases have been modified. No functional changes to PyFluent code or behavior.

## Final notes:
All tests are fixed and Nightly dev test is running fine in this branch and hence the main branch.

Only "test_ansys_units_integration" needs fixing that @hpohekar is looking into. It has been skipped as of now.
