### PR TITLE
fix: Autoscale images in modelling solidification example [skip tests]

### DIFF
--- a/doc/changelog.d/5072.fixed.md
+++ b/doc/changelog.d/5072.fixed.md
@@ -1,1 +1,1 @@
-Autoscale images in modelling solidification example
+Autoscale images in modelling solidification example [skip tests]

--- a/doc/changelog.d/5072.fixed.md
+++ b/doc/changelog.d/5072.fixed.md
@@ -1,0 +1,1 @@
+Autoscale images in modelling solidification example

--- a/examples/00-fluent/Modeling_solidification_workflow.py
+++ b/examples/00-fluent/Modeling_solidification_workflow.py
@@ -134,6 +134,7 @@ mesh.surfaces_list = all_walls
 mesh.options.edges = True
 mesh.display()
 
+graphics.views.auto_scale()
 graphics.picture.save_picture(file_name="modeling_solidification_1.png")
 
 # %%
@@ -329,6 +330,7 @@ temp_contour.field = "temperature"
 temp_contour.display()
 
 graphics.views.restore_view(view_name="front")
+graphics.views.auto_scale()
 graphics.picture.save_picture(file_name="modeling_solidification_2.png")
 
 # %%
@@ -347,6 +349,7 @@ mushy_temp.range_option = {
 mushy_temp.display()
 
 graphics.views.restore_view(view_name="front")
+graphics.views.auto_scale()
 graphics.picture.save_picture(file_name="modeling_solidification_3.png")
 
 # %%
@@ -383,6 +386,7 @@ liquid_fraction_contour = Contour(solver, new_instance_name="liquid-fraction")
 liquid_fraction_contour.field = "liquid-fraction"
 liquid_fraction_contour.display()
 
+graphics.views.auto_scale()
 graphics.picture.save_picture(file_name="modeling_solidification_4.png")
 
 # %%
@@ -401,6 +405,7 @@ liquid_fraction_contour_t_5_sec = Contour(solver, new_instance_name="liquid-frac
 liquid_fraction_contour_t_5_sec.field = "liquid-fraction"
 liquid_fraction_contour_t_5_sec.display()
 
+graphics.views.auto_scale()
 graphics.picture.save_picture(file_name="modeling_solidification_5.png")
 
 # %%


### PR DESCRIPTION
Refs some of TFS 1448096

## Context
Currently the images look like
<img width="650" height="450" alt="modeling_solidification_1 can" src="https://github.com/user-attachments/assets/1273efe4-f61b-43cf-8d12-f77ea850b12a" />
This updates them to look like
<img width="650" height="450" alt="modeling_solidification_1" src="https://github.com/user-attachments/assets/38cec96c-434e-45d0-9273-dc001738c68f" />


## Change Summary
Add call to graphics.views.auto_scale() before saving in the modelling solidification example