### PR TITLE
chore: flush stale workflow subscriptions before workflow-mutating commands.

### DIFF
--- a/doc/changelog.d/5144.maintenance.md
+++ b/doc/changelog.d/5144.maintenance.md
@@ -1,0 +1,1 @@
+Flush stale workflow subscriptions before workflow-mutating commands.

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -483,6 +483,39 @@ class SubscriptionList:
                 v = next(reversed(self._subscriptions.values()))
                 v.unsubscribe()
 
+    _WORKFLOW_RESET_COMMANDS: frozenset[str] = frozenset(
+        {
+            # legacy "workflow" rules (CamelCase)
+            "InitializeWorkflow",
+            "LoadWorkflow",
+            "CreateNewWorkflow",
+            "ResetWorkflow",
+            "DeleteTasks",
+            "LoadState",
+            # v1 "meshing_workflow" rules (snake_case)
+            "initialize_workflow",
+            "load_workflow",
+            "create_new_workflow",
+            "reset_workflow",
+            "delete_tasks",
+            "load_state",
+        }
+    )
+    _WORKFLOW_RULES: tuple[str, ...] = ("workflow", "meshing_workflow")
+
+    def unsubscribe_for_command(self, command: str) -> None:
+        """Flush client subscriptions affected by a workflow-mutating command.
+
+        If ``command`` is one of the known workflow-resetting commands, all
+        subscription objects on workflow rules are unsubscribed so that
+        stale on-changed/on-deleted observers do not fire against freed paths.
+        """
+        if command not in self._WORKFLOW_RESET_COMMANDS:
+            return
+        for rules in self._WORKFLOW_RULES:
+            for stage in ("before", "after"):
+                self.unsubscribe_while_deleting(rules, "", stage)
+
 
 class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
     """Pure Python wrapper of DatamodelServiceImpl."""
@@ -657,6 +690,7 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self, rules: str, path: str, command: str, args: dict[str, ValueT]
     ) -> ValueT:
         """Execute the command."""
+        self.subscriptions.unsubscribe_for_command(command)
         request = DataModelProtoModule.ExecuteCommandRequest(
             rules=rules, path=path, command=command, wait=True
         )

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -465,12 +465,15 @@ class SubscriptionList:
             unsubscribed after the datamodel object is deleted.
         """
         with self._lock:
+            rules_prefix = f"/{rules}/"
             delete_tag = f"/{rules}/deleted"
             after = deletion_stage == "after"
             keys_to_unsubscribe = []
             for k, v in self._subscriptions.items():
-                if v.path.startswith(path) and not (
-                    after ^ v.tag.startswith(delete_tag)
+                if (
+                    v.tag.startswith(rules_prefix)
+                    and v.path.startswith(path)
+                    and not (after ^ v.tag.startswith(delete_tag))
                 ):
                     keys_to_unsubscribe.append(k)
             for k in reversed(keys_to_unsubscribe):
@@ -501,20 +504,34 @@ class SubscriptionList:
             "load_state",
         }
     )
-    _WORKFLOW_RULES: tuple[str, ...] = ("workflow", "meshing_workflow")
 
-    def unsubscribe_for_command(self, command: str) -> None:
+    _WORKFLOW_TASK_PATH_PREFIXES: dict[str, str] = {
+        "workflow": "/TaskObject:",  # legacy CamelCase rules
+        "meshing_workflow": "/task_object:",  # v1 snake_case rules
+    }
+
+    def unsubscribe_for_command(self, command: str, stage: str) -> None:
         """Flush client subscriptions affected by a workflow-mutating command.
 
