### PR TITLE
chore: Remove get_specs.

### DIFF
--- a/devel/undocumented_fields/undocumented_fields.txt
+++ b/devel/undocumented_fields/undocumented_fields.txt
@@ -209,8 +209,6 @@
   Class: PyMenu
     - deleteAllChildObjects
     - deleteChildObjects
-  Class: PyMenuGeneric
-    - attrs
   Class: PyNamedObjectContainer
     - getChildObjectDisplayNames
     - getState

--- a/doc/changelog.d/5102.maintenance.md
+++ b/doc/changelog.d/5102.maintenance.md
@@ -1,0 +1,1 @@
+Remove get_specs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ non-cap = [
     "executeCommand",
     "createCommandArguments",
     "deleteCommandArguments",
-    "getSpecs",
     "getStaticInfo",
     "subscribeEvents",
     "unsubscribeEvents"

--- a/src/ansys/fluent/core/meshing/meshing_workflow.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow.py
@@ -29,7 +29,7 @@ from enum import Enum
 import os
 
 from ansys.fluent.core._types import PathType
-from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
+from ansys.fluent.core.services.datamodel_se import PyMenu
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.workflow import Workflow
 
@@ -47,8 +47,8 @@ class MeshingWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         name: str,
         identifier: str,
         fluent_version: FluentVersion,
@@ -58,9 +58,9 @@ class MeshingWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         name: str
             Workflow name to initialize it.
@@ -101,8 +101,8 @@ class WatertightMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -110,9 +110,9 @@ class WatertightMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -134,10 +134,10 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
-        part_management: PyMenuGeneric,
-        pm_file_management: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
+        part_management: PyMenu,
+        pm_file_management: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -145,13 +145,13 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
-        part_management : PyMenuGeneric
+        part_management : PyMenu
             Part management object.
-        pm_file_management : PyMenuGeneric
+        pm_file_management : PyMenu
             File management object in the part management object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -170,23 +170,23 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
         self._pm_file_management = pm_file_management
 
     @property
-    def part_management(self) -> PyMenuGeneric | None:
+    def part_management(self) -> PyMenu | None:
         """Access part-management in fault-tolerant mode.
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             Part-management.
         """
         return self._part_management
 
     @property
-    def pm_file_management(self):
+    def pm_file_management(self) -> PyMenu | None:
         """Access the part-management file-management object in fault-tolerant mode.
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             File management object in the part management object.
         """
         return self._pm_file_management
@@ -197,8 +197,8 @@ class TwoDimensionalMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -206,9 +206,9 @@ class TwoDimensionalMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -230,8 +230,8 @@ class TopologyBasedMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -239,9 +239,9 @@ class TopologyBasedMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -272,8 +272,8 @@ class LoadWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         file_path: PathType,
         fluent_version: FluentVersion,
     ) -> None:
@@ -281,9 +281,9 @@ class LoadWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         file_path: os.PathLike[str | bytes] | str | bytes
             Path to the saved workflow file.
