### PR TITLE
fix: Setting string values to rp vars.

### DIFF
--- a/doc/changelog.d/5079.fixed.md
+++ b/doc/changelog.d/5079.fixed.md
@@ -1,0 +1,1 @@
+Setting string values to rp vars.

--- a/doc/changelog.d/5079.fixed.md
+++ b/doc/changelog.d/5079.fixed.md
@@ -1,1 +1,1 @@
-Setting string rpvars now accepts values already wrapped in single or double quotes.
+Setting string values to rp vars.

--- a/doc/changelog.d/5079.fixed.md
+++ b/doc/changelog.d/5079.fixed.md
@@ -1,1 +1,1 @@
-Setting string values to rp vars.
+Setting string rpvars now accepts values already wrapped in single or double quotes.

--- a/doc/source/user_guide/legacy/rpvars.rst
+++ b/doc/source/user_guide/legacy/rpvars.rst
@@ -49,10 +49,10 @@ that can hold any value type.
    >>> # Create string rpvars using RPVarType enum
    >>> solver_session.rp_vars.create(name="my-str-var", value="my-string", var_type=RPVarType.STRING)
    >>> solver_session.rp_vars("my-str-var")
-   '"my-string"'
+   "my-string"
    >>> solver_session.rp_vars("my-str-var", "new-str")
    >>> solver_session.rp_vars("my-str-var")
-   '"new-str"'
+   "new-str"
    
    >>> # Create custom-typed rpvars that accepts any type
    >>> solver_session.rp_vars.create(name="my-custom-var", value=100, var_type=None)
@@ -60,7 +60,7 @@ that can hold any value type.
    100
    >>> solver_session.rp_vars("my-custom-var", "any-str")
    >>> solver_session.rp_vars("my-custom-var")
-   '"any-str"'
+   "any-str"
 
 
 **Type validation:**

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -148,26 +148,15 @@ class RPVars:
         list_val = self._execute("(cx-send 'rp-variables)")
         return {val[0]: val[1] for val in list_val}
 
-    @staticmethod
-    def _scheme_escape(text: str) -> str:
-        """Escape a Python string for safe embedding in a Scheme string literal.
-
-        Escapes backslashes and double-quotes so that the resulting string can
-        be safely placed between double-quote delimiters in a Scheme command
-        without producing invalid syntax or allowing command injection.
-        """
-        return text.replace("\\", "\\\\").replace('"', '\\"')
-
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
             text = val.strip()
-            # If caller already passed quoted content ('...','"...",'''...'''), peel outer quotes.
-            while len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+            # If caller already passed quoted content ('...','"..."), peel outer quotes.
+            if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
                 text = text[1:-1].strip()
-
             # Escape backslashes and double-quotes before embedding in the Scheme command.
-            cmd = f'(rpsetvar {RPVars._var(var)} "{RPVars._scheme_escape(text)}")'
+            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"
         return self._execute(cmd)

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -148,14 +148,25 @@ class RPVars:
         list_val = self._execute("(cx-send 'rp-variables)")
         return {val[0]: val[1] for val in list_val}
 
+    @staticmethod
+    def _strip_string_of_quotes(input_string: str) -> str:
+        """Normalize user-provided string values for ``rpsetvar`` string writes.
+
+        This helper addresses a narrow interoperability case where callers may pass
+        a value already wrapped in matching outer quotes (for example ``'"value"'``.
+        In that specific case, only the outer quote pair is
+        removed before the value is embedded in the Scheme command.
+        """
+        text = input_string.strip()
+        if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+            text = text[1:-1]
+        return text
+
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
-            text = val.strip()
-            # If caller already passed quoted content ('...', "..."), peel outer quotes.
-            if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
-                text = text[1:-1]
-            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
+            # Only normalize pre-quoted string payloads for this string-specific rpsetvar path.
+            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(self._strip_string_of_quotes(val))}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"
         return self._execute(cmd)

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -142,20 +142,34 @@ class RPVars:
             )
 
         cmd = f"(rpgetvar {RPVars._var(var)})"
