### PR TITLE
Fix mutation of data_types causing order-dependent behavior

### DIFF
--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -689,10 +689,11 @@ class FileFieldData(FieldDataSource):
         overset_mesh: bool | None = False,
         flatten_connectivity: bool = False,
     ):
-        for d_type in data_types:
-            if isinstance(d_type, str):
-                data_types.remove(d_type)
-                data_types.append(SurfaceDataType(d_type))
+        data_types = [
+    d_type if isinstance(d_type, SurfaceDataType)
+    else SurfaceDataType(d_type)
+    for d_type in data_types
+]
 
         surface_ids = self.get_surface_ids(surfaces=surfaces)
 


### PR DESCRIPTION
Fix mutation of data_types causing order-dependent behavior

The current implementation mutates the `data_types` list while iterating over it, which can lead to order-dependent behavior and inconsistent return types.

This PR replaces the mutation logic with a list comprehension that preserves order and avoids in-place modification:

    data_types = [
        d_type if isinstance(d_type, SurfaceDataType)
        else SurfaceDataType(d_type)
        for d_type in data_types
    ]

This ensures consistent behavior regardless of input ordering.

Tested using the reproduction steps from the issue.
