### PR TITLE
feat: Support aliased paths in builtin settingsgen

### DIFF
--- a/doc/changelog.d/5124.added.md
+++ b/doc/changelog.d/5124.added.md
@@ -1,0 +1,1 @@
+Support aliased paths in builtin settingsgen

--- a/src/ansys/fluent/core/codegen/builtin_settingsgen.py
+++ b/src/ansys/fluent/core/codegen/builtin_settingsgen.py
@@ -23,12 +23,14 @@
 """Generate builtin setting classes."""
 
 import re
+from typing import Literal, cast
 
 from ansys.fluent.core.module_config import config
 from ansys.fluent.core.solver.flobject import (
     CreatableNamedObjectMixin,
     NamedObject,
     _ChildNamedObjectAccessorMixin,
+    get_full_path,
 )
 from ansys.fluent.core.solver.settings_builtin_data import DATA
 from ansys.fluent.core.utils.fluent_version import FluentVersion, all_versions
@@ -40,6 +42,8 @@ _CLASS_NAME_OVERRIDES = {
     "ReadCaseData": "ReadCaseAndData",
     "WriteCaseData": "WriteCaseAndData",
 }
+
+SettingKind = Literal["Singleton", "NamedObject", "Command"]
 
 
 def _get_settings_root(version: str):
@@ -63,24 +67,45 @@ def _get_public_class_name(legacy_name: str) -> str:
     return _CLASS_NAME_OVERRIDES.get(legacy_name, legacy_name)
 
 
-def _get_named_objects_in_path(root, path, kind):
+def _get_named_objects_in_path(
+    root, path: list[str], kind: SettingKind
+) -> tuple[list[str], bool]:
+    """Get the named objects in the path and whether the final type of the setting is creatable.
+
+    Parameters
+    ----------
+    root : type
+        The root class to start from.
+    path : list[str]
+        The path to traverse.
+    kind : {'Singleton', 'NamedObject', 'Command'}
+        The kind of setting.
+
+    Returns
+    -------
+    tuple[list[str], bool]
+        A tuple containing the list of named objects in the path and a boolean indicating if the final type of the setting is creatable.
+    """
     named_objects = []
     cls = root
-    comps = path.split(".")
+    comps = path.copy()
     for i, comp in enumerate(comps):
-        cls = cls._child_classes[comp]
+        if comp in cls._child_classes:
+            cls = cls._child_classes[comp]
+        elif comp in cls._child_aliases:
+            child_path = cls._child_aliases[comp][0]
+            full_path = get_full_path(comps[:i], child_path.split("/"))
+            return _get_named_objects_in_path(root, full_path, kind)
         if i < len(comps) - 1 and issubclass(cls, NamedObject):
             named_objects.append(comp)
             cls = cls.child_object_type
-    final_type = ""
+    is_creatable = False
     if kind == "NamedObject":
         if not issubclass(cls, (NamedObject, _ChildNamedObjectAccessorMixin)):
             raise TypeError(f"{cls.__name__} is not NamedObject type.")
         if issubclass(cls, CreatableNamedObjectMixin):
-            final_type = "Creatable"
-        else:
-            final_type = "NonCreatable"
-    return named_objects, final_type
+            is_creatable = True
+    return named_objects, is_creatable
 
 
 def generate(version: str):
@@ -150,9 +175,11 @@ def generate(version: str):
                         break
                 if not version_supported:
                     continue
-            named_objects, final_type = _get_named_objects_in_path(root, path, kind)
+            named_objects, is_creatable = _get_named_objects_in_path(
+                root, path.split("."), cast(SettingKind, kind)
+            )
             if kind == "NamedObject":
-                kind = f"{final_type}NamedObject"
+                kind = f"{'Creatable' if is_creatable else 'NonCreatable'}NamedObject"
             f.write(f"class {name}(_{kind}Setting):\n")
             doc_kind = "command object" if kind == "Command" else "setting"
             f.write(f'    """{name} {doc_kind}."""\n\n')
@@ -234,5 +261,5 @@ def generate(version: str):
 
 
 if __name__ == "__main__":
