### PR TITLE
chore: Correct some typos in repo.

### DIFF
--- a/.ci/fluent_test_runner.py
+++ b/.ci/fluent_test_runner.py
@@ -45,12 +45,12 @@ def _run_single_test(
     """
     logging.debug(f"journal_file: {journal_file}")
     src_pyfluent_dir = str(Path(pyfluent.__file__).parent)
-    verion_for_file_name = FluentVersion.current_dev().number
-    dst_pyfluent_dir = f"/ansys_inc/v{verion_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore/ansys/fluent/core"
+    version_for_file_name = FluentVersion.current_dev().number
+    dst_pyfluent_dir = f"/ansys_inc/v{version_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore/ansys/fluent/core"
     src_gen_dir = (
         Path(pyfluent.__file__).parent / "ansys" / "fluent" / "core" / "generated"
     )
-    dst_gen_dir = f"/ansys_inc/v{verion_for_file_name}/fluent/fluent{FluentVersion.current_dev()!r}/cortex/pylib/flapi/generated"
+    dst_gen_dir = f"/ansys_inc/v{version_for_file_name}/fluent/fluent{FluentVersion.current_dev()!r}/cortex/pylib/flapi/generated"
     dst_test_dir = "/testing"
     working_dir = Path(dst_test_dir)
     parent = journal_file.parent

--- a/doc/settings_rstgen.py
+++ b/doc/settings_rstgen.py
@@ -9,12 +9,12 @@ Process
     -- Populate a parents dictionary with current class file name (not class name) as key and list of parents file names (not class names) as value.
     - Recursively Generate the rst files for classes starting with settings.root.
     -- Add target reference as the file name for the given class. This is used by other classes to generate hyperlinks
-    -- Add properties like members, undoc-memebers, show-inheritence to the autoclass directive.
+    -- Add properties like members, undoc-members, show-inheritance to the autoclass directive.
     -- Generate the tables of children, commands, arguments, and parents.
     --- Get access to the respective properties and members on the class with get_attr.
     --- Use the file name of the child class to generate the hyperlink to that class.
     --- Use the __doc__ property to generate the short summary for the corresponding child
-    --- Use the previously generated perents dict to populate the parents table.
+    --- Use the previously generated parents dict to populate the parents table.
 Usage
 -----
 python <path to settings_rstgen.py>

--- a/examples/00-fluent/lunar_lander_thermal.py
+++ b/examples/00-fluent/lunar_lander_thermal.py
@@ -665,13 +665,13 @@ for i in range(n_steps):
     )
 
     # Simulate closing louvers below 273 K by changing emissivity
-    rad_emiss = solver_session.setup.boundary_conditions.wall[
+    radiation_emission = solver_session.setup.boundary_conditions.wall[
         "sc-radiator"
     ].radiation.internal_emissivity_band["thermal-ir"]
     if rad_mean_temp < 273:
-        rad_emiss.value = 0.09
+        radiation_emission.value = 0.09
     else:
-        rad_emiss.value = 0.70
+        radiation_emission.value = 0.70
 
     # Run simulation for 1 timestep
     solver_session.solution.run_calculation.calculate()

--- a/examples/00-fluent/modeling_ablation.py
+++ b/examples/00-fluent/modeling_ablation.py
@@ -34,7 +34,7 @@ Modeling Ablation
 # the damaging effects of external high temperatures caused by shock wave and viscous
 # heating. The ablative material is chipped away due to surface reactions that remove a
 # significant amount of heat and keep the vehicle surface temperature below the melting
-# point. In this tutorial, Fluent ablation model is demonstrated for a re-entry vehicle
+# point. In this tutorial, Fluent ablation model is demonstrated for a reentry vehicle
 # geometry simplified as a 3D wedge.
 #
 # This tutorial demonstrates how to do the following:

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -104,7 +104,7 @@ class MonitorThread(threading.Thread):
     """A class used for monitoring a Fluent session.
 
     Daemon thread which will ensure cleanup of session objects, shutdown of
-    non-deamon threads etc.
+    non-daemon threads etc.
 
     Attributes
     ----------


### PR DESCRIPTION
## Context
There were some imminent typos in some files of the codebase (mostly affecting documentation)

## Change Summary
The typos were corrected.

## Rationale
'typo' was run on the code-base and some of the suggestions were implemented.

## Impact
Prevent typos in documentation rendering


## In future some tool to be integrated with pre-commit to take care of these automatically like "typo', needs discussion.