### PR TITLE
build: Bump version 0.36.dev1

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -81,7 +81,7 @@ from ansys.fluent.core.utils import fldoc
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
 
-__version__ = "0.36.dev0"
+__version__ = "0.36.dev1"
 
 _VERSION_INFO = None
 """


### PR DESCRIPTION
Creating a dev release to make the [slurm-launcher fix](https://github.com/ansys/pyfluent/pull/4611) available for internal testing.