@@ -304,8 +304,8 @@ class CreateWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -313,9 +313,9 @@ class CreateWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -353,7 +353,7 @@ def get_current_workflow(
 
     Parameters
     ----------
-    meshing_root : PyMenuGeneric
+    meshing_root : PyMenu
         Root meshing datamodel object containing GlobalSettings and workflow state.
     current_workflow : Workflow or None
         Currently cached workflow instance (may be None or outdated).

--- a/src/ansys/fluent/core/meshing/meshing_workflow_new.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow_new.py
@@ -29,7 +29,7 @@ from enum import Enum
 import os
 
 from ansys.fluent.core._types import PathType
-from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
+from ansys.fluent.core.services.datamodel_se import PyMenu
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.workflow_new import Workflow
 
@@ -40,8 +40,8 @@ class MeshingWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         name: str,
         fluent_version: FluentVersion,
         initialize: bool = True,
@@ -50,9 +50,9 @@ class MeshingWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         name: str
             Workflow name to initialize it.
@@ -76,8 +76,8 @@ class WatertightMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -85,9 +85,9 @@ class WatertightMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -108,10 +108,10 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
-        part_management: PyMenuGeneric,
-        pm_file_management: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
+        part_management: PyMenu,
+        pm_file_management: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -119,13 +119,13 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
-        part_management : PyMenuGeneric
+        part_management : PyMenu
             Part management object.
-        pm_file_management : PyMenuGeneric
+        pm_file_management : PyMenu
             File management object in the part management object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -144,12 +144,12 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
         self._pm_file_management = pm_file_management
 
     @property
-    def parts(self) -> PyMenuGeneric | None:
+    def parts(self) -> PyMenu | None:
         """Access part-management in fault-tolerant mode.
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             Part-management.
         """
         return self._parent_workflow.parts
@@ -160,30 +160,30 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             File management object in the part management object.
         """
         return self._parent_workflow.parts_files
 
     @property
-    def part_management(self) -> PyMenuGeneric | None:
+    def part_management(self) -> PyMenu | None:
         """Access part-management in fault-tolerant mode.
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             Part-management.
         """
         # TODO: Remove this after migrating to the new workflow
         return self._part_management
 
     @property
-    def pm_file_management(self):
+    def pm_file_management(self) -> PyMenu | None:
         """Access the part-management file-management object in fault-tolerant mode.
 
         Returns
         -------
-        PyMenuGeneric | None
+        PyMenu | None
             File management object in the part management object.
         """
         # TODO: Remove this after migrating to the new workflow
@@ -195,8 +195,8 @@ class TwoDimensionalMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -204,9 +204,9 @@ class TwoDimensionalMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -227,8 +227,8 @@ class TopologyBasedMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -236,9 +236,9 @@ class TopologyBasedMeshingWorkflow(MeshingWorkflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -268,8 +268,8 @@ class LoadWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         file_path: PathType = None,
         initialize: bool = True,
@@ -278,9 +278,9 @@ class LoadWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         file_path: os.PathLike[str | bytes] | str | bytes
             Path to the saved workflow file.
@@ -303,8 +303,8 @@ class CreateWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        meshing: PyMenuGeneric,
+        workflow: PyMenu,
+        meshing: PyMenu,
         fluent_version: FluentVersion,
         initialize: bool = True,
     ) -> None:
@@ -312,9 +312,9 @@ class CreateWorkflow(Workflow):
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             Underlying workflow object.
-        meshing : PyMenuGeneric
+        meshing : PyMenu
             Meshing object.
         fluent_version: FluentVersion
             Version of Fluent in this session.
@@ -341,7 +341,7 @@ def get_current_workflow(
 
     Parameters
     ----------
-    workflow_root : PyMenuGeneric
+    workflow_root : PyMenu
         Root workflow datamodel object.
     current_workflow : Workflow or None
         Currently cached workflow instance.

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -23,7 +23,6 @@
 """Wrappers over StateEngine based datamodel gRPC service of Fluent."""
 from enum import Enum
 import functools
-import itertools
 import logging
 import os
 from threading import RLock
@@ -296,12 +295,6 @@ class DatamodelServiceImpl:
                 "while deleting a command instance. Command instancing is"
                 "supported from Ansys 2023R2 onward."
             ) from None
-
-    def get_specs(
-        self, request: DataModelProtoModule.GetSpecsRequest
-    ) -> DataModelProtoModule.GetSpecsResponse:
-        """RPC getSpecs of DataModel service."""
-        return self._stub.getSpecs(request, metadata=self._metadata)
 
     def get_static_info(
         self, request: DataModelProtoModule.GetStaticInfoRequest
@@ -698,20 +691,6 @@ class DatamodelService(StreamingService):
             rules=rules, path=path, command=command, commandid=commandid
         )
         self._impl.delete_command_arguments(request)
-
-    def get_specs(
-        self,
-        rules: str,
-        path: str,
-    ) -> dict[str, Any]:
-        """Get specifications."""
-        request = DataModelProtoModule.GetSpecsRequest(
-            rules=rules,
-            path=path,
-        )
-        return MessageToDict(
-            self._impl.get_specs(request).member, use_integers_for_enums=True
-        )
 
     def get_static_info(self, rules: str) -> dict[str, Any]:
         """Get static info."""
@@ -1615,32 +1594,6 @@ class PyNamedObjectContainer:
         else:
             self.path = path
 
-    def _get_child_object_names(self) -> list[str]:
-        parent_path = self.path[0:-1]
-        child_type_suffix = self.path[-1][0] + ":"
-        response = self.service.get_specs(
-            self.rules, convert_path_to_se_path(parent_path)
-        )
-        child_object_names = []
-        for struct_type in ("singleton", "namedobject"):
-            struct_field = response.get(struct_type)
-            if struct_field:
-                for member in struct_field["members"]:
-                    if member.startswith(child_type_suffix):
-                        child_object_names.append(member[len(child_type_suffix) :])
-        return child_object_names
-
-    def _get_child_object_display_names(self) -> list[str]:
-        child_object_display_names = []
-        for name in self._get_child_object_names():
-            name_path = self.path[0:-1]
-            name_path.append((self.path[-1][0], name))
-            name_path.append(("_name_", ""))
-            child_object_display_names.append(
-                PyMenu(self.service, self.rules, name_path).get_state()
-            )
-        return child_object_display_names
-
     def get_object_names(self) -> Any:
         """Displays the name of objects within a container."""
         return self.service.get_object_names(
@@ -2178,57 +2131,6 @@ arg_class_by_type = {
 }
 
 
-class PyMenuGeneric(PyMenu):
-    """Generic PyMenu class for when generated API code is not available."""
-
-    attrs = ("service", "rules", "path", "_cached_attrs")
-
-    def _get_child_names(self) -> tuple[list, list, list, list]:
-        response = self.service.get_specs(
-            self.rules, convert_path_to_se_path(self.path)
-        )
-        singleton_names = []
-        creatable_type_names = []
-        command_names = []
-        query_names = []
-        for struct_type in ("singleton", "namedobject"):
-            struct_field = response.get(struct_type)
-            if struct_field:
-                for member in struct_field["members"]:
-                    if ":" not in member:
-                        singleton_names.append(member)
-                creatable_type_names = struct_field.get("creatabletypes", [])
-                command_names = [x["name"] for x in struct_field.get("commands", [])]
-                query_names = [x["name"] for x in struct_field.get("queries", [])]
-        return singleton_names, creatable_type_names, command_names, query_names
-
-    def _get_child(self, name: str) -> PyNamedObjectContainer | PyCommand | PyQuery:
-        singletons, creatable_types, commands, queries = self._get_child_names()
-        if name in singletons:
-            child_path = self.path + [(name, "")]
-            return PyMenuGeneric(self.service, self.rules, child_path)
-        elif name in creatable_types:
-            child_path = self.path + [(name, "")]
-            return PyNamedObjectContainerGeneric(self.service, self.rules, child_path)
-        elif name in commands:
-            return PyCommand(self.service, self.rules, name, self.path)
-        elif name in queries:
-            return PyQuery(self.service, self.rules, name, self.path)
-        else:
-            raise LookupError(
-                f"{name} is not found at path " f"{convert_path_to_se_path(self.path)}"
-            )
-
-    def __dir__(self) -> list[str]:
-        return list(itertools.chain(*self._get_child_names()))
-
-    def __getattr__(self, name: str):
-        if name in PyMenuGeneric.attrs:
-            return super().__getattr__(name)
-        else:
-            return self._get_child(name)
-
-
 class PySimpleMenuGeneric(PyMenu, PyDictionary):
     """A simple implementation of PyMenuGeneric applicable only for SINGLETONS.
 
@@ -2247,24 +2149,3 @@ class PySimpleMenuGeneric(PyMenu, PyDictionary):
             return super().__getattr__(name)
         else:
             return self._get_child(name)
-
-
-class PyNamedObjectContainerGeneric(PyNamedObjectContainer):
-    """Generic PyNamedObjectContainer class for when generated API code is not
-    available."""
-
-    def __iter__(self) -> Iterator[PyMenuGeneric]:
-        for name in self.get_object_names():
-            child_path = self.path[:-1]
-            child_path.append((self.path[-1][0], name))
-            yield PyMenuGeneric(self.service, self.rules, child_path)
-
-    def _get_item(self, key: str) -> PyMenuGeneric:
-        if key in self.get_object_names():
-            child_path = self.path[:-1]
-            child_path.append((self.path[-1][0], key))
-            return PyMenuGeneric(self.service, self.rules, child_path)
-        else:
-            raise LookupError(
-                f"{key} is not found at path " f"{convert_path_to_se_path(self.path)}"
-            )

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -291,12 +291,6 @@ class DatamodelServiceImpl:
                 "supported from Ansys 2023R2 onward."
             ) from None
 