-    version = "261"  # for development
+    version = "271"  # for development
     generate(version)

--- a/src/ansys/fluent/core/codegen/builtin_settingsgen.py
+++ b/src/ansys/fluent/core/codegen/builtin_settingsgen.py
@@ -95,7 +95,13 @@ def _get_named_objects_in_path(
         elif comp in cls._child_aliases:
             child_path = cls._child_aliases[comp][0]
             full_path = get_full_path(comps[:i], child_path.split("/"))
+            full_path.extend(comps[i + 1 :])
             return _get_named_objects_in_path(root, full_path, kind)
+        else:
+            raise KeyError(
+                f"Unable to resolve path component {comp!r} in path {path!r} "
+                f"for setting kind {kind!r} from class {cls.__name__}."
+            )
         if i < len(comps) - 1 and issubclass(cls, NamedObject):
             named_objects.append(comp)
             cls = cls.child_object_type

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -265,15 +265,63 @@ def _get_python_path_comps(obj):
     return comps[1:]
 
 
-def _get_class_from_paths(root_cls, some_path: list[str], other_path: list[str]):
-    """Get the class for the given alias path."""
-    parent_count = 0
-    while other_path[0] == "..":
-        parent_count += 1
-        other_path.pop(0)
-    for _ in range(parent_count):
-        some_path.pop()
-    full_path = some_path + other_path
+def get_full_path(base_path: list[str], relative_path: list[str]) -> list[str]:
+    """
+    Get full path by applying relative path to base path.
+
+    Parameters
+    ----------
+    base_path: list[str]
+        The base path.
+
+    relative_path: list[str]
+        The relative path, which can contain ".." to indicate going up one level in the hierarchy.
+
+    Returns
+    -------
+    list[str]
+        The full path obtained by applying the relative path to the base path.
+
+    Raises
+    ------
+    ValueError
+        If the relative path tries to go beyond the root of the hierarchy.
+    """
+    base_path = base_path.copy()
+    relative_path = relative_path.copy()
+    while relative_path and relative_path[0] == "..":
+        if not base_path:
+            raise ValueError("Relative path goes beyond root.")
+        base_path.pop()
+        relative_path.pop(0)
+    return base_path + relative_path
+
+
+def _get_class_from_paths(
+    root_cls, base_path: list[str], relative_path: list[str]
+) -> tuple[type, list[str]]:
+    """
+    Get the settings class from a base path and a relative path.
+
+    Parameters
+    ----------
+    root_cls: type
+        The root class to start from.
+
+    base_path: list[str]
+        The base path from the root class to the base of the relative path.
+
+    relative_path: list[str]
+        The relative path from the base to the target class. This can contain ".." to
+        indicate going up one level in the hierarchy.
+
+    Returns
+    -------
+    tuple[type, list[str]]
+        The target class and the full path from the root class to the target class.
+    """
+
+    full_path = get_full_path(base_path, relative_path)
     cls = root_cls
     for comp in full_path:
         cls = cls._child_classes[comp]

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1169,7 +1169,7 @@ class Group(SettingsBase[DictStateType]):
 
         Raises
         ------
-        RuntimeError
+        ValueError
             If key is invalid.
         """
         if isinstance(value, collections.abc.Mapping):
@@ -1187,7 +1187,7 @@ class Group(SettingsBase[DictStateType]):
                         v, root_cls, alias_path
                     )
                 else:
-                    raise RuntimeError("Key '" + str(k) + "' is invalid")
+                    raise ValueError("Key '" + str(k) + "' is invalid")
             return ret
         else:
             return value


### PR DESCRIPTION
## Context
Previously, the builtin_settingsgen didn't follow aliased paths. This limitation has caused a failure in a recent 27.1 settings API change (Fluent bug 1452586).

## Change Summary
Update builtin_settingsgen code so that it follows the aliased paths.

## Rationale
This change will work for any future similar change in the settings API. We don't need to update the paths in settings_builtin_data.py.

## Impact
The limitation will be removed.
