### PR TITLE
ci: Update new issue creation template in repository [skip tests]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: 🐞 Bug, problem, error
+description: Report an issue, problem, or error in PyFluent.
+title: "[BUG]: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill in the
+        sections below so we can reproduce and resolve the issue quickly.
+
+  - type: checkboxes
+    id: prior-search
+    attributes:
+      label: ✅ Before submitting
+      description: Please confirm the following before opening the issue.
+      options:
+        - label: I have searched the [existing issues](https://github.com/ansys/pyfluent/issues) and did not find a duplicate.
+          required: true
+        - label: I am using a Python virtual environment.
+          required: true
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description of the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I call ..., PyFluent raises ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 🔁 Steps to reproduce
+      description: Provide a minimal, self-contained code snippet that reproduces the problem.
+      render: python
+      placeholder: |
+        import ansys.fluent.core as pyfluent
+        session = pyfluent.launch_fluent()
+        # ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 🎯 Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 💥 Actual behavior / traceback
+      description: What actually happened? Paste the full traceback if any.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: pyfluent-version
+    attributes:
+      label: 📦 PyFluent version
+      description: Run `python -c "import ansys.fluent.core as pyfluent; print(pyfluent.__version__)"` to get the exact version.
+      placeholder: e.g. 0.34.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: fluent-version
+    attributes:
+      label: 🌀 Ansys Fluent version
+      options:
+        - "2027 R1 (27.1)"
+        - "2026 R1 (26.1)"
+        - "2025 R2 (25.2)"
+        - "2025 R1 (25.1)"
+        - "2024 R2 (24.2)"
+        - "Other / not listed"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: 🐍 Python version
+      options:
+        - "3.14"
+        - "3.13"
+        - "3.12"
+        - "3.11"
+        - "3.10"
+        - "Other / not listed"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: 💻 Operating system
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📌 Additional context
+      description: Logs, screenshots, environment details, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,5 +5,5 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Fluent issue
-    url: https://developer.ansys.com/
+    url: https://discuss.ansys.com/
     about: "Hitting a problem in Ansys Fluent itself or its APIs (not in PyFluent)? Please report it on the Ansys Developer Portal or through the usual support channel."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Controls the "New issue" chooser page.
+# Keep this true so the "Blank issue" card continues to appear,
+# matching the previous behavior inherited from the ansys org defaults.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Fluent issue
+    url: https://developer.ansys.com/
+    about: "Hitting a problem in Ansys Fluent itself or its APIs (not in PyFluent)? Please report it on the Ansys Developer Portal or through your usual Ansys support channel, the same way you would for any other Fluent issue."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://developer.ansys.com/
-    about: "Hitting a problem in Ansys Fluent itself or its APIs (not in PyFluent)? Please report it on the Ansys Developer Portal or through your usual Ansys support channel, the same way you would for any other Fluent issue."
+    about: "Hitting a problem in Ansys Fluent itself or its APIs (not in PyFluent)? Please report it on the Ansys Developer Portal or through the usual support channel."

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,31 @@
+name: 📖 Documentation
+description: Report a problem or suggest an improvement to the PyFluent documentation.
+title: "[DOC]: <short description>"
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: 🔗 Affected page or URL
+      placeholder: https://fluent.docs.pyansys.com/version/stable/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: ⚠️ What is wrong or missing?
+      description: Describe the documentation problem (typo, unclear text, missing example, broken link, etc.).
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: ✏️ Suggested improvement
+      description: How would you improve this documentation?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📌 Additional context

--- a/.github/ISSUE_TEMPLATE/example_request.yml
+++ b/.github/ISSUE_TEMPLATE/example_request.yml
@@ -1,0 +1,24 @@
+name: 🎓 Adding an example
+description: Request a new PyFluent example or improvement to an existing one.
+title: "[EXAMPLE]: <short description>"
+labels: ["examples"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: 🎯 Use case
+      description: What workflow or simulation should the example demonstrate?
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: 🔧 Details
+      description: Physics, geometry, solver settings, post-processing, etc.
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 📚 References
+      description: Papers, tutorials, or existing scripts related to this example.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: 💡 New feature
+description: Suggest a new feature or enhancement for PyFluent.
+title: "[FEAT]: <short description>"
+labels: ["new feature", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new feature! Please describe the motivation
+        and the desired behavior so we can evaluate it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: ❓ Problem statement
+      description: What problem are you trying to solve? Why is the current behavior insufficient?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 💡 Proposed solution
+      description: Describe the API or behavior you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🔀 Alternatives considered
+      description: Any alternative solutions or workarounds you have considered.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📌 Additional context
+      description: Links, references, screenshots, or related issues.

--- a/doc/changelog.d/5097.maintenance.md
+++ b/doc/changelog.d/5097.maintenance.md
@@ -1,0 +1,1 @@
+Update new issue creation template in repository.

--- a/doc/changelog.d/5097.maintenance.md
+++ b/doc/changelog.d/5097.maintenance.md
@@ -1,1 +1,1 @@
-Update new issue creation template in repository.
+Update new issue creation template in repository [skip tests]


### PR DESCRIPTION
## Context
The default issue creation template from github was being used. That had some limitation as we could not edit the labels or contents of it.

## Change Summary
1. Custom issue template has been added for all the issues. Now we can add extra fields to any issues and update user facing messages in the repo, etc.
2. We have tried maintaining the similar look and feel with an extra checkbox or some extra fields.
3. Some limitations are we cannot move the link before issue creation, and no message box is allowed, so a suggestion is to pin an issue with enough information.
4. Suggestion: Might be we close all those issues related to Fluent and mark it here in this issue so that users are aware why their issue got closed along with providing them a message.
5. blank issues remain intentionally supported.

## Rationale
To allow users to get better guidance while creating an issue, so that our repo does not get issues from settings-api or Fluent.

## Impact
Users will have better issue creation guidance.