-    def get_specs(
-        self, request: DataModelProtoModule.GetSpecsRequest
-    ) -> DataModelProtoModule.GetSpecsResponse:
-        """RPC GetSpecs of DataModel service."""
-        return self._stub.GetSpecs(request, metadata=self._metadata)
-
     def get_static_info(
         self, request: DataModelProtoModule.GetStaticInfoRequest
     ) -> DataModelProtoModule.GetStaticInfoResponse:
@@ -561,22 +555,6 @@ class DatamodelService(StreamingService):
         )
         self._impl.delete_command_arguments(request)
 
-    def get_specs(
-        self,
-        rules: str,
-        path: str,
-    ) -> dict[str, Any]:
-        """Get specifications."""
-        request = DataModelProtoModule.GetSpecsRequest(
-            rules=rules,
-            path=path,
-        )
-        return _normalize_v1_datamodel_dict_keys(
-            MessageToDict(
-                self._impl.get_specs(request).member, use_integers_for_enums=True
-            )
-        )
-
     def get_static_info(self, rules: str) -> dict[str, Any]:
         """Get static info."""
         request = DataModelProtoModule.GetStaticInfoRequest(rules=rules)
@@ -810,9 +788,7 @@ PyArgumentsDictionarySubItem = _v0.PyArgumentsDictionarySubItem
 PyArgumentsParameterSubItem = _v0.PyArgumentsParameterSubItem
 PyArgumentsSingletonSubItem = _v0.PyArgumentsSingletonSubItem
 arg_class_by_type = _v0.arg_class_by_type
