### PR TITLE
fix: Avoid command-argument RPCs in destructors during shutdown by adding finalizer-based cleanup

### DIFF
--- a/doc/changelog.d/5127.fixed.md
+++ b/doc/changelog.d/5127.fixed.md
@@ -1,0 +1,1 @@
+Avoid command-argument RPCs in destructors during shutdown by adding finalizer-based cleanup

--- a/src/ansys/fluent/core/services/_command_arguments_mixin.py
+++ b/src/ansys/fluent/core/services/_command_arguments_mixin.py
@@ -76,5 +76,5 @@ class CommandArgumentsCleanupMixin(ABC):
     def _delete_command_arguments_rpc(
         self, rules: str, path: str, command: str, commandid: str
     ) -> None:
-        """Perform the RPC call to delete command arguments on the Fluent side."""
+        """Issue RPC to delete command arguments."""
         pass

--- a/src/ansys/fluent/core/services/_command_arguments_mixin.py
+++ b/src/ansys/fluent/core/services/_command_arguments_mixin.py
@@ -1,3 +1,25 @@
+# Copyright (C) 2021 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """Mixin for managing the lifecycle of command arguments in datamodel services."""
 
 from abc import ABC, abstractmethod

--- a/src/ansys/fluent/core/services/_command_arguments_mixin.py
+++ b/src/ansys/fluent/core/services/_command_arguments_mixin.py
@@ -10,7 +10,8 @@ logger = logging.getLogger("pyfluent.datamodel")
 class CommandArgumentsCleanupMixin(ABC):
     """Shared command-argument lifecycle cleanup for datamodel services."""
 
-    def _init_command_arguments_cleanup(self) -> None:
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._command_arguments: set[tuple[str, str, str, str]] = set()
         self._command_arguments_lock = RLock()
         self._shutdown_cleanup_started = False