-        return self._execute(cmd)
+        ret_val = self._execute(cmd)
+        if isinstance(ret_val, str):
+            return self._strip_string_of_quotes(ret_val)
+        return ret_val
 
     def _get_vars(self):
         list_val = self._execute("(cx-send 'rp-variables)")
-        return {val[0]: val[1] for val in list_val}
+        return {
+            val[0]: (
+                self._strip_string_of_quotes(val[1])
+                if isinstance(val[1], str)
+                else val[1]
+            )
+            for val in list_val
+        }
 
     @staticmethod
     def _strip_string_of_quotes(input_string: str) -> str:
-        """Normalize user-provided string values for ``rpsetvar`` string writes.
+        """Normalize rpvar string values when handling quoted edge cases.
 
-        This helper addresses a narrow interoperability case where callers may pass
-        a value already wrapped in matching outer quotes (for example ``'"value"'``.
-        In that specific case, only the outer quote pair is
-        removed before the value is embedded in the Scheme command.
+        Fluent may return string rpvar values wrapped in an extra layer of quotes
+        (for example ``'"value"'``), and callers may similarly pass pre-quoted
+        strings when writing. In both cases, only the single outermost matching
+        quote pair is removed so the value round-trips correctly between Python
+        and Scheme.
+
+        This normalization applies to the string-specific read paths
+        (``_get_var``, ``_get_vars``).
         """
         text = input_string.strip()
         if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
@@ -165,8 +179,7 @@ class RPVars:
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
-            # Only normalize pre-quoted string payloads.
-            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(self._strip_string_of_quotes(val))}")'
+            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(val)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"
         return self._execute(cmd)

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -165,7 +165,7 @@ class RPVars:
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
-            # Only normalize pre-quoted string payloads for this string-specific rpsetvar path.
+            # Only normalize pre-quoted string payloads.
             cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(self._strip_string_of_quotes(val))}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -148,6 +148,16 @@ class RPVars:
         list_val = self._execute("(cx-send 'rp-variables)")
         return {val[0]: val[1] for val in list_val}
 
+    @staticmethod
+    def _scheme_escape(text: str) -> str:
+        """Escape a Python string for safe embedding in a Scheme string literal.
+
+        Escapes backslashes and double-quotes so that the resulting string can
+        be safely placed between double-quote delimiters in a Scheme command
+        without producing invalid syntax or allowing command injection.
+        """
+        return text.replace("\\", "\\\\").replace('"', '\\"')
+
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
@@ -156,7 +166,8 @@ class RPVars:
             while len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
                 text = text[1:-1].strip()
 
-            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
+            # Escape backslashes and double-quotes before embedding in the Scheme command.
+            cmd = f'(rpsetvar {RPVars._var(var)} "{RPVars._scheme_escape(text)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"
         return self._execute(cmd)

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -155,7 +155,6 @@ class RPVars:
             # If caller already passed quoted content ('...','"..."), peel outer quotes.
             if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
                 text = text[1:-1].strip()
-            # Escape backslashes and double-quotes before embedding in the Scheme command.
             cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -152,7 +152,7 @@ class RPVars:
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
             text = val.strip()
-            # If caller already passed quoted content ('...','"..."), peel outer quotes.
+            # If caller already passed quoted content ('...', "..."), peel outer quotes.
             if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
                 text = text[1:-1].strip()
             cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -154,7 +154,7 @@ class RPVars:
             text = val.strip()
             # If caller already passed quoted content ('...', "..."), peel outer quotes.
             if len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
-                text = text[1:-1].strip()
+                text = text[1:-1]
             cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -151,7 +151,12 @@ class RPVars:
     def _set_var(self, var: str, val):
         prefix = "'" if isinstance(val, (list, tuple)) else ""
         if type(val) is str:
-            cmd = f'(rpsetvar {RPVars._var(var)} {prefix}"{lispy.to_string(val)}")'
+            text = val.strip()
+            # If caller already passed quoted content ('...','"...",'''...'''), peel outer quotes.
+            while len(text) >= 2 and text[0] == text[-1] and text[0] in ("'", '"'):
+                text = text[1:-1].strip()
+
+            cmd = f'(rpsetvar {RPVars._var(var)} "{lispy.to_string(text)}")'
         else:
             cmd = f"(rpsetvar {RPVars._var(var)} {prefix}{lispy.to_string(val)})"
         return self._execute(cmd)

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -24,7 +24,27 @@ import pytest
 
 from ansys.fluent.core.examples import download_file, path
 from ansys.fluent.core.filereader.casereader import CaseReader
-from ansys.fluent.core.rpvars import RPVarType
+from ansys.fluent.core.rpvars import RPVarType, RPVars
+
+
+def test_scheme_escape() -> None:
+    """Unit-tests for the Scheme-string escaping helper (no Fluent session required)."""
+    escape = RPVars._scheme_escape
+
+    # Plain string: no change
+    assert escape("gauss-seidel") == "gauss-seidel"
+
+    # Backslash must be doubled
+    assert escape("test\\path") == "test\\\\path"
+
+    # Double-quote must be escaped with a backslash
+    assert escape('say "hello"') == 'say \\"hello\\"'
+
+    # Both backslash and double-quote
+    assert escape('path\\to\\"file"') == 'path\\\\to\\\\\\"file\\"'
+
+    # Single-quote is valid inside Scheme strings and must not be altered
+    assert escape("it's fine") == "it's fine"
 
 
 def test_get_and_set_rp_vars(new_solver_session) -> None:

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -50,14 +50,14 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
     amg_cpld_relaxation_method = "dynamesh/smooth/laplace/amg-cpld-relaxation-method"
     original_amg_cpld_relaxation_method = solver.rp_vars(amg_cpld_relaxation_method)
     try:
-        solver.rp_vars(amg_cpld_relaxation_method, '"least-squares"')
-        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
+        solver.rp_vars(amg_cpld_relaxation_method, "least-squares")
+        assert solver.rp_vars(amg_cpld_relaxation_method) == "least-squares"
 
         solver.rp_vars(amg_cpld_relaxation_method, "gauss-seidel")
-        assert solver.rp_vars(amg_cpld_relaxation_method) == '"gauss-seidel"'
+        assert solver.rp_vars(amg_cpld_relaxation_method) == "gauss-seidel"
 
         solver.rp_vars(amg_cpld_relaxation_method, "least-squares")
-        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
+        assert solver.rp_vars(amg_cpld_relaxation_method) == "least-squares"
 
     finally:
         solver.rp_vars(amg_cpld_relaxation_method, original_amg_cpld_relaxation_method)
@@ -65,8 +65,8 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
     size_field_name = "dynamesh/remesh/rdc/size-field-name"
     original_size_field_name = solver.rp_vars(size_field_name)
     try:
-        solver.rp_vars(size_field_name, '"sizes_1.sf"')
-        assert solver.rp_vars(size_field_name) == '"sizes_1.sf"'
+        solver.rp_vars(size_field_name, "sizes_1.sf")
+        assert solver.rp_vars(size_field_name) == "sizes_1.sf"
     finally:
         solver.rp_vars(size_field_name, original_size_field_name)
 
@@ -143,9 +143,9 @@ def test_create_rp_vars(new_solver_session) -> None:
     solver.rp_vars.create(
         name="my-str-var", value="my-string", var_type=RPVarType.STRING
     )
-    assert solver.rp_vars("my-str-var") == '"my-string"'
+    assert solver.rp_vars("my-str-var") == "my-string"
     solver.rp_vars("my-str-var", "new-str")
-    assert solver.rp_vars("my-str-var") == '"new-str"'
+    assert solver.rp_vars("my-str-var") == "new-str"
 
     with pytest.raises(RuntimeError):
         # Since it was defined with string type
@@ -154,7 +154,7 @@ def test_create_rp_vars(new_solver_session) -> None:
     solver.rp_vars.create(name="my-custom-var", value=100, var_type=None)
     assert solver.rp_vars("my-custom-var") == 100
     solver.rp_vars("my-custom-var", "any-str")
-    assert solver.rp_vars("my-custom-var") == '"any-str"'
+    assert solver.rp_vars("my-custom-var") == "any-str"
 
     # Create RPVar with a list value and verify it is stored and retrieved correctly.
     solver.rp_vars.create(name="my-list-var", value=[1, 2, 3], var_type=None)

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -46,50 +46,38 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
     before_init_mod_2 = rp_vars("strategy/solution-strategy/before-init-modification")
     assert before_init_mod_2[1][1][1] == ("value", True)
 
-    # Test string assignment to rp vars
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"gauss-seidel"'
+    # Test string assignment to rp vars without depending on case-specific defaults
+    amg_cpld_relaxation_method = (
+        "dynamesh/smooth/laplace/amg-cpld-relaxation-method"
     )
-    solver.rp_vars(
-        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", '"least-squares"'
-    )
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"least-squares"'
-    )
-    solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method", "gauss-seidel")
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"gauss-seidel"'
-    )
-    solver.rp_vars(
-        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", "least-squares"
-    )
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"least-squares"'
-    )
-    solver.rp_vars(
-        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", """gauss-seidel"""
-    )
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"gauss-seidel"'
-    )
-    solver.rp_vars(
-        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", """least-squares"""
-    )
-    assert (
-        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
-        == '"least-squares"'
-    )
+    original_amg_cpld_relaxation_method = solver.rp_vars(amg_cpld_relaxation_method)
+    try:
+        solver.rp_vars(amg_cpld_relaxation_method, '"least-squares"')
+        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
 
-    assert solver.rp_vars("dynamesh/remesh/rdc/size-field-name") == '"sizes.sf"'
-    solver.rp_vars("dynamesh/remesh/rdc/size-field-name", '"sizes_1.sf"')
-    assert solver.rp_vars("dynamesh/remesh/rdc/size-field-name") == '"sizes_1.sf"'
+        solver.rp_vars(amg_cpld_relaxation_method, "gauss-seidel")
+        assert solver.rp_vars(amg_cpld_relaxation_method) == '"gauss-seidel"'
 
+        solver.rp_vars(amg_cpld_relaxation_method, "least-squares")
+        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
 
+        solver.rp_vars(amg_cpld_relaxation_method, """gauss-seidel""")
+        assert solver.rp_vars(amg_cpld_relaxation_method) == '"gauss-seidel"'
+
+        solver.rp_vars(amg_cpld_relaxation_method, """least-squares""")
+        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
+    finally:
+        solver.rp_vars(
+            amg_cpld_relaxation_method, original_amg_cpld_relaxation_method
+        )
+
+    size_field_name = "dynamesh/remesh/rdc/size-field-name"
+    original_size_field_name = solver.rp_vars(size_field_name)
+    try:
+        solver.rp_vars(size_field_name, '"sizes_1.sf"')
+        assert solver.rp_vars(size_field_name) == '"sizes_1.sf"'
+    finally:
+        solver.rp_vars(size_field_name, original_size_field_name)
 @pytest.mark.fluent_version(">=23.1, !=24.1")
 def test_get_all_rp_vars(new_solver_session) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -24,27 +24,7 @@ import pytest
 
 from ansys.fluent.core.examples import download_file, path
 from ansys.fluent.core.filereader.casereader import CaseReader
-from ansys.fluent.core.rpvars import RPVarType, RPVars
-
-
-def test_scheme_escape() -> None:
-    """Unit-tests for the Scheme-string escaping helper (no Fluent session required)."""
-    escape = RPVars._scheme_escape
-
-    # Plain string: no change
-    assert escape("gauss-seidel") == "gauss-seidel"
-
-    # Backslash must be doubled
-    assert escape("test\\path") == "test\\\\path"
-
-    # Double-quote must be escaped with a backslash
-    assert escape('say "hello"') == 'say \\"hello\\"'
-
-    # Both backslash and double-quote
-    assert escape('path\\to\\"file"') == 'path\\\\to\\\\\\"file\\"'
-
-    # Single-quote is valid inside Scheme strings and must not be altered
-    assert escape("it's fine") == "it's fine"
+from ansys.fluent.core.rpvars import RPVarType
 
 
 def test_get_and_set_rp_vars(new_solver_session) -> None:
@@ -67,9 +47,7 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
     assert before_init_mod_2[1][1][1] == ("value", True)
 
     # Test string assignment to rp vars without depending on case-specific defaults
-    amg_cpld_relaxation_method = (
-        "dynamesh/smooth/laplace/amg-cpld-relaxation-method"
-    )
+    amg_cpld_relaxation_method = "dynamesh/smooth/laplace/amg-cpld-relaxation-method"
     original_amg_cpld_relaxation_method = solver.rp_vars(amg_cpld_relaxation_method)
     try:
         solver.rp_vars(amg_cpld_relaxation_method, '"least-squares"')
@@ -81,15 +59,8 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
         solver.rp_vars(amg_cpld_relaxation_method, "least-squares")
         assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
 
-        solver.rp_vars(amg_cpld_relaxation_method, """gauss-seidel""")
-        assert solver.rp_vars(amg_cpld_relaxation_method) == '"gauss-seidel"'
-
-        solver.rp_vars(amg_cpld_relaxation_method, """least-squares""")
-        assert solver.rp_vars(amg_cpld_relaxation_method) == '"least-squares"'
     finally:
-        solver.rp_vars(
-            amg_cpld_relaxation_method, original_amg_cpld_relaxation_method
-        )
+        solver.rp_vars(amg_cpld_relaxation_method, original_amg_cpld_relaxation_method)
 
     size_field_name = "dynamesh/remesh/rdc/size-field-name"
     original_size_field_name = solver.rp_vars(size_field_name)
@@ -98,6 +69,8 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
         assert solver.rp_vars(size_field_name) == '"sizes_1.sf"'
     finally:
         solver.rp_vars(size_field_name, original_size_field_name)
+
+
 @pytest.mark.fluent_version(">=23.1, !=24.1")
 def test_get_all_rp_vars(new_solver_session) -> None:
     case_path = download_file("Static_Mixer_main.cas.h5", "pyfluent/static_mixer")

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -46,6 +46,49 @@ def test_get_and_set_rp_vars(new_solver_session) -> None:
     before_init_mod_2 = rp_vars("strategy/solution-strategy/before-init-modification")
     assert before_init_mod_2[1][1][1] == ("value", True)
 
+    # Test string assignment to rp vars
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"gauss-seidel"'
+    )
+    solver.rp_vars(
+        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", '"least-squares"'
+    )
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"least-squares"'
+    )
+    solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method", "gauss-seidel")
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"gauss-seidel"'
+    )
+    solver.rp_vars(
+        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", "least-squares"
+    )
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"least-squares"'
+    )
+    solver.rp_vars(
+        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", """gauss-seidel"""
+    )
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"gauss-seidel"'
+    )
+    solver.rp_vars(
+        "dynamesh/smooth/laplace/amg-cpld-relaxation-method", """least-squares"""
+    )
+    assert (
+        solver.rp_vars("dynamesh/smooth/laplace/amg-cpld-relaxation-method")
+        == '"least-squares"'
+    )
+
+    assert solver.rp_vars("dynamesh/remesh/rdc/size-field-name") == '"sizes.sf"'
+    solver.rp_vars("dynamesh/remesh/rdc/size-field-name", '"sizes_1.sf"')
+    assert solver.rp_vars("dynamesh/remesh/rdc/size-field-name") == '"sizes_1.sf"'
+
 
 @pytest.mark.fluent_version(">=23.1, !=24.1")
 def test_get_all_rp_vars(new_solver_session) -> None:


### PR DESCRIPTION
## Context
get_var to return string data in required format. "value"

## Change Summary
Earlier it was returning '"value"'. That was causing confusion.

Support string inputs with all the following format:

## Rationale
The simplest logic is to get rid of any extra "" or '' in the string output.

## Impact
Users will not get error while setting the value in the documented way.
