### PR TITLE
build: Bump version to v0.39.dev1

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -83,7 +83,7 @@ from ansys.fluent.core.utils.context_managers import using  # noqa: F401
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
 
-__version__ = "0.39.dev0"
+__version__ = "0.39.dev1"
 
 _VERSION_INFO = None
 """


### PR DESCRIPTION
Bump version to v0.39.dev1

This will contain the updated grpc interface to be used with Fluent 27 R1.