-PyMenuGeneric = _v0.PyMenuGeneric
 PySimpleMenuGeneric = _v0.PySimpleMenuGeneric
-PyNamedObjectContainerGeneric = _v0.PyNamedObjectContainerGeneric
 
 _bool_value_if_none = _v0._bool_value_if_none
 true_if_none = _v0.true_if_none

--- a/src/ansys/fluent/core/session_shared.py
+++ b/src/ansys/fluent/core/session_shared.py
@@ -26,7 +26,6 @@ import logging
 
 from ansys.fluent.core.module_config import config
 from ansys.fluent.core.pyfluent_warnings import warning_for_fluent_dev_version
-from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
 from ansys.fluent.core.utils import load_module
 
@@ -74,7 +73,5 @@ def _make_datamodel_module(session, module_name):
         warning_for_fluent_dev_version(session._version)
         return module.Root(session._se_service, module_name, [])
     except (ImportError, FileNotFoundError) as ex:
-        datamodel_logger.debug(ex)
-        datamodel_logger.warning("Generated API not found for %s.", module_name)
-        datamodel_logger.warning(_CODEGEN_MSG_DATAMODEL)
-        return PyMenuGeneric(session._se_service, module_name)
+        msg = "Please run `python codegen/allapigen.py` from the top-level pyfluent directory to generate the local datamodel API classes."
+        raise RuntimeError(msg) from ex

--- a/src/ansys/fluent/core/session_shared.py
+++ b/src/ansys/fluent/core/session_shared.py
@@ -29,12 +29,6 @@ from ansys.fluent.core.pyfluent_warnings import warning_for_fluent_dev_version
 from ansys.fluent.core.services.datamodel_tui import TUIMenu
 from ansys.fluent.core.utils import load_module
 
