### PR TITLE
chore: Properly handle typos or errors in naming tasks.

### DIFF
--- a/doc/changelog.d/5135.maintenance.md
+++ b/doc/changelog.d/5135.maintenance.md
@@ -1,0 +1,1 @@
+Properly handle typos or errors in naming tasks.

--- a/src/ansys/fluent/core/workflow_new.py
+++ b/src/ansys/fluent/core/workflow_new.py
@@ -46,6 +46,7 @@ simulation workflows, with automatic dependency management and validation.
 from __future__ import annotations
 
 from collections import OrderedDict
+import difflib
 from functools import wraps
 import inspect
 import re
@@ -635,7 +636,16 @@ class Workflow:
             return make_task_wrapper(
                 self._task_dict[item], item, self._workflow, self, self._command_source
             )
-        return getattr(self._workflow, item)
+        try:
+            return getattr(self._workflow, item)
+        except AttributeError:
+            msg = f"'{type(self._workflow).__name__}' object has no attribute '{item}'"
+            close_matches = difflib.get_close_matches(
+                item, self._task_dict.keys(), n=3, cutoff=0.6
+            )
+            if close_matches:
+                msg += f". Did you mean: {', '.join(repr(m) for m in close_matches)}?"
+            raise AttributeError(msg)
 
     def __call__(self):
         """Get workflow state when called as a function."""

--- a/src/ansys/fluent/core/workflow_new.py
+++ b/src/ansys/fluent/core/workflow_new.py
@@ -46,13 +46,13 @@ simulation workflows, with automatic dependency management and validation.
 from __future__ import annotations
 
 from collections import OrderedDict
-import difflib
 from functools import wraps
 import inspect
 import re
 from typing import ValuesView
 
 from ansys.fluent.core.services.datamodel_se import PyMenu
+from ansys.fluent.core.solver.error_message import allowed_name_error_message
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 
@@ -638,14 +638,14 @@ class Workflow:
             )
         try:
             return getattr(self._workflow, item)
-        except AttributeError:
-            msg = f"'{type(self._workflow).__name__}' object has no attribute '{item}'"
-            close_matches = difflib.get_close_matches(
-                item, self._task_dict.keys(), n=3, cutoff=0.6
-            )
-            if close_matches:
-                msg += f". Did you mean: {', '.join(repr(m) for m in close_matches)}?"
-            raise AttributeError(msg)
+        except AttributeError as ex:
+            raise AttributeError(
+                allowed_name_error_message(
+                    allowed_values=list(self._task_dict.keys()),
+                    context=type(self).__name__,
+                    trial_name=item,
+                )
+            ) from ex
 
     def __call__(self):
         """Get workflow state when called as a function."""

--- a/tests/test_server_meshing_workflow.py
+++ b/tests/test_server_meshing_workflow.py
@@ -2064,3 +2064,26 @@ def test_rename(new_meshing_session):
     with pytest.raises(LookupError):
         watertight.import_geometry["Import Geometry"]
     assert watertight.import_geometry["IG"]
+
+
+@pytest.mark.fluent_version(">=27.1")
+def test_workflow_getattr_suggests_close_match(new_meshing_session):
+    """AttributeError for a near-miss name should list the closest task name."""
+    meshing = new_meshing_session
+    watertight = meshing.watertight()
+    with pytest.raises(AttributeError) as exc_info:
+        _ = watertight.add_local_sizing  # typo — correct name is add_local_sizing_wtm
+
+    assert "add_local_sizing_wtm" in str(exc_info.value)
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = watertight.create  # wrong — correct name is create_regions
+
+    assert "create_regions" in str(exc_info.value)
+
+    with pytest.raises(AttributeError) as exc_info:
+        _ = (
+            watertight.create_volume_mesh
+        )  # typo — correct name is create_volume_mesh_wtm
+
+    assert "create_volume_mesh_wtm" in str(exc_info.value)


### PR DESCRIPTION
## Context
Some python names for tasks have changed in the updated `meshing_workflow` and some users might still use the earlier names which will correctly raise AttributeError but does not suggest closest matching names.

For example:
```python
>>> watertight.add_local_sizing

Traceback (most recent call last):
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 640, in __getattr__
    return getattr(self._workflow, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Root' object has no attribute 'add_local_sizing'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 648, in __getattr__
    raise AttributeError(msg)
AttributeError: 'Root' object has no attribute 'add_local_sizing'.
```

## Change Summary
Implemented `difflib.get_close_matches` with the task_names as database and the tolerance values to default.

Updated behavior:
```python
>>> watertight.add_local_sizing

Traceback (most recent call last):
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 640, in __getattr__
    return getattr(self._workflow, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Root' object has no attribute 'add_local_sizing'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 642, in __getattr__
    raise AttributeError(
AttributeError: 'WatertightMeshingWorkflow' has no attribute 'add_local_sizing'.
The most similar names are: add_local_sizing_wtm
```

```python
>>> watertight.create

Traceback (most recent call last):
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 640, in __getattr__
    return getattr(self._workflow, item)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Root' object has no attribute 'create'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "D:\PyFluent_Dev\pyfluent\src\ansys\fluent\core\workflow_new.py", line 642, in __getattr__
    raise AttributeError(
AttributeError: 'WatertightMeshingWorkflow' has no attribute 'create'.
The most similar names are: create_regions
```

## Impact
Users to get proper suggestions in case of Attribute errors. 

Fluent: 1457440
