### PR TITLE
chore: Enhance FileSession batching reliability and error clarity

### DIFF
--- a/doc/changelog.d/5061.maintenance.md
+++ b/doc/changelog.d/5061.maintenance.md
@@ -1,0 +1,1 @@
+Tidy up FileSession

--- a/doc/changelog.d/5061.maintenance.md
+++ b/doc/changelog.d/5061.maintenance.md
@@ -1,1 +1,1 @@
-Tidy up FileSession
+Enhance FileSession batching reliability and error clarity

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -76,6 +76,26 @@ class InvalidFieldName(ValueError):
         super().__init__("The only allowed field is 'velocity'.")
 
 
+def _normalize_file_session_scalar_options(
+    node_value: bool | None,
+    boundary_value: bool | None,
+) -> tuple[bool, bool]:
+    """Normalize scalar options for FileSession face-based scalar data.
+
+    FileSession scalar data comes from face values only. To avoid claiming nodal or
+    boundary-specific scalar data semantics that are not available from file reader
+    APIs, scalar requests are normalized to element location and boundaryValues=False.
+    """
+    if node_value is not False or boundary_value is not False:
+        warnings.warn(
+            "FileSession scalar data is face-based only. "
+            "Ignoring 'node_value' and 'boundary_value' and using "
+            "node_value=False, boundary_value=False.",
+            PyFluentDeprecationWarning,
+        )
+    return False, False
+
+
 def _data_type_converter(args_dict):
     d_type_list = []
     d_type_map = {
@@ -118,11 +138,15 @@ class BatchFieldData:
         self,
         **kwargs,
     ) -> Dict[int | str, np.array]:
+        node_value, boundary_value = _normalize_file_session_scalar_options(
+            kwargs.get("node_value"),
+            kwargs.get("boundary_value"),
+        )
         scalar_field_data = self.data[
             (
                 ("type", "scalar-field"),
-                ("dataLocation", 0 if kwargs.get("node_value") else 1),
-                ("boundaryValues", kwargs.get("boundary_value")),
+                ("dataLocation", 0 if node_value else 1),
+                ("boundaryValues", boundary_value),
             )
         ]
         return self._returned_data._scalar_data(
@@ -226,10 +250,19 @@ class Batch(FieldBatch):
             self.provide_faces = provide_faces
 
     class _ScalarFieldTransaction:
-        def __init__(self, field_name, surface_ids, phase="phase-1"):
+        def __init__(
+            self,
+            field_name,
+            surface_ids,
+            phase="phase-1",
+            node_value=True,
+            boundary_value=True,
+        ):
             self.phase_name = phase
             self.field_name = field_name
             self.surface_ids = surface_ids
+            self.node_value = node_value
+            self.boundary_value = boundary_value
 
     class _VectorFieldTransaction:
         def __init__(self, field_name, surface_ids, phase="phase-1"):
@@ -366,18 +399,31 @@ class Batch(FieldBatch):
         node_value: bool | None = True,
         boundary_value: bool | None = True,
     ) -> None:
