### PR TITLE
ci: Update release ci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   update-changelog:
     name: "Update CHANGELOG (on release)"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to commit and push CHANGELOG updates.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   update-changelog:
     name: "Update CHANGELOG (on release)"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to commit and push CHANGELOG updates.
@@ -595,7 +595,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [test, update-changelog]
+    needs: [test]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # required for trusted publishing

--- a/doc/changelog.d/5122.maintenance.md
+++ b/doc/changelog.d/5122.maintenance.md
@@ -1,0 +1,1 @@
+Update release ci.


### PR DESCRIPTION
## Context
There has been a recent update in the change-log action which has affected the dev release. The changelog is not getting generated for dev release but our PyFluent release ci depends on it. So dev release was not going through.

## Change Summary
Make changelog run only for minor, patch or major releases (not for dev release).
Make release independent of changelog

## Rationale
Dev releases shouldn't build changelogs in fact.

## Impact
No effect on users.
