### PR TITLE
chore: Replace Named Tuples with dataclass

### DIFF
--- a/doc/changelog.d/5055.maintenance.md
+++ b/doc/changelog.d/5055.maintenance.md
@@ -1,0 +1,1 @@
+Replace Named Tuples with dataclass.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import platform
 import subprocess
+import sys
 
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 from sphinx_gallery.sorting import FileNameSortKey
@@ -300,9 +301,40 @@ def skip(app, what, name, obj, would_skip, options):
     return would_skip
 
 
+def _inject_dataclass_field_docs(app, what, name, obj, options, lines):
+    """Inject per-field docs from ``__dataclass_field_docs__`` into attribute docstrings.
+
+    Dataclass field attributes do not carry ``__doc__`` descriptors the way
+    ``NamedTuple`` properties do.  This hook reads the mapping stored by
+    :func:`~ansys.fluent.core.field_data_interfaces._set_namedtuple_field_docs`
+    on the class and injects the relevant documentation so that Sphinx/autodoc
+    renders per-field member docs correctly.
+    """
+    if what != "attribute" or lines:
+        return
+    # name is the fully qualified attribute name, e.g.
+    # "ansys.fluent.core.field_data_interfaces.SurfaceFieldDataRequest.data_types"
+    class_path, _, attr_name = name.rpartition(".")
+    if not class_path or not attr_name:
+        return
+    module_name, _, class_name = class_path.rpartition(".")
+    if not module_name:
+        return
+    module = sys.modules.get(module_name)
+    if module is None:
+        return
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        return
+    field_docs = getattr(cls, "__dataclass_field_docs__", None)
+    if field_docs and attr_name in field_docs:
+        lines[:] = [field_docs[attr_name]]
+
+
 def setup(app):
     """Setup function for Sphinx builder."""
     app.connect("autodoc-skip-member", skip)
+    app.connect("autodoc-process-docstring", _inject_dataclass_field_docs)
 
 
 # PyAnsys tags configuration

--- a/src/ansys/fluent/core/field_data_interfaces.py
+++ b/src/ansys/fluent/core/field_data_interfaces.py
@@ -22,8 +22,9 @@
 
 """Common interfaces for field data."""
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import Callable, Dict, List, NamedTuple
+from typing import Callable, Dict, List
 import warnings
 
 import numpy as np
@@ -49,7 +50,32 @@ class SurfaceDataType(Enum):
     FacesCentroid = "centroid"
 
 
-class SurfaceFieldDataRequest(NamedTuple):
+class _NamedTupleCompat:
+    """Compatibility helpers for former NamedTuple request objects."""
+
+    @property
+    def _fields(self) -> tuple[str, ...]:
+        return tuple(self.__dataclass_fields__.keys())
+
+    def _asdict(self) -> dict[str, object]:
+        return {name: getattr(self, name) for name in self._fields}
+
+    def _replace(self, /, **changes):
+        return replace(self, **changes)
+
+    def __iter__(self):
+        for name in self._fields:
+            yield getattr(self, name)
+
+    def __len__(self) -> int:
+        return len(self._fields)
+
+    def __getitem__(self, index):
+        return tuple(self)[index]
+
+
+@dataclass
+class SurfaceFieldDataRequest(_NamedTupleCompat):
     """Container storing parameters for surface data request."""
 
     data_types: List[SurfaceDataType] | List[str]
@@ -58,7 +84,8 @@ class SurfaceFieldDataRequest(NamedTuple):
     flatten_connectivity: bool = False
 
 
-class ScalarFieldDataRequest(NamedTuple):
+@dataclass
+class ScalarFieldDataRequest(_NamedTupleCompat):
     """Container storing parameters for scalar field data request."""
 
     field_name: str
@@ -67,14 +94,16 @@ class ScalarFieldDataRequest(NamedTuple):
     boundary_value: bool | None = True
 
 
-class VectorFieldDataRequest(NamedTuple):
+@dataclass
+class VectorFieldDataRequest(_NamedTupleCompat):
     """Container storing parameters for vector field data request."""
 
     field_name: str
     surfaces: List[int | str | object]
 
 
-class PathlinesFieldDataRequest(NamedTuple):
+@dataclass
+class PathlinesFieldDataRequest(_NamedTupleCompat):
     """Container storing parameters for path-lines field data request."""
 
     field_name: str
