### PR TITLE
chore: Revert temporary fix for blocking get_attrs for Action items.

### DIFF
--- a/doc/changelog.d/5149.maintenance.md
+++ b/doc/changelog.d/5149.maintenance.md
@@ -1,0 +1,1 @@
+Revert temporary fix for blocking get_attrs for Action items.

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1949,32 +1949,6 @@ class Action(Base):
                     raise allowed_values_error(name, value, allowed) from ex
             raise
 
-    def get_attrs(self, attrs, recursive=False) -> Any:
-        """Get the requested attributes for the object.
-
-        Parameters
-        ----------
-        attrs : list
-            List of attribute names to retrieve.
-        recursive : bool, optional
-            Whether to retrieve attributes recursively. Recursive queries are
-            not supported for command/query objects; if ``True`` is passed it
-            is ignored and a warning is issued, by default False.
-
-        Returns
-        -------
-        Any
-            Requested attributes.
-        """
-        if recursive:
-            warnings.warn(
-                f"Recursive attribute queries are not supported for command/query "
-                f"objects. Ignoring recursive=True for '{self.python_path}'.",
-                PyFluentUserWarning,
-            )
-            recursive = False
-        return self.flproxy.get_attrs(self.path, attrs, recursive)
-
 
 class BaseCommand(Action):
     """Executes command."""

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -906,7 +906,7 @@ def test_action_behavior(mixing_elbow_case_session):
     )
     solver.settings.solution.run_calculation.iterate.iter_count = 55
     assert solver.settings.solution.run_calculation.iterate.iter_count() == 55
-    with pytest.warns(PyFluentUserWarning, match="command/query object"):
-        solver.settings.solution.run_calculation.iterate.get_attrs(
-            ["active?"], recursive=True
-        )
+    result = solver.settings.solution.run_calculation.iterate.get_attrs(
+        ["active?"], recursive=True
+    )
+    assert "iter-count" in result["group_children"]


### PR DESCRIPTION
## Context
Earlier recursive = True was being blocked for Action (command and query) items. Ideal scenario is that recursive=True on action items like commands should list the command arguments attributes.

## Change Summary
The ideal scenario is working.

```python
pprint.pprint(
solver.settings.solution.run_calculation.iterate.get_attrs(["active?"], recursive=True))
{'attrs': {'active?': True},
 'group_children': {'iter-count': {'attrs': {'active?': True}}}}
```

## Rationale
The server side was behaving correctly, only there were some issues with some commands like:
```python
solver_session.settings.results.report.forces.get_attrs(['active?'], recursive=True)
```

There are a few of them that are being corrected at the server level.

## Impact
Users to get the expected behavior that they were getting earlier.
