### PR TITLE
fix: list and list_properties for named objects.

### DIFF
--- a/doc/changelog.d/5126.fixed.md
+++ b/doc/changelog.d/5126.fixed.md
@@ -1,0 +1,1 @@
+List and list_properties for named objects.

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1543,14 +1543,14 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
             )
         return CombinedNamedObject([self, other])
 
-    def _list_fallback(self):
+    def list(self):
         """Print the object names."""
         if FluentVersion(self._version) >= FluentVersion.v261:
             return self._root.list(object_path=self.path)
         else:
             return self.list_1()
 
-    def _list_properties_fallback(self, object_name):
+    def list_properties(self, object_name):
         """Print the properties of the given object name.
 
         Parameters
@@ -2389,12 +2389,6 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
         if commands:
             cls.command_names = []
             _process_cls_names(commands, cls.command_names)
-
-        if obj_type == "named-object":
-            if "list" not in cls.command_names:
-                cls.list = NamedObject._list_fallback
-            if "list_properties" not in cls.command_names:
-                cls.list_properties = NamedObject._list_properties_fallback
 
         queries = info.get("queries")
         if queries:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2308,7 +2308,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
 
         original_pname = pname
         i = 1
-        if parent_taboo:
+        if parent_taboo and original_pname not in ("list", "list_properties"):
             while pname in parent_taboo:
                 pname = f"{original_pname}_{i}"
                 i += 1

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2396,7 +2396,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
                             object_path=f"{self.path}/{object_name}"
                         )
                     else:
-                        return self.list_properties_1(object_name)
+                        return self.list_properties_1(object_name=object_name)
 
                 cls.list_properties = _list_properties
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1543,6 +1543,26 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
             )
         return CombinedNamedObject([self, other])
 
+    def _list_fallback(self):
+        """Print the object names."""
+        if FluentVersion(self._version) >= FluentVersion.v261:
+            return self._root.list(object_path=self.path)
+        else:
+            return self.list_1()
+
+    def _list_properties_fallback(self, object_name):
+        """Print the properties of the given object name.
+
+        Parameters
+        ----------
+        object_name : str
+            Name of the object whose properties are to be listed.
+        """
+        if FluentVersion(self._version) >= FluentVersion.v261:
+            return self._root.list_properties(object_path=f"{self.path}/{object_name}")
+        else:
+            return self.list_properties_1(object_name=object_name)
+
 
 class CombinedNamedObject:
     """A ``CombinedNamedObject`` contains the concatenated named-objects."""
@@ -2372,33 +2392,9 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
 
         if obj_type == "named-object":
             if "list" not in cls.command_names:
-
-                def _list(self):
-                    """Print the object names."""
-                    if FluentVersion(self._version) >= FluentVersion.v261:
-                        return self._root.list(object_path=self.path)
-                    else:
-                        return self.list_1()
-
-                cls.list = _list
+                cls.list = NamedObject._list_fallback
             if "list_properties" not in cls.command_names:
-
-                def _list_properties(self, object_name):
-                    """Print the properties of the given object name.
-
-                    Parameters
-                    ----------
-                    object_name : str
-                        Name of the object whose properties are to be listed.
-                    """
-                    if FluentVersion(self._version) >= FluentVersion.v261:
-                        return self._root.list_properties(
-                            object_path=f"{self.path}/{object_name}"
-                        )
-                    else:
-                        return self.list_properties_1(object_name)
-
-                cls.list_properties = _list_properties
+                cls.list_properties = NamedObject._list_properties_fallback
 
         queries = info.get("queries")
         if queries:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2343,7 +2343,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             cls._deprecated_version = ""
 
         taboo = set(dir(cls))
-        if version >= "261":
+        if version and version >= "261":
             taboo -= {"list", "list_properties"}
         taboo |= set(
             [

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1543,26 +1543,6 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
             )
         return CombinedNamedObject([self, other])
 
-    def list(self):
-        """Print the object names."""
-        if FluentVersion(self._version) >= FluentVersion.v261:
-            return self._root.list(object_path=self.path)
-        else:
-            return self.list_1()
-
-    def list_properties(self, object_name):
-        """Print the properties of the given object name.
-
-        Parameters
-        ----------
-        object_name : str
-            Name of the object whose properties are to be listed.
-        """
-        if FluentVersion(self._version) >= FluentVersion.v261:
-            return self._root.list_properties(object_path=f"{self.path}/{object_name}")
-        else:
-            return self.list_properties_1(object_name=object_name)
-
 
 class CombinedNamedObject:
     """A ``CombinedNamedObject`` contains the concatenated named-objects."""
@@ -2389,6 +2369,36 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
         if commands:
             cls.command_names = []
             _process_cls_names(commands, cls.command_names)
+
+        if obj_type == "named-object":
+            if "list" not in cls.command_names:
+
+                def _list(self):
+                    """Print the object names."""
+                    if FluentVersion(self._version) >= FluentVersion.v261:
+                        return self._root.list(object_path=self.path)
+                    else:
+                        return self.list_1()
+
+                cls.list = _list
+            if "list_properties" not in cls.command_names:
+
+                def _list_properties(self, object_name):
+                    """Print the properties of the given object name.
+
+                    Parameters
+                    ----------
+                    object_name : str
+                        Name of the object whose properties are to be listed.
+                    """
+                    if FluentVersion(self._version) >= FluentVersion.v261:
+                        return self._root.list_properties(
+                            object_path=f"{self.path}/{object_name}"
+                        )
+                    else:
+                        return self.list_properties_1(object_name)
+
+                cls.list_properties = _list_properties
 
         queries = info.get("queries")
         if queries:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2308,7 +2308,7 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
 
         original_pname = pname
         i = 1
-        if parent_taboo and original_pname not in ("list", "list_properties"):
+        if parent_taboo:
             while pname in parent_taboo:
                 pname = f"{original_pname}_{i}"
                 i += 1
@@ -2343,6 +2343,8 @@ def get_cls(name, info, parent=None, version=None, parent_taboo=None):
             cls._deprecated_version = ""
 
         taboo = set(dir(cls))
+        if version >= "261":
+            taboo -= {"list", "list_properties"}
         taboo |= set(
             [
                 "child_names",

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1265,7 +1265,7 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
     if solver.get_fluent_version() < FluentVersion.v261:
         # The following is the default behavior when no arguments are associated with the command.
-        assert solver.results.graphics.contour.list_1.argument_names == []
+        assert solver.results.graphics.contour.list.argument_names == []
 
 
 @pytest.mark.fluent_version(">=25.1")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1263,9 +1263,6 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
 
     assert set(solver.results.graphics.contour.rename.argument_names) == {"new", "old"}
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
-    if solver.get_fluent_version() < FluentVersion.v261:
-        # The following is the default behavior when no arguments are associated with the command.
-        assert solver.results.graphics.contour.list_1.argument_names == []
 
 
 @pytest.mark.fluent_version(">=25.1")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1263,6 +1263,9 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
 
     assert set(solver.results.graphics.contour.rename.argument_names) == {"new", "old"}
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
+    if solver.get_fluent_version() < FluentVersion.v261:
+        # The following is the default behavior when no arguments are associated with the command.
+        assert solver.results.graphics.contour.list_1.argument_names == []
 
 
 @pytest.mark.fluent_version(">=25.1")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -1263,8 +1263,10 @@ def test_default_argument_names_for_commands(static_mixer_settings_session):
 
     assert set(solver.results.graphics.contour.rename.argument_names) == {"new", "old"}
     assert solver.results.graphics.contour.delete.argument_names == ["name_list"]
+    # The following is the default behavior when no arguments are associated with the command.
     if solver.get_fluent_version() < FluentVersion.v261:
-        # The following is the default behavior when no arguments are associated with the command.
+        assert solver.results.graphics.contour.list_1.argument_names == []
+    else:
         assert solver.results.graphics.contour.list.argument_names == []
 
 
@@ -1403,3 +1405,15 @@ def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
         list(solver.settings.setup.boundary_conditions.pressure_outlet.items())[0]
         in chained_named_objects.items()
     )
+
+
+def test_list_and_list_properties(new_solver_session):
+    solver = new_solver_session
+    if solver.get_fluent_version() < FluentVersion.v261:
+        assert {"list_1", "list_properties_1"}.issubset(
+            solver.settings.setup.materials.mixture.command_names
+        )
+    else:
+        assert {"list", "list_properties"}.issubset(
+            solver.settings.setup.materials.mixture.command_names
+        )

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -33,6 +33,7 @@ from ansys.fluent.core.solver import VelocityInlets, Viscous
 from ansys.fluent.core.solver.flobject import (
     DeprecatedSettingWarning,
     InactiveObjectError,
+    NamedObject,
     ReadOnlyActionError,
     _Alias,
     _InputFile,
@@ -842,6 +843,9 @@ def test_named_object_commands(mixing_elbow_settings_session):
     inlets = VelocityInlets(solver)
     inlets.list()
     inlets.list_properties(object_name="hot-inlet")
+    if solver.get_fluent_version() >= FluentVersion.v261:
+        NamedObject.list(inlets)
+        NamedObject.list_properties(inlets, object_name="hot-inlet")
 
 
 @pytest.mark.fluent_version(">=26.1")

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -33,7 +33,6 @@ from ansys.fluent.core.solver import VelocityInlets, Viscous
 from ansys.fluent.core.solver.flobject import (
     DeprecatedSettingWarning,
     InactiveObjectError,
-    NamedObject,
     ReadOnlyActionError,
     _Alias,
     _InputFile,
@@ -843,9 +842,6 @@ def test_named_object_commands(mixing_elbow_settings_session):
     inlets = VelocityInlets(solver)
     inlets.list()
     inlets.list_properties(object_name="hot-inlet")
-    if solver.get_fluent_version() >= FluentVersion.v261:
-        NamedObject.list(inlets)
-        NamedObject.list_properties(inlets, object_name="hot-inlet")
 
 
 @pytest.mark.fluent_version(">=26.1")


### PR DESCRIPTION
## Context
Command names under named objects like list and list_propreties were having a suffix "_1". The reason behind it was that from server side the implementation for these methods were to be moved to root. However currently it is there in root as well as in the leaf nodes (almost for all objects). On the other hand PyFluent has the implementation assuming that the list and list_properties would only be in the root level. Thus this issue.

```python
>>> materials = solver.settings.setup.materials
>>> sorted(materials.mixture.command_names)
['create', 'delete', 'list_1', 'list_properties_1', 'make_a_copy', 'rename']
>>> 
```

## Change Summary
Where the taboo code is incrementing the methods to have this suffixes, we just ignore the list and list properties. In this way the settings classes will get preference like required only without the suffix in the name.

## Impact
A correct list will be returned now:

```python
>>> materials = solver.settings.setup.materials
>>> sorted(materials.mixture.command_names)
['create', 'delete', 'list', 'list_properties', 'make_a_copy', 'rename']
>>> 
```