+        node_value, boundary_value = _normalize_file_session_scalar_options(
+            node_value,
+            boundary_value,
+        )
         surface_ids = self.get_surface_ids(surfaces)
         if len(self._file_session._data_file.get_phases()) > 1:
             if not field_name.startswith("phase-"):
                 raise InvalidMultiPhaseFieldName()
             self._scalar_field_batches.append(
                 Batch._ScalarFieldTransaction(
-                    field_name, surface_ids, field_name.split(":")[0]
+                    field_name,
+                    surface_ids,
+                    field_name.split(":")[0],
+                    node_value,
+                    boundary_value,
                 )
             )
         else:
             self._scalar_field_batches.append(
-                Batch._ScalarFieldTransaction(field_name, surface_ids)
+                Batch._ScalarFieldTransaction(
+                    field_name,
+                    surface_ids,
+                    node_value=node_value,
+                    boundary_value=boundary_value,
+                )
             )
 
     @deprecate_arguments(
@@ -542,22 +588,19 @@ class Batch(FieldBatch):
         mesh = self._file_session._case_file.get_mesh()
         field_data = {}
 
-        scalar_field_tag = (
-            ("type", "scalar-field"),
-            (
-                "dataLocation",
-                DataLocation.Elements,
-            ),
-            ("boundaryValues", False),
-        )
-
         for batch in self._scalar_field_batches:
-            if scalar_field_tag not in field_data:
-                field_data[scalar_field_tag] = {}
-            field_data_surface = field_data[scalar_field_tag]
+            scalar_field_tag = (
+                ("type", "scalar-field"),
+                (
+                    "dataLocation",
+                    DataLocation.Nodes if batch.node_value else DataLocation.Elements,
+                ),
+                ("boundaryValues", batch.boundary_value),
+            )
+            field_data_surface = field_data.setdefault(scalar_field_tag, {})
             for surface_id in batch.surface_ids:
-                field_data_surface[surface_id] = {}
-                field_data_surface[surface_id][batch.field_name] = (
+                surface_data = field_data_surface.setdefault(surface_id, {})
+                surface_data[batch.field_name] = (
                     self._file_session._data_file.get_face_scalar_field_data(
                         batch.phase_name, batch.field_name, surface_id
                     )
@@ -566,31 +609,28 @@ class Batch(FieldBatch):
         vector_field_tag = (("type", "vector-field"),)
 
         for batch in self._vector_field_batches:
-            if "velocity" not in batch.field_name:
+            bare_name = batch.field_name.split(":", 1)[-1]
+            if bare_name.lower() != "velocity":
                 raise InvalidFieldName()
             if vector_field_tag not in field_data:
                 field_data[vector_field_tag] = {}
             field_data_surface = field_data[vector_field_tag]
             for surface_id in batch.surface_ids:
-                field_data_surface[surface_id] = {}
-                field_data_surface[surface_id][batch.field_name] = (
+                surface_data = field_data_surface.setdefault(surface_id, {})
+                surface_data[batch.field_name] = (
                     self._file_session._data_file.get_face_vector_field_data(
                         batch.phase_name, surface_id
                     )
                 )
-                field_data_surface[surface_id]["vector-scale"] = np.array([0.1])
+                surface_data["vector-scale"] = np.array([0.1])
 
         for batch in self._surface_batches:
             if (("type", "surface-data"),) not in field_data:
                 field_data[(("type", "surface-data"),)] = {}
             field_data_surface = field_data[(("type", "surface-data"),)]
-            field_data_surface[batch.surface_id] = {}
-            field_data_surface[batch.surface_id]["faces"] = mesh.get_connectivity(
-                batch.surface_id
-            )
-            field_data_surface[batch.surface_id]["vertices"] = mesh.get_vertices(
-                batch.surface_id
-            )
+            surface_data = field_data_surface.setdefault(batch.surface_id, {})
+            surface_data["faces"] = mesh.get_connectivity(batch.surface_id)
+            surface_data["vertices"] = mesh.get_vertices(batch.surface_id)
         return BatchFieldData(
             field_data,
             self._field_info,
@@ -805,6 +845,7 @@ class FileFieldData(FieldDataSource):
         node_value: bool | None = True,
         boundary_value: bool | None = True,
     ):
+        _normalize_file_session_scalar_options(node_value, boundary_value)
         field_name = _to_scalar_field_name(field_name)
         surface_ids = self.get_surface_ids(surfaces=surfaces)
         scalar_data = {}
@@ -1044,6 +1085,7 @@ class _FileFieldInfo(BaseFieldInfo):
     def _get_scalar_field_range(
         self, field: str, node_value: bool = False, surface_ids: List[int] = None
     ) -> List[float]:
+        _normalize_file_session_scalar_options(node_value, False)
         minimum = None
         maximum = None
         if not surface_ids:

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -146,7 +146,10 @@ class BatchFieldData:
         scalar_field_data = self.data[
             (
                 ("type", "scalar-field"),
-                ("dataLocation", 0 if node_value else 1),
+                (
+                    "dataLocation",
+                    DataLocation.Nodes if node_value else DataLocation.Elements,
+                ),
                 ("boundaryValues", boundary_value),
             )
         ]

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -629,8 +629,10 @@ class Batch(FieldBatch):
                 field_data[(("type", "surface-data"),)] = {}
             field_data_surface = field_data[(("type", "surface-data"),)]
             surface_data = field_data_surface.setdefault(batch.surface_id, {})
-            surface_data["faces"] = mesh.get_connectivity(batch.surface_id)
-            surface_data["vertices"] = mesh.get_vertices(batch.surface_id)
+            if batch.provide_faces:
+                surface_data["faces"] = mesh.get_connectivity(batch.surface_id)
+            if batch.provide_vertices:
+                surface_data["vertices"] = mesh.get_vertices(batch.surface_id)
         return BatchFieldData(
             field_data,
             self._field_info,

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -374,11 +374,11 @@ class Batch(FieldBatch):
         surfaces : List[int | str]
             List of surface IDS or surface names for the surface data.
         node_value : bool, optional
-            Whether to provide the nodal location. The default is ``True``. If
-            ``False``, the element location is provided.
+            Ignored for FileSession. FileSession only provides face/element data.
+            Passing ``True`` will emit a deprecation warning.
         boundary_value : bool, optional
-            Whether to provide the slip velocity at the wall boundaries. The default
-            is ``True``. When ``True``, no slip velocity is provided.
+            Ignored for FileSession. FileSession only provides face/element data.
+            Passing ``True`` will emit a deprecation warning.
 
         Returns
         -------
@@ -819,11 +819,11 @@ class FileFieldData(FieldDataSource):
         surfaces : List[int | str]
             List of surface IDS or surface names for the surface data.
         node_value : bool, optional
-            Whether to provide data for the nodal location. The default is ``True``.
-            When ``False``, data is provided for the element location.
+            Ignored for FileSession. FileSession only provides face/element data.
+            Passing ``True`` will emit a deprecation warning.
         boundary_value : bool, optional
-            Whether to provide slip velocity at the wall boundaries. The default is
-            ``True``. When ``True``, no slip velocity is provided.
+            Ignored for FileSession. FileSession only provides face/element data.
+            Passing ``True`` will emit a deprecation warning.
 
         Returns
         -------

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -416,8 +416,8 @@ class Batch(FieldBatch):
                     field_name,
                     surface_ids,
                     field_name.split(":")[0],
-                    node_value,
-                    boundary_value,
+                    node_value=node_value,
+                    boundary_value=boundary_value,
                 )
             )
         else:

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -259,8 +259,8 @@ class Batch(FieldBatch):
             field_name,
             surface_ids,
             phase="phase-1",
-            node_value=True,
-            boundary_value=True,
+            node_value=False,
+            boundary_value=False,
         ):
             self.phase_name = phase
             self.field_name = field_name

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -80,18 +80,24 @@ def _normalize_file_session_scalar_options(
     node_value: bool | None,
     boundary_value: bool | None,
 ) -> tuple[bool, bool]:
-    """Normalize scalar options for FileSession face-based scalar data.
+    """Normalize scalar options for file-session scalar data.
 
-    FileSession scalar data comes from face values only. To avoid claiming nodal or
-    boundary-specific scalar data semantics that are not available from file reader
-    APIs, scalar requests are normalized to element location and boundaryValues=False.
+    Scalar data read from file sources is limited to face/element locations.
+    Nodal and boundary-specific scalar semantics are not available from file
+    reader APIs, so both options are overridden to ensure consistent behavior.
     """
-    if node_value is not False or boundary_value is not False:
+    if node_value is not False:
         warnings.warn(
-            "FileSession scalar data is face-based only. "
-            "Ignoring 'node_value' and 'boundary_value' and using "
-            "node_value=False, boundary_value=False.",
-            PyFluentDeprecationWarning,
+            "Scalar data from a file session is limited to face/element locations. "
+            "'node_value' will be overridden to False.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if boundary_value is not False:
+        warnings.warn(
+            "Scalar data from a file session is limited to face/element locations. "
+            "'boundary_value' will be overridden to False.",
+            UserWarning,
             stacklevel=2,
         )
     return False, False

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -92,6 +92,7 @@ def _normalize_file_session_scalar_options(
             "Ignoring 'node_value' and 'boundary_value' and using "
             "node_value=False, boundary_value=False.",
             PyFluentDeprecationWarning,
+            stacklevel=2,
         )
     return False, False
 

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -857,7 +857,9 @@ class FileFieldData(FieldDataSource):
         node_value: bool | None = True,
         boundary_value: bool | None = True,
     ):
-        _normalize_file_session_scalar_options(node_value, boundary_value)
+        node_value, boundary_value = _normalize_file_session_scalar_options(
+            node_value, boundary_value
+        )
         field_name = _to_scalar_field_name(field_name)
         surface_ids = self.get_surface_ids(surfaces=surfaces)
         scalar_data = {}

--- a/tests/test_file_session.py
+++ b/tests/test_file_session.py
@@ -687,7 +687,9 @@ def test_batch_request_single_phase_deprecated():
 
     batch_1 = field_data.new_batch()
 
-    batch_1.add_surfaces_request(provide_vertices=True, surfaces=[3, 5])
+    batch_1.add_surfaces_request(
+        provide_vertices=True, provide_faces=True, surfaces=[3, 5]
+    )
 
     batch_1.add_scalar_fields_request("SV_T", surfaces=[3, 5])
     batch_1.add_scalar_fields_request("SV_T", surfaces=["wall", "symmetry"])

--- a/tests/test_file_session.py
+++ b/tests/test_file_session.py
@@ -255,6 +255,114 @@ def test_batch_request_single_phase():
     assert round(vector_data[5][50][2], 5) == 0.00468
 
 
+def test_batch_request_single_phase_preserves_scalar_request_options():
+    case_file_name = examples.download_file(
+        "elbow1.cas.h5", "pyfluent/file_session", return_without_path=False
+    )
+    data_file_name = examples.download_file(
+        "elbow1.dat.h5", "pyfluent/file_session", return_without_path=False
+    )
+    file_session = FileSession()
+    file_session.read_case(case_file_name)
+    file_session.read_data(data_file_name)
+
+    batch = file_session.fields.field_data.new_batch()
+    default_request = ScalarFieldDataRequest(field_name="SV_T", surfaces=[3, 5])
+    element_request = ScalarFieldDataRequest(
+        field_name="SV_T",
+        surfaces=["wall", "symmetry"],
+        node_value=False,
+        boundary_value=False,
+    )
+
+    data = batch.add_requests(default_request, element_request).get_response()
+
+    default_scalar_data = data.get_field_data(default_request)
+    assert len(default_scalar_data) == 2
+    assert default_scalar_data[5].shape == (100,)
+    assert round(default_scalar_data[5][50], 2) == 295.43
+
+    element_scalar_data = data.get_field_data(element_request)
+    assert len(element_scalar_data) == 2
+    assert round(element_scalar_data["wall"][50], 2) == 293.15
+    assert round(element_scalar_data["symmetry"][50], 2) == 293.15
+
+
+def test_batch_request_single_phase_merges_multiple_fields_per_surface():
+    case_file_name = examples.download_file(
+        "elbow1.cas.h5", "pyfluent/file_session", return_without_path=False
+    )
+    data_file_name = examples.download_file(
+        "elbow1.dat.h5", "pyfluent/file_session", return_without_path=False
+    )
+    file_session = FileSession()
+    file_session.read_case(case_file_name)
+    file_session.read_data(data_file_name)
+
+    batch = file_session.fields.field_data.new_batch()
+    temperature_request = ScalarFieldDataRequest(
+        field_name="SV_T",
+        surfaces=[5],
+        node_value=False,
+        boundary_value=False,
+    )
+    pressure_request = ScalarFieldDataRequest(
+        field_name="SV_P",
+        surfaces=[5],
+        node_value=False,
+        boundary_value=False,
+    )
+
+    data = batch.add_requests(temperature_request, pressure_request).get_response()
+
+    temperature_data = data.get_field_data(temperature_request)
+    pressure_data = data.get_field_data(pressure_request)
+
+    assert temperature_data[5].shape == (100,)
+    assert pressure_data[5].shape == (100,)
+
+    scalar_field_tag = (
+        ("type", "scalar-field"),
+        ("dataLocation", 1),
+        ("boundaryValues", False),
+    )
+    assert set(data()[scalar_field_tag][5]) == {"SV_T", "SV_P"}
+
+
+def test_batch_request_single_phase_merges_surface_data_per_surface():
+    case_file_name = examples.download_file(
+        "elbow1.cas.h5", "pyfluent/file_session", return_without_path=False
+    )
+    data_file_name = examples.download_file(
+        "elbow1.dat.h5", "pyfluent/file_session", return_without_path=False
+    )
+    file_session = FileSession()
+    file_session.read_case(case_file_name)
+    file_session.read_data(data_file_name)
+
+    batch = file_session.fields.field_data.new_batch()
+    vertices_request = SurfaceFieldDataRequest(
+        data_types=[SurfaceDataType.Vertices],
+        surfaces=[3],
+    )
+    connectivity_request = SurfaceFieldDataRequest(
+        data_types=[SurfaceDataType.FacesConnectivity],
+        surfaces=[3],
+        flatten_connectivity=True,
+    )
+
+    data = batch.add_requests(vertices_request, connectivity_request).get_response()
+
+    vertices = data.get_field_data(vertices_request)
+    connectivity = data.get_field_data(connectivity_request)
+
+    assert vertices[3].vertices.shape == (3810, 3)
+    assert len(connectivity[3].connectivity) > 0
+
+    surface_data = data()[(("type", "surface-data"),)]
+    assert set(surface_data[3]) == {"faces", "vertices"}
+
+
 def test_batch_request_multi_phase():
     case_file_name = examples.download_file(
         "mixing_elbow_mul_ph.cas.h5",


### PR DESCRIPTION
## Context
`FileSession` batching behavior had several issues: scalar field requests incorrectly reflected node/boundary semantics that don't apply to file-based sessions, batch responses overwrote prior results when multiple requests targeted the same surface, and public docstrings misled callers about `node_value`/`boundary_value` behavior.

## Change Summary
- **Scalar option normalization**: `node_value`/`boundary_value` are normalized to `False` for FileSession scalar reads (face/element-only), emitting a `PyFluentDeprecationWarning` with correct `stacklevel` when non-default values are passed.
- **Consistent enum usage**: `DataLocation` enum used in both tag construction and response aggregation, eliminating fragile integer-to-enum key alignment.
- **`_ScalarFieldTransaction` defaults**: `node_value`/`boundary_value` now default to `False`, accurately reflecting FileSession semantics regardless of instantiation path.
- **Batch response merging**: Switched to `setdefault`-based aggregation so multiple scalar/vector field requests for the same surface merge instead of overwriting.
- **Selective mesh reads**: `Batch.get_response` now respects `provide_faces`/`provide_vertices` flags, skipping unnecessary connectivity/vertex reads for surfaces that didn't request them.
- **Docstrings**: Updated `add_scalar_fields_request` and `get_scalar_field_data` to document that `node_value`/`boundary_value` are ignored in FileSession (face-only data) and emit a deprecation warning when set to `True`.

## Rationale
FileSession reads data from files (face/element only); exposing node/boundary options as meaningful controls is incorrect and misleading. Merging rather than overwriting batch results is necessary for correctness when multiple field requests share a surface.

## Impact
- `FileSession` scalar field batching and direct reads.
- Callers passing `node_value=True` or `boundary_value=True` will now see a deprecation warning.
- Batch responses for multi-request scenarios will no longer silently drop earlier results.