### PR TITLE
fix: Behavior issues with command/query objects in flobject.py

### DIFF
--- a/doc/changelog.d/5140.fixed.md
+++ b/doc/changelog.d/5140.fixed.md
@@ -1,0 +1,1 @@
+Behavior issues with command/query objects in flobject.py

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1885,17 +1885,15 @@ class Action(Base):
                 ) from None
 
     def __setattr__(self, name: str, value):
-        if name in self.argument_names or name in self._child_aliases:
-            attr = getattr(self, name)
-            try:
-                return attr.set_state(value)
-            except Exception as ex:
-                if hasattr(attr, "allowed_values"):
-                    allowed = attr.allowed_values()
-                    if allowed and value not in allowed:
-                        raise allowed_values_error(name, value, allowed) from ex
-                raise
-        raise AttributeError(name)
+        attr = getattr(self, name)
+        try:
+            return attr.set_state(value)
+        except Exception as ex:
+            if hasattr(attr, "allowed_values"):
+                allowed = attr.allowed_values()
+                if allowed and value not in allowed:
+                    raise allowed_values_error(name, value, allowed) from ex
+            raise
 
 
 class BaseCommand(Action):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1877,7 +1877,25 @@ class Action(Base):
                 )
             return alias_obj
         else:
-            return getattr(super(), name)
+            try:
+                return getattr(super(), name)
+            except AttributeError:
+                raise AttributeError(
+                    f"'{self.python_path}' is a command/query object and has no attribute '{name}'"
+                ) from None
+
+    def __setattr__(self, name: str, value):
+        if name in self.argument_names or name in self._child_aliases:
+            attr = getattr(self, name)
+            try:
+                return attr.set_state(value)
+            except Exception as ex:
+                if hasattr(attr, "allowed_values"):
+                    allowed = attr.allowed_values()
+                    if allowed and value not in allowed:
+                        raise allowed_values_error(name, value, allowed) from ex
+                raise
+        raise AttributeError(name)
 
 
 class BaseCommand(Action):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -428,14 +428,20 @@ class Base:
         return ppath + "." + self.python_name
 
     def get_attrs(self, attrs, recursive=False) -> Any:
-        """Get the requested attributes for the object."""
-        if recursive and isinstance(self, Action):
-            warnings.warn(
-                f"Recursive attribute queries are not supported for command/query "
-                f"objects. Ignoring recursive=True for '{self.python_path}'.",
-                PyFluentUserWarning,
-            )
-            recursive = False
+        """Get the requested attributes for the object.
+
+        Parameters
+        ----------
+        attrs : list
+            List of attribute names to retrieve.
+        recursive : bool, optional
+            Whether to retrieve attributes recursively, by default False.
+
+        Returns
+        -------
+        Any
+            Requested attributes.
+        """
         return self.flproxy.get_attrs(self.path, attrs, recursive)
 
     def get_attr(
@@ -1894,6 +1900,32 @@ class Action(Base):
                 if allowed and value not in allowed:
                     raise allowed_values_error(name, value, allowed) from ex
             raise
+
+    def get_attrs(self, attrs, recursive=False) -> Any:
+        """Get the requested attributes for the object.
+
+        Parameters
+        ----------
+        attrs : list
+            List of attribute names to retrieve.
+        recursive : bool, optional
+            Whether to retrieve attributes recursively. Recursive queries are
+            not supported for command/query objects; if ``True`` is passed it
+            is ignored and a warning is issued, by default False.
+
+        Returns
+        -------
+        Any
+            Requested attributes.
+        """
+        if recursive:
+            warnings.warn(
+                f"Recursive attribute queries are not supported for command/query "
+                f"objects. Ignoring recursive=True for '{self.python_path}'.",
+                PyFluentUserWarning,
+            )
+            recursive = False
+        return self.flproxy.get_attrs(self.path, attrs, recursive)
 
 
 class BaseCommand(Action):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -429,6 +429,13 @@ class Base:
 
     def get_attrs(self, attrs, recursive=False) -> Any:
         """Get the requested attributes for the object."""
+        if recursive and isinstance(self, Action):
+            warnings.warn(
+                f"Recursive attribute queries are not supported for command/query "
+                f"objects. Ignoring recursive=True for '{self.python_path}'.",
+                PyFluentUserWarning,
+            )
+            recursive = False
         return self.flproxy.get_attrs(self.path, attrs, recursive)
 
     def get_attr(

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -903,3 +903,19 @@ def test_read_only_command_execution(mixing_elbow_case_session):
     assert contour.display.is_read_only() is True
     with pytest.raises(ReadOnlyActionError):
         contour.display()
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_action_behavior(mixing_elbow_case_session):
+    solver = mixing_elbow_case_session
+    with pytest.raises(AttributeError, match="command/query object"):
+        solver.settings.solution.run_calculation.iterate.get_state()
+    assert isinstance(
+        solver.settings.solution.run_calculation.iterate.iter_count(), int
+    )
+    solver.settings.solution.run_calculation.iterate.iter_count = 55
+    assert solver.settings.solution.run_calculation.iterate.iter_count() == 55
+    with pytest.warns(PyFluentUserWarning, match="command/query object"):
+        solver.settings.solution.run_calculation.iterate.get_attrs(
+            ["active?"], recursive=True
+        )


### PR DESCRIPTION
## Context
There were some issues like:
1. Calling get_state over command/query objects used to give error messages that does not make much sense.
2. Setting values to command/query object's arguments via `=` was not permitted.
3. get_attrs(['active?'], recursive=True) does not work for command/query objects but it was not handled properly.

## Change Summary
1. 
```python
>>> solver.settings.solution.run_calculation.iterate.get_state()
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "...\pyfluent\src\ansys\fluent\core\solver\flobject.py", line 1883, in __getattr__
    raise AttributeError(
AttributeError: '<session>.settings.solution.run_calculation.iterate' is a command/query object and has no attribute 'get_state'. Did you mean: 'get_attr'?
```
2.
```python

>>> solver.settings.solution.run_calculation.iterate.iter_count()
50
>>> solver.settings.solution.run_calculation.iterate.iter_count=60
>>> solver.settings.solution.run_calculation.iterate.iter_count()
60
```
3.
```python

>>> solver.settings.solution.run_calculation.iterate.get_attrs(['active?'], recursive=True)
...\pyfluent\src\ansys\fluent\core\solver\flobject.py:433: PyFluentUserWarning: Recursive attribute queries are not supported for command/query objects. Ignoring recursive=True for '<session>.settings.solution.run_calculation.iterate'.
  warnings.warn(
{'active?': True}
```

## Impact
Users to be able to use command/query objects seamlessly.