--- a/src/ansys/fluent/core/services/_command_arguments_mixin.py
+++ b/src/ansys/fluent/core/services/_command_arguments_mixin.py
@@ -1,0 +1,80 @@
+"""Mixin for managing the lifecycle of command arguments in datamodel services."""
+
+from abc import ABC, abstractmethod
+import logging
+from threading import RLock
+
+logger = logging.getLogger("pyfluent.datamodel")
+
+
+class CommandArgumentsCleanupMixin(ABC):
+    """Shared command-argument lifecycle cleanup for datamodel services."""
+
+    def _init_command_arguments_cleanup(self) -> None:
+        self._command_arguments: set[tuple[str, str, str, str]] = set()
+        self._command_arguments_lock = RLock()
+        self._shutdown_cleanup_started = False
+
+    @staticmethod
+    def _command_arguments_key(
+        rules: str, path: str, command: str, commandid: str
+    ) -> tuple[str, str, str, str]:
+        return (rules, path, command, commandid)
+
+    def register_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Register command arguments for explicit cleanup during shutdown."""
+        with self._command_arguments_lock:
+            if self._shutdown_cleanup_started:
+                return
+            self._command_arguments.add(
+                self._command_arguments_key(rules, path, command, commandid)
+            )
+
+    def release_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Release command arguments when their Python wrapper is deleted."""
+        key = self._command_arguments_key(rules, path, command, commandid)
+        with self._command_arguments_lock:
+            was_registered = key in self._command_arguments
+            self._command_arguments.discard(key)
+            shutdown_cleanup_started = self._shutdown_cleanup_started
+
+        if was_registered and not shutdown_cleanup_started:
+            self._delete_command_arguments_rpc(rules, path, command, commandid)
+
+    def delete_all_command_arguments(self) -> None:
+        """Delete all tracked command arguments as part of shutdown finalization."""
+        with self._command_arguments_lock:
+            self._shutdown_cleanup_started = True
+            command_arguments = list(self._command_arguments)
+            self._command_arguments.clear()
+
+        for rules, path, command, commandid in command_arguments:
+            try:
+                self._delete_command_arguments_rpc(rules, path, command, commandid)
+            except Exception as exc:
+                logger.info(
+                    "delete_all_command_arguments %s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
+
+    def delete_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Delete command arguments and stop tracking them."""
+        with self._command_arguments_lock:
+            self._command_arguments.discard(
+                self._command_arguments_key(rules, path, command, commandid)
+            )
+        self._delete_command_arguments_rpc(rules, path, command, commandid)
+
+    @abstractmethod
+    def _delete_command_arguments_rpc(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Perform the RPC call to delete command arguments on the Fluent side."""
+        pass

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -506,7 +506,6 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self.file_transfer_service = file_transfer_service
         self.cache = DataModelCache() if config.datamodel_use_state_cache else None
         self.version = version
-        self._init_command_arguments_cleanup()
 
     def _delete_command_arguments_rpc(
         self, rules: str, path: str, command: str, commandid: str

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -503,6 +503,65 @@ class DatamodelService(StreamingService):
         self.file_transfer_service = file_transfer_service
         self.cache = DataModelCache() if config.datamodel_use_state_cache else None
         self.version = version
+        self._command_arguments: set[tuple[str, str, str, str]] = set()
+        self._command_arguments_lock = RLock()
+        self._shutdown_cleanup_started = False
+
+    @staticmethod
+    def _command_arguments_key(
+        rules: str, path: str, command: str, commandid: str
+    ) -> tuple[str, str, str, str]:
+        return (rules, path, command, commandid)
+
+    def register_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Register command arguments for explicit cleanup during shutdown."""
+        with self._command_arguments_lock:
+            if self._shutdown_cleanup_started:
+                return
+            self._command_arguments.add(
+                self._command_arguments_key(rules, path, command, commandid)
+            )
+
+    def release_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Release command arguments when their Python wrapper is deleted."""
+        key = self._command_arguments_key(rules, path, command, commandid)
+        with self._command_arguments_lock:
+            was_registered = key in self._command_arguments
+            self._command_arguments.discard(key)
+            shutdown_cleanup_started = self._shutdown_cleanup_started
+
+        if was_registered and not shutdown_cleanup_started:
+            self._delete_command_arguments_rpc(rules, path, command, commandid)
+
+    def delete_all_command_arguments(self) -> None:
+        """Delete all tracked command arguments as part of shutdown finalization."""
+        with self._command_arguments_lock:
+            self._shutdown_cleanup_started = True
+            command_arguments = list(self._command_arguments)
+            self._command_arguments.clear()
+
+        for rules, path, command, commandid in command_arguments:
+            try:
+                self._delete_command_arguments_rpc(rules, path, command, commandid)
+            except Exception as exc:
+                logger.info(
+                    "delete_all_command_arguments %s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
+
+    def _delete_command_arguments_rpc(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Issue RPC to delete command arguments."""
+        request = DataModelProtoModule.DeleteCommandArgumentsRequest(
+            rules=rules, path=path, command=command, commandid=commandid
+        )
+        self._impl.delete_command_arguments(request)
 
     def get_attribute_value(self, rules: str, path: str, attribute: str) -> ValueT:
         """Get attribute value."""
@@ -682,10 +741,11 @@ class DatamodelService(StreamingService):
         self, rules: str, path: str, command: str, commandid: str
     ) -> None:
         """Delete command arguments."""
-        request = DataModelProtoModule.DeleteCommandArgumentsRequest(
-            rules=rules, path=path, command=command, commandid=commandid
-        )
-        self._impl.delete_command_arguments(request)
+        with self._command_arguments_lock:
+            self._command_arguments.discard(
+                self._command_arguments_key(rules, path, command, commandid)
+            )
+        self._delete_command_arguments_rpc(rules, path, command, commandid)
 
     def get_static_info(self, rules: str) -> dict[str, Any]:
         """Get static info."""
@@ -1987,10 +2047,16 @@ class PyArguments(PyStateContainer):
             )
         )
         self.path.append((command, id))
+        self.service.register_command_arguments(
+            self.rules,
+            convert_path_to_se_path(self.path[:-1]),
+            self.path[-1][0],
+            self.path[-1][1],
+        )
 
     def __del__(self) -> None:
         try:
-            self.service.delete_command_arguments(
+            self.service.release_command_arguments(
                 self.rules,
                 convert_path_to_se_path(self.path[:-1]),
                 self.path[-1][0],

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -36,6 +36,9 @@ from ansys.api.fluent.v0 import datamodel_se_pb2_grpc as DataModelGrpcModule
 from ansys.api.fluent.v0.variant_pb2 import Variant
 from ansys.fluent.core.data_model_cache import DataModelCache, NameKey
 from ansys.fluent.core.module_config import config
+from ansys.fluent.core.services._command_arguments_mixin import (
+    CommandArgumentsCleanupMixin,
+)
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
@@ -481,7 +484,7 @@ class SubscriptionList:
                 v.unsubscribe()
 
 
-class DatamodelService(StreamingService):
+class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
     """Pure Python wrapper of DatamodelServiceImpl."""
 
     def __init__(
@@ -503,56 +506,7 @@ class DatamodelService(StreamingService):
         self.file_transfer_service = file_transfer_service
         self.cache = DataModelCache() if config.datamodel_use_state_cache else None
         self.version = version
-        self._command_arguments: set[tuple[str, str, str, str]] = set()
-        self._command_arguments_lock = RLock()
-        self._shutdown_cleanup_started = False
-
-    @staticmethod
-    def _command_arguments_key(
-        rules: str, path: str, command: str, commandid: str
-    ) -> tuple[str, str, str, str]:
-        return (rules, path, command, commandid)
-
-    def register_command_arguments(
-        self, rules: str, path: str, command: str, commandid: str
-    ) -> None:
-        """Register command arguments for explicit cleanup during shutdown."""
-        with self._command_arguments_lock:
-            if self._shutdown_cleanup_started:
-                return
-            self._command_arguments.add(
-                self._command_arguments_key(rules, path, command, commandid)
-            )
-
-    def release_command_arguments(
-        self, rules: str, path: str, command: str, commandid: str
-    ) -> None:
-        """Release command arguments when their Python wrapper is deleted."""
-        key = self._command_arguments_key(rules, path, command, commandid)
-        with self._command_arguments_lock:
-            was_registered = key in self._command_arguments
-            self._command_arguments.discard(key)
-            shutdown_cleanup_started = self._shutdown_cleanup_started
-
-        if was_registered and not shutdown_cleanup_started:
-            self._delete_command_arguments_rpc(rules, path, command, commandid)
-
-    def delete_all_command_arguments(self) -> None:
-        """Delete all tracked command arguments as part of shutdown finalization."""
-        with self._command_arguments_lock:
-            self._shutdown_cleanup_started = True
-            command_arguments = list(self._command_arguments)
-            self._command_arguments.clear()
-
-        for rules, path, command, commandid in command_arguments:
-            try:
-                self._delete_command_arguments_rpc(rules, path, command, commandid)
-            except Exception as exc:
-                logger.info(
-                    "delete_all_command_arguments %s: %s",
-                    type(exc).__name__,
-                    exc,
-                )
+        self._init_command_arguments_cleanup()
 
     def _delete_command_arguments_rpc(
         self, rules: str, path: str, command: str, commandid: str
@@ -741,11 +695,7 @@ class DatamodelService(StreamingService):
         self, rules: str, path: str, command: str, commandid: str
     ) -> None:
         """Delete command arguments."""
-        with self._command_arguments_lock:
-            self._command_arguments.discard(
-                self._command_arguments_key(rules, path, command, commandid)
-            )
-        self._delete_command_arguments_rpc(rules, path, command, commandid)
+        return super().delete_command_arguments(rules, path, command, commandid)
 
     def get_static_info(self, rules: str) -> dict[str, Any]:
         """Get static info."""

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -568,7 +568,7 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
     def _delete_command_arguments_rpc(
         self, rules: str, path: str, command: str, commandid: str
     ) -> None:
-        """Perform the RPC call to delete command arguments on the Fluent side."""
+        """Issue RPC to delete command arguments."""
         request = DataModelProtoModule.DeleteCommandArgumentsRequest(
             rules=rules, path=path, command=command, command_id=commandid
         )

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -382,7 +382,6 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self.file_transfer_service = file_transfer_service
         self.cache = DataModelCache() if config.datamodel_use_state_cache else None
         self.version = version
-        self._init_command_arguments_cleanup()
 
     def get_attribute_value(self, rules: str, path: str, attribute: str) -> ValueT:
         """Get attribute value."""

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -39,6 +39,9 @@ from ansys.fluent.core.module_config import config
 from ansys.fluent.core.services import (
     datamodel_se as _v0,  # v0 base: shared logic is reused; only v1-specific proto/stub differences are overridden below
 )
+from ansys.fluent.core.services._command_arguments_mixin import (
+    CommandArgumentsCleanupMixin,
+)
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
@@ -357,7 +360,7 @@ class EventSubscription:
             self._service.subscriptions.remove(self.tag)
 
 
-class DatamodelService(StreamingService):
+class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
     """Pure Python wrapper of DatamodelServiceImpl (v1)."""
 
     def __init__(
@@ -379,6 +382,7 @@ class DatamodelService(StreamingService):
         self.file_transfer_service = file_transfer_service
         self.cache = DataModelCache() if config.datamodel_use_state_cache else None
         self.version = version
+        self._init_command_arguments_cleanup()
 
     def get_attribute_value(self, rules: str, path: str, attribute: str) -> ValueT:
         """Get attribute value."""
@@ -561,14 +565,20 @@ class DatamodelService(StreamingService):
         response = self._impl.create_command_arguments(request)
         return response.command_id
 
-    def delete_command_arguments(
+    def _delete_command_arguments_rpc(
         self, rules: str, path: str, command: str, commandid: str
     ) -> None:
-        """Delete command arguments."""
+        """Perform the RPC call to delete command arguments on the Fluent side."""
         request = DataModelProtoModule.DeleteCommandArgumentsRequest(
             rules=rules, path=path, command=command, command_id=commandid
         )
         self._impl.delete_command_arguments(request)
+
+    def delete_command_arguments(
+        self, rules: str, path: str, command: str, commandid: str
+    ) -> None:
+        """Delete command arguments."""
+        return super().delete_command_arguments(rules, path, command, commandid)
 
     def get_static_info(self, rules: str) -> dict[str, Any]:
         """Get static info."""

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -305,6 +305,9 @@ class BaseSession:
         self._fluent_connection.register_finalizer_cb(
             self._datamodel_service_se.unsubscribe_all_events
         )
+        self._fluent_connection.register_finalizer_cb(
+            self._datamodel_service_se.delete_all_command_arguments
+        )
         for obj in filter(None, (self._datamodel_events, self.transcript, self.events)):
             self._fluent_connection.register_finalizer_cb(obj.stop)
 

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -32,6 +32,9 @@ from ansys.api.fluent.v0 import datamodel_se_pb2
 from ansys.api.fluent.v0.variant_pb2 import Variant
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import examples
+from ansys.fluent.core.services._command_arguments_mixin import (
+    CommandArgumentsCleanupMixin,
+)
 from ansys.fluent.core.services.datamodel_se import (
     PyArguments,
     PyArgumentsSingletonSubItem,
@@ -95,11 +98,37 @@ def test_pyarguments_registers_and_releases_command_arguments():
         ("workflow", "", "ImportGeometry", "cmd-id"),
     ]
 
-    arguments.__del__()
+    del arguments
+    gc.collect()
 
     assert service.released == [
         ("workflow", "", "ImportGeometry", "cmd-id"),
     ]
+
+
+def test_command_arguments_cleanup_mixin_deletes_and_stops_tracking():
+    class DummyService(CommandArgumentsCleanupMixin):
+        def __init__(self):
+            self.deleted = []
+            self._init_command_arguments_cleanup()
+
+        def _delete_command_arguments_rpc(self, rules, path, command, commandid):
+            self.deleted.append((rules, path, command, commandid))
+
+    service = DummyService()
+    key = ("workflow", "", "ImportGeometry", "cmd-id")
+
+    service.register_command_arguments(*key)
+    service.delete_command_arguments(*key)
+
+    assert service.deleted == [key]
+    assert service._command_arguments == set()
+
+    service.register_command_arguments(*key)
+    service.delete_all_command_arguments()
+    service.release_command_arguments(*key)
+
+    assert service.deleted == [key, key]
 
 
 @pytest.mark.fluent_version(">=23.2")

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -76,6 +76,32 @@ def test_convert_value_to_variant_to_value(value, expected):
     assert expected == _convert_variant_to_value(variant)
 
 
+def test_pyarguments_registers_and_releases_command_arguments():
+    class DummyService:
+        def __init__(self):
+            self.registered = []
+            self.released = []
+
+        def register_command_arguments(self, rules, path, command, commandid):
+            self.registered.append((rules, path, command, commandid))
+
+        def release_command_arguments(self, rules, path, command, commandid):
+            self.released.append((rules, path, command, commandid))
+
+    service = DummyService()
+    arguments = PyArguments(service, "workflow", "ImportGeometry", [], "cmd-id")
+
+    assert service.registered == [
+        ("workflow", "", "ImportGeometry", "cmd-id"),
+    ]
+
+    arguments.__del__()
+
+    assert service.released == [
+        ("workflow", "", "ImportGeometry", "cmd-id"),
+    ]
+
+
 @pytest.mark.fluent_version(">=23.2")
 @pytest.mark.codegen_required
 def test_event_subscription(new_meshing_session):

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -109,8 +109,8 @@ def test_pyarguments_registers_and_releases_command_arguments():
 def test_command_arguments_cleanup_mixin_deletes_and_stops_tracking():
     class DummyService(CommandArgumentsCleanupMixin):
         def __init__(self):
+            super().__init__()
             self.deleted = []
-            self._init_command_arguments_cleanup()
 
         def _delete_command_arguments_rpc(self, rules, path, command, commandid):
             self.deleted.append((rules, path, command, commandid))


### PR DESCRIPTION
## Context
Some rpcs are executed during garbage-collection of command argument instances which is problematic during session-shutdown if those rpcs are executed during/after service/channel teardown.

## Change Summary
There is a finalizer mechanism within pyfluent sessions where remote cleanup code can be executed before the service/channel teardown during session-shutdown. The deletion rpcs for all live command argument instances are executed within a finalizer callback. This ensures that those rpcs are executed before the service/channel teardown.

## Rationale
This fixes the teardown order of command arguments and service/channel.

## Impact
This is one possible cause of the random test failure on github as found in the logs. The github run on the current branch looks stable.
