### PR TITLE
feat: add BaseSession solver properties

### DIFF
--- a/doc/changelog.d/4994.added.md
+++ b/doc/changelog.d/4994.added.md
@@ -1,1 +1,1 @@
-Add BaseSession runtime properties for precision, dimension, and processor count
+Add BaseSession changes

--- a/doc/changelog.d/4994.added.md
+++ b/doc/changelog.d/4994.added.md
@@ -1,1 +1,1 @@
-Add BaseSession changes
+Add BaseSession solver properties

--- a/doc/changelog.d/4994.added.md
+++ b/doc/changelog.d/4994.added.md
@@ -1,1 +1,1 @@
-Added the changes
+Add BaseSession runtime properties for precision, dimension, and processor count

--- a/doc/changelog.d/4994.added.md
+++ b/doc/changelog.d/4994.added.md
@@ -1,0 +1,1 @@
+Added the changes

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -312,6 +312,33 @@ class BaseSession:
         """Return the session ID."""
         return self._fluent_connection._id
 
+    @property
+    def precision(self) -> int:
+        """Return the current solver precision.
+
+        Returns
+        -------
+        int
+            ``1`` for single precision, ``2`` for double precision.
+        """
+        return 2 if self.scheme.eval("(rp-double?)") else 1
+
+    @property
+    def dimension(self) -> int:
+        """Return the current dimensionality.
+
+        Returns
+        -------
+        int
+            ``2`` for 2D, ``3`` for 3D.
+        """
+        return 3 if self.scheme.eval("(rp-3d?)") else 2
+
+    @property
+    def processor_count(self) -> int:
+        """Return the current processor count."""
+        return int(str(self.rp_vars("parallel/nprocs_string")).strip('"'))
+
     def start_journal(self, file_name: str):
         """Executes tui command to start journal."""
         warnings.warn("Use -> journal.start()", PyFluentDeprecationWarning)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -531,16 +531,17 @@ def test_additional_arguments_fluent_launch_args_string():
 
 
 def test_processor_count():
-    def get_processor_count(solver):
-        return int(solver.rp_vars("parallel/nprocs_string").strip('"'))
-
     grpc_kwds = get_grpc_launcher_args_for_gh_runs()
-    with pyfluent.launch_fluent(processor_count=2, **grpc_kwds) as solver:
-        assert get_processor_count(solver) == 2
+    with pyfluent.launch_fluent(
+        dimension=2, precision="single", processor_count=2, **grpc_kwds
+    ) as solver:
+        assert solver.dimension == 2
+        assert solver.precision == 1
+        assert solver.processor_count == 2
     # The following check is not yet supported for container launch
     # https://github.com/ansys/pyfluent/issues/2624
     # with pyfluent.launch_fluent(additional_arguments="-t2") as solver:
-    #     assert get_processor_count(solver) == 2
+    #     assert solver.processor_count == 2
 
 
 def test_container_mount_source_target(caplog):


### PR DESCRIPTION
## Context
Before this change, validation for launch settings (especially in tests) relied more on launch construction/dry-run behavior than on querying the live Fluent session state directly.

## Change Summary

- Added runtime properties on BaseSession:
    > - precision
    > - dimension
    > - processor_count
- Implemented these using live Fluent queries so values come from the active session.
- Updated launcher test coverage to assert these properties directly from a running session.

## Impact
- Affects session metadata access and launch validation tests.
- Improves developer/test workflows by providing direct, readable runtime checks.
- No breaking API changes; this is additive `(new BaseSession properties)`.