-        If ``command`` is one of the known workflow-resetting commands, all
-        subscription objects on workflow rules are unsubscribed so that
-        stale on-changed/on-deleted observers do not fire against freed paths.
+        If ``command`` is one of the known workflow-resetting commands,
+        subscriptions on the TaskObject subtree of both workflow rules
+        namespaces are unsubscribed so that stale on-changed/on-deleted
+        observers do not fire against freed paths.
+
+        Parameters
+        ----------
+        command : str
+            Command name.
+        stage : {"before", "after"}
+            Pass ``"before"`` prior to dispatch so non-deleted observers are
+            dropped before the server mutates state.  Pass ``"after"`` (in a
+            ``finally`` block) to clean up on-deleted observers once the
+            server-side deletion is complete.
         """
         if command not in self._WORKFLOW_RESET_COMMANDS:
             return
-        for rules in self._WORKFLOW_RULES:
-            for stage in ("before", "after"):
-                self.unsubscribe_while_deleting(rules, "", stage)
+        for rules, path_prefix in self._WORKFLOW_TASK_PATH_PREFIXES.items():
+            self.unsubscribe_while_deleting(rules, path_prefix, stage)
 
 
 class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
@@ -690,20 +707,23 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self, rules: str, path: str, command: str, args: dict[str, ValueT]
     ) -> ValueT:
         """Execute the command."""
-        self.subscriptions.unsubscribe_for_command(command)
+        self.subscriptions.unsubscribe_for_command(command, "before")
         request = DataModelProtoModule.ExecuteCommandRequest(
             rules=rules, path=path, command=command, wait=True
         )
         _convert_value_to_variant(args, request.args)
-        response = self._impl.execute_command(request)
-        if self.cache is not None:
-            self.cache.update_cache(
-                rules,
-                response.state,
-                response.deletedpaths,
-                version=self.version,
-            )
-        return _convert_variant_to_value(response.result)
+        try:
+            response = self._impl.execute_command(request)
+            if self.cache is not None:
+                self.cache.update_cache(
+                    rules,
+                    response.state,
+                    response.deletedpaths,
+                    version=self.version,
+                )
+            return _convert_variant_to_value(response.result)
+        finally:
+            self.subscriptions.unsubscribe_for_command(command, "after")
 
     def execute_query(
         self, rules: str, path: str, query: str, args: dict[str, ValueT]

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -531,6 +531,7 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self, rules: str, path: str, command: str, args: dict[str, ValueT]
     ) -> ValueT:
         """Execute the command."""
+        self.subscriptions.unsubscribe_for_command(command)
         request = DataModelProtoModule.ExecuteCommandRequest(
             rules=rules, path=path, command=command, wait=True
         )

--- a/src/ansys/fluent/core/services/datamodel_se_v1.py
+++ b/src/ansys/fluent/core/services/datamodel_se_v1.py
@@ -531,20 +531,23 @@ class DatamodelService(CommandArgumentsCleanupMixin, StreamingService):
         self, rules: str, path: str, command: str, args: dict[str, ValueT]
     ) -> ValueT:
         """Execute the command."""
-        self.subscriptions.unsubscribe_for_command(command)
+        self.subscriptions.unsubscribe_for_command(command, "before")
         request = DataModelProtoModule.ExecuteCommandRequest(
             rules=rules, path=path, command=command, wait=True
         )
         _convert_value_to_variant(args, request.args)
-        response = self._impl.execute_command(request)
-        if self.cache is not None:
-            self.cache.update_cache(
-                rules,
-                response.state,
-                response.deleted_paths,
-                version=self.version,
-            )
-        return _convert_variant_to_value(response.result)
+        try:
+            response = self._impl.execute_command(request)
+            if self.cache is not None:
+                self.cache.update_cache(
+                    rules,
+                    response.state,
+                    response.deleted_paths,
+                    version=self.version,
+                )
+            return _convert_variant_to_value(response.result)
+        finally:
+            self.subscriptions.unsubscribe_for_command(command, "after")
 
     def execute_query(
         self, rules: str, path: str, query: str, args: dict[str, ValueT]


### PR DESCRIPTION
## Context

When a meshing workflow is re-initialized, loaded, or tasks are deleted, Fluent's Cortex server destroys the existing TaskObject tree server-side (deleteUnusedTaskObjects inside S_InitializeWorkflow, S_LoadWorkflow, etc.). 

On the PyFluent client, PyStateContainer._get_cached_attr had previously registered add_on_attribute_changed event subscriptions on those paths (e.g. /TaskObject:Import Geometry/Arguments, /TaskObject:Import Geometry/CommandName, …). 
These subscriptions remained alive on the client after the objects were freed on the server. When they later fired, Cortex tried to resolve paths that no longer exists.

**Root cause**

Client-side event subscriptions were not being cleaned up before workflow-mutating server commands. The cleanup that existed (in PyMenu.delete_child_objects / delete_all_child_objects / PyNamedObjectContainer._del_item) only covered explicit Python-level object deletions, not the implicit server-side tree destruction triggered by InitializeWorkflow, LoadWorkflow, CreateNewWorkflow, ResetWorkflow, DeleteTasks, and LoadState.

## Change Summary

Added SubscriptionList.unsubscribe_for_command(command) — the single point of truth for this cleanup.

_WORKFLOW_RESET_COMMANDS covers both legacy CamelCase (InitializeWorkflow, LoadWorkflow, CreateNewWorkflow, ResetWorkflow, DeleteTasks, LoadState) and snake_case variants.

WORKFLOW_RULES = ("workflow", "meshing_workflow")).

Flushes all subscriptions on those rules (both "before" and "after" stages) using the existing unsubscribe_while_deleting primitive with an empty path (match-all sentinel).

DatamodelService.execute_command gains a single line before the gRPC dispatch:

## Rationale

The hook sits at DatamodelService.execute_command, which is the single dispatch point for every datamodel command regardless of caller (high-level Workflow wrapper, raw meshing_workflow.general.initialize_workflow(...), or any future API).

## Impact
Users will not land into issues while re-initializing workflows or deleting them.