-_CODEGEN_MSG_DATAMODEL = (
-    "Currently calling the datamodel API in a generic manner. "
-    "Please run `python codegen/allapigen.py` from the top-level pyfluent "
-    "directory to generate the local datamodel API classes."
-)
-
 _CODEGEN_MSG_TUI = (
     "Currently calling the TUI commands in a generic manner. "
     "Please run `python codegen/allapigen.py` from the top-level pyfluent "

--- a/src/ansys/fluent/core/session_solver_aero.py
+++ b/src/ansys/fluent/core/session_solver_aero.py
@@ -29,7 +29,7 @@ from typing import Any, Dict
 
 from ansys.fluent.core.fluent_connection import FluentConnection
 from ansys.fluent.core.services import SchemeEval
-from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
+from ansys.fluent.core.services.datamodel_se import PySimpleMenuGeneric
 from ansys.fluent.core.session_solver import Solver
 
 
@@ -104,7 +104,8 @@ class SolverAero(Solver):
     @property
     def _flserver(self):
         """Root datamodel object."""
-        return PyMenuGeneric(service=self._se_service, rules="flserver")
+        # TODO: Have the generated files for this first before implementing this property
+        return PySimpleMenuGeneric(service=self._se_service, rules="flserver")
 
     @property
     def aero(self):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -39,7 +39,6 @@ from ansys.fluent.core.services.datamodel_se import (
     PyCallableStateObject,
     PyCommand,
     PyMenu,
-    PyMenuGeneric,
 )
 from ansys.fluent.core.utils.dictionary_operations import get_first_dict_key_for_value
 from ansys.fluent.core.utils.fluent_version import FluentVersion
@@ -1333,17 +1332,17 @@ class Workflow:
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        command_source: PyMenuGeneric,
+        workflow: PyMenu,
+        command_source: PyMenu,
         fluent_version: FluentVersion,
     ) -> None:
         """Initialize WorkflowWrapper.
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             The workflow object.
-        command_source : PyMenuGeneric
+        command_source : PyMenu
             The application root for commanding.
         """
         self.__dict__.update(
@@ -1712,17 +1711,17 @@ class ClassicWorkflow:
 
     def __init__(
         self,
-        workflow: PyMenuGeneric,
-        command_source: PyMenuGeneric,
+        workflow: PyMenu,
+        command_source: PyMenu,
         fluent_version: FluentVersion,
     ) -> None:
         """Initialize ClassicWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenuGeneric
+        workflow : PyMenu
             The workflow object.
-        command_source : PyMenuGeneric
+        command_source : PyMenu
             The application root for commanding.
         """
         self._workflow = workflow

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -39,7 +39,6 @@ from ansys.fluent.core.services.datamodel_se import (
     PyCommand,
     PyNumerical,
     PyQuery,
-    PySimpleMenuGeneric,
     ReadOnlyObjectError,
     _convert_value_to_variant,
     _convert_variant_to_value,
@@ -413,88 +412,6 @@ def test_task_object_keys_are_display_names(new_meshing_session):
     task_object_state = meshing.workflow.TaskObject()
     assert len(task_object_state) > 0
     assert not any(_is_internal_name(x, "TaskObject:") for x in task_object_state)
-
-
-@pytest.mark.fluent_version(">=24.2")
-def test_named_object_specific_methods_using_flserver(new_solver_session):
-    import_file_name = examples.download_file(
-        "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
-    )
-    solver = new_solver_session
-    solver.file.read(file_type="case", file_name=import_file_name)
-    solver.solution.initialization.hybrid_initialize()
-    solver.solution.run_calculation.iterate(iter_count=10)
-    solver.tui.display.objects.create(
-        "contour",
-        "contour-z1",
-        "field",
-        "velocity-magnitude",
-        "surfaces-list",
-        "cold-inlet",
-    )
-    solver.tui.display.objects.create(
-        "contour",
-        "contour-z2",
-        "field",
-        "velocity-magnitude",
-        "surfaces-list",
-        "hot-inlet",
-    )
-    solver.tui.display.objects.create(
-        "contour",
-        "contour-z3",
-        "field",
-        "velocity-magnitude",
-        "surfaces-list",
-        "outlet",
-    )
-    solver.tui.display.objects.create(
-        "contour",
-        "contour-z4",
-        "field",
-        "velocity-magnitude",
-        "surfaces-list",
-        "wall-elbow",
-    )
-    solver.tui.display.objects.create(
-        "contour",
-        "contour-z5",
-        "field",
-        "velocity-magnitude",
-        "surfaces-list",
-        "wall-inlet",
-    )
-
-    # Testing with flserver is not possible without get_specs implementation.
-    flserver = PySimpleMenuGeneric(solver._datamodel_service_se, "flserver")
-
-    assert set(flserver.Case.Results.Graphics.Contour.get_object_names()) == {
-        "contour-z1",
-        "contour-z2",
-        "contour-z3",
-        "contour-z4",
-        "contour-z5",
-    }
-
-    assert "contour-x1" not in flserver.Case.Results.Graphics.Contour.get_object_names()
-
-    flserver.Case.Results.Graphics.Contour["contour-z1"].rename("contour-x1")
-
-    assert "contour-x1" in flserver.Case.Results.Graphics.Contour.get_object_names()
-
-    flserver.Case.Results.Graphics.delete_child_objects(
-        "Contour", ["contour-x1", "contour-z2"]
-    )
-
-    assert set(flserver.Case.Results.Graphics.Contour.get_object_names()) == {
-        "contour-z3",
-        "contour-z4",
-        "contour-z5",
-    }
-
-    flserver.Case.Results.Graphics.delete_all_child_objects("Contour")
-
-    assert not flserver.Case.Results.Graphics.Contour.get_object_names()
 
 
 @pytest.mark.fluent_version(">=24.2")

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -37,9 +37,9 @@ from ansys.fluent.core.services.datamodel_se import (
     PyArgumentsSingletonSubItem,
     PyArgumentsTextualSubItem,
     PyCommand,
-    PyMenuGeneric,
     PyNumerical,
     PyQuery,
+    PySimpleMenuGeneric,
     ReadOnlyObjectError,
     _convert_value_to_variant,
     _convert_variant_to_value,
@@ -415,19 +415,6 @@ def test_task_object_keys_are_display_names(new_meshing_session):
     assert not any(_is_internal_name(x, "TaskObject:") for x in task_object_state)
 
 
-def test_generic_datamodel(new_solver_session):
-    solver = new_solver_session
-    import_file_name = examples.download_file(
-        "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
-    )
-    solver.file.read(file_type="case", file_name=import_file_name)
-    solver.setup.general.solver.time = "unsteady-2nd-order"
-    solver.solution.initialization.hybrid_initialize()
-    solver.scheme.eval("(init-flserver)")
-    flserver = PyMenuGeneric(solver._datamodel_service_se, "flserver")
-    assert flserver.Case.Solution.Calculation.TimeStepSize() == 1.0
-
-
 @pytest.mark.fluent_version(">=24.2")
 def test_named_object_specific_methods_using_flserver(new_solver_session):
     import_file_name = examples.download_file(
@@ -478,7 +465,8 @@ def test_named_object_specific_methods_using_flserver(new_solver_session):
         "wall-inlet",
     )
 
-    flserver = PyMenuGeneric(solver._datamodel_service_se, "flserver")
+    # Testing with flserver is not possible without get_specs implementation.
+    flserver = PySimpleMenuGeneric(solver._datamodel_service_se, "flserver")
 
     assert set(flserver.Case.Results.Graphics.Contour.get_object_names()) == {
         "contour-z1",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import string
 import time
 
 import pytest
@@ -53,10 +52,3 @@ def test_custom_python_error_via_grpc(datamodel_api_version_new, new_solver_sess
     # This may need to be updated if the error type changes in the server
     with pytest.raises(RuntimeError, match="prefereces not found!"):
         solver._se_service.get_state("prefereces", "General")
-    translator = str.maketrans("", "", string.punctuation)
-    with pytest.raises(ValueError) as ex:
-        solver._se_service.get_specs("prefereces", "General")
-    assert (
-        ex.value.args[0].translate(translator)
-        == "Datamodel rules for prefereces not found"
-    )


### PR DESCRIPTION
## Context
Remove 'getSpecs' Completely from PyFluent. This is done with the assumption that PyFluent compulsorily works with codegen run first.

One issue: Some parts of aero needs to be refactored later.

## Change Summary
PyMenuGeneric and PyNamedObjectContainerGeneric-> removed

Tests using them removed as well.

## Impact
None of the user facing documented interfaces should be affected.

Please note: Now it will raise RuntimeError during session creation if the codegen has not been run earlier, i.e. if the generated files are missing.
