### PR TITLE
fix: Correct the launch timeout environment variable

### DIFF
--- a/doc/changelog.d/5088.fixed.md
+++ b/doc/changelog.d/5088.fixed.md
@@ -1,0 +1,1 @@
+Correct the launch timeout environment variable

--- a/src/ansys/fluent/core/module_config.py
+++ b/src/ansys/fluent/core/module_config.py
@@ -259,9 +259,9 @@ class Config:
         lambda instance: instance._env.get("PYFLUENT_USE_PODMAN_COMPOSE") == "1"
     )
 
-    #: The timeout in seconds to wait for Fluent to launch, defaults to the value of ``PYFLUENT_TIMEOUT_FORCE_EXIT`` environment variable or 60 seconds.
+    #: The timeout in seconds to wait for Fluent to launch, defaults to the value of ``PYFLUENT_FLUENT_LAUNCH_TIMEOUT`` environment variable or 60 seconds.
     launch_fluent_timeout = _ConfigDescriptor["Config"](
-        lambda instance: int(instance._env.get("PYFLUENT_TIMEOUT_FORCE_EXIT", 60))
+        lambda instance: int(instance._env.get("PYFLUENT_FLUENT_LAUNCH_TIMEOUT", 60))
     )
 
     #: Whether to show the Fluent GUI when launching the server, defaults to the value of ``PYFLUENT_SHOW_SERVER_GUI`` environment variable.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,6 +105,7 @@ def test_set_deprecated_var_after_config(reset_examples_path):
 
 
 def test_launch_timeout_environment_variable(monkeypatch):
+    monkeypatch.delattr(pyfluent.config, "_launch_fluent_timeout", raising=False)
     monkeypatch.setitem(pyfluent.config._env, "PYFLUENT_FLUENT_LAUNCH_TIMEOUT", "120")
 
     assert pyfluent.config.launch_fluent_timeout == 120

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
 import pytest
 
 import ansys.fluent.core as pyfluent
@@ -101,3 +102,9 @@ def test_set_deprecated_var_after_config(reset_examples_path):
     # Both deprecated var and config should have the latest value
     assert pyfluent.EXAMPLES_PATH == new_path2
     assert pyfluent.config.examples_path == new_path2
+
+
+def test_launch_timeout_environment_variable(monkeypatch):
+    monkeypatch.setitem(pyfluent.config._env, "PYFLUENT_FLUENT_LAUNCH_TIMEOUT", "120")
+
+    assert pyfluent.config.launch_fluent_timeout == 120


### PR DESCRIPTION
## Context
The launch timeout env var name was incorrect.

## Change Summary
The launch timeout env var name has been corrected.

## Rationale
Fixes coding error.

## Impact
Launch timeout can be configured using env var.
