### PR TITLE
fix: introduce DomainError for invalid domain name (#5044)

### DIFF
--- a/src/ansys/fluent/core/services/solution_variables.py
+++ b/src/ansys/fluent/core/services/solution_variables.py
@@ -331,6 +331,19 @@ class ZoneError(ValueError):
         )
 
 
+class DomainError(ValueError):
+    """Exception class for errors in Domain name."""
+
+    def __init__(self, domain_name: str, allowed_values: List[str]):
+        """Initialize DomainError."""
+        self.domain_name = domain_name
+        super().__init__(
+            allowed_name_error_message(
+                context="domain", trial_name=domain_name, allowed_values=allowed_values
+            )
+        )
+
+
 class _AllowedNames:
     def is_valid(self, name):
         """Check whether a given name is valid or not."""
@@ -426,11 +439,11 @@ class _AllowedDomainNames(_AllowedNames):
 
         Raises
         ------
-        ZoneError
+        DomainError
             If the given domain name is invalid.
         """
         if not self.is_valid(domain_name):
-            raise ZoneError(
+            raise DomainError(
                 domain_name=domain_name,
                 allowed_values=self(),
             )

--- a/src/ansys/fluent/core/services/solution_variables_v1.py
+++ b/src/ansys/fluent/core/services/solution_variables_v1.py
@@ -45,6 +45,7 @@ _to_field_name_str = _v0._to_field_name_str
 
 InvalidSolutionVariableNameError = _v0.InvalidSolutionVariableNameError
 ZoneError = _v0.ZoneError
+DomainError = _v0.DomainError
 _AllowedNames = _v0._AllowedNames
 _AllowedSvarNames = _v0._AllowedSvarNames
 _AllowedZoneNames = _v0._AllowedZoneNames


### PR DESCRIPTION
## Context

`_AllowedDomainNames.valid_name` in `solution_variables.py` raised `ZoneError(domain_name=..., allowed_values=...)`, but `ZoneError.__init__` only accepts `zone_name`. Passing an invalid domain name therefore raised an unrelated `TypeError` instead of the intended validation error.

## Change Summary

- Add a `DomainError` class that mirrors `ZoneError` but uses the `domain` context in the error message.
- Switch `_AllowedDomainNames.valid_name` to raise `DomainError`.
- Re-export `DomainError` from `solution_variables_v1` alongside `ZoneError`.

## Rationale

`ZoneError` keeps its zone-specific signature (back-compatible) and a separate `DomainError` carries the domain context cleanly, matching the existing pattern.

## Impact

Any caller that passes an invalid `domain_name` to `_AllowedDomainNames.valid_name` will now receive a clear `DomainError` with the list of allowed domains, instead of a `TypeError`. `ZoneError` behavior is unchanged.

Resolves #5044.