@@ -90,18 +119,19 @@ class PathlinesFieldDataRequest(NamedTuple):
     tolerance: float | None = 0.001
     coarsen: int | None = 1
     velocity_domain: str | None = "all-phases"
-    zones: list | None = None
+    zones: list | None = field(default_factory=list)
     flatten_connectivity: bool = False
 
 
 def _set_namedtuple_field_docs(cls: type, field_docs: dict[str, str]) -> None:
-    """Set docstrings for NamedTuple-generated field attributes.
+    """Set docstrings for dataclass field attributes.
 
-    Without this, Sphinx may render default ``NamedTuple`` field docs like
-    "Alias for field number N" in attribute/member tables.
+    For dataclass fields, this stores documentation in a class attribute
+    that Sphinx and documentation tools can use to render field documentation
+    in attribute/member tables.
     """
-    for field_name, field_doc in field_docs.items():
-        getattr(cls, field_name).__doc__ = field_doc
+    # Store field documentation in a class attribute for Sphinx discovery
+    cls.__dataclass_field_docs__ = field_docs
 
 
 _set_namedtuple_field_docs(

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -745,7 +745,6 @@ class Batch(FieldBatch):
         self,
         **kwargs,
     ) -> None:
-        zones = kwargs.get("zones", [])
         field_name = self._allowed_scalar_field_names.valid_name(
             kwargs.get("field_name")
         )
@@ -777,7 +776,7 @@ class Batch(FieldBatch):
                 tolerance=kwargs.get("tolerance"),
                 coarsen=kwargs.get("coarsen"),
                 velocityDomain=kwargs.get("velocity_domain"),
-                zones=zones,
+                zones=kwargs.get("zones"),
             )
         )
 
@@ -1561,7 +1560,6 @@ class LiveFieldData(BaseFieldData, FieldDataSource):
         self,
         **kwargs,
     ) -> Dict:
-        zones = kwargs.get("zones", [])
         surface_ids = self.get_surface_ids(kwargs.get("surfaces"))
         field_name = self._allowed_scalar_field_names.valid_name(
             kwargs.get("field_name")
@@ -1591,7 +1589,7 @@ class LiveFieldData(BaseFieldData, FieldDataSource):
                 tolerance=kwargs.get("tolerance"),
                 coarsen=kwargs.get("coarsen"),
                 velocityDomain=kwargs.get("velocity_domain"),
-                zones=zones,
+                zones=kwargs.get("zones"),
             )
         )
         fields = ChunkParser().extract_fields(self._service.get_fields(fields_request))


### PR DESCRIPTION
## Context
`SurfaceFieldDataRequest`, `ScalarFieldDataRequest`, `VectorFieldDataRequest`, and `PathlinesFieldDataRequest` were `NamedTuple` subclasses. NamedTuple property descriptors carry `__doc__` directly, so `_set_namedtuple_field_docs()` could patch per-field Sphinx docs at runtime. After migration to `@dataclass`, docs were stored in `cls.__dataclass_field_docs__` but nothing consumed that attribute, silently dropping per-field API docs.

## Change Summary
- **`field_data_interfaces.py`**: Converted the four request containers from `NamedTuple` to `@dataclass` with a `_NamedTupleCompat` mixin preserving `_asdict()`, `_replace()`, iteration, and indexing. Updated `_set_namedtuple_field_docs()` to store docs in `cls.__dataclass_field_docs__` (since dataclass fields have no property descriptor to patch `__doc__` on). Fixed `PathlinesFieldDataRequest.zones` to use `default_factory=list`.
- **`field_data.py`**: Minor internal call-site updates to pass `zones` from `kwargs` directly.
- **`doc/source/conf.py`**: Added `_inject_dataclass_field_docs` — an `autodoc-process-docstring` Sphinx hook that reads `__dataclass_field_docs__` on any dataclass and injects per-field docs into empty attribute docstrings, restoring the Sphinx member-table output that previously worked via NamedTuple descriptors.

## Rationale
The Sphinx hook is the minimal fix: it bridges the gap between dataclass fields (no descriptor `__doc__`) and Sphinx autodoc without requiring verbose `dataclasses.field(metadata={"doc": ...})` rewrites across every field definition.

## Impact
- Sphinx/autodoc output for the four request dataclasses now renders per-field member documentation correctly.
- Downstream code using `_asdict()`, `_replace()`, tuple unpacking, or index access continues to work unchanged via the `_NamedTupleCompat` mixin.