### PR TITLE
test: Parameter workspace in settings

### DIFF
--- a/doc/changelog.d/5150.test.md
+++ b/doc/changelog.d/5150.test.md
@@ -1,0 +1,1 @@
+Parameter workspace in settings

--- a/src/ansys/fluent/core/solver/settings_builtin_data.py
+++ b/src/ansys/fluent/core/solver/settings_builtin_data.py
@@ -529,7 +529,12 @@ DATA = {
             until(FluentVersion.v271): "parametric_studies.design_points",
         },
     ),
-    "ParameterWorkspace": ("Singleton", "parameter_workspace"),
+    "ParameterWorkspace": (
+        "Singleton",
+        {
+            since(FluentVersion.v271): "parameter_workspace",
+        },
+    ),
     "ReadCase": ("Command", "file.read_case"),
     "ReadData": ("Command", "file.read_data"),
     "ReadCaseData": ("Command", "file.read_case_data"),

--- a/src/ansys/fluent/core/solver/settings_builtin_data.py
+++ b/src/ansys/fluent/core/solver/settings_builtin_data.py
@@ -22,7 +22,7 @@
 
 """Data for for builtin setting classes."""
 
-from ansys.fluent.core.utils.fluent_version import FluentVersion, since
+from ansys.fluent.core.utils.fluent_version import FluentVersion, since, until
 
 # {<class name>: (<kind>, <path>)}
 DATA = {
@@ -457,11 +457,21 @@ DATA = {
     ),
     "InputParameters": (
         "Singleton",
-        "parameters.input_parameters",
+        {
+            since(
+                FluentVersion.v271
+            ): "parameter_workspace.parameters.input_parameters",
+            until(FluentVersion.v271): "parameters.input_parameters",
+        },
     ),
     "OutputParameters": (
         "Singleton",
-        "parameters.output_parameters",
+        {
+            since(
+                FluentVersion.v271
+            ): "parameter_workspace.parameters.output_parameters",
+            until(FluentVersion.v271): "parameters.output_parameters",
+        },
     ),
     "CustomFieldFunctions": (
         "Singleton",
@@ -487,10 +497,39 @@ DATA = {
         "Singleton",
         "results.report.simulation_reports",
     ),
-    "ParametricStudies": ("Singleton", "parametric_studies"),
-    "ParametricStudy": ("NamedObject", "parametric_studies"),
-    "DesignPoints": ("Singleton", "parametric_studies.design_points"),
-    "DesignPoint": ("NamedObject", "parametric_studies.design_points"),
+    "ParametricStudies": (
+        "Singleton",
+        {
+            since(FluentVersion.v271): "parameter_workspace.parametric_studies",
+            until(FluentVersion.v271): "parametric_studies",
+        },
+    ),
+    "ParametricStudy": (
+        "NamedObject",
+        {
+            since(FluentVersion.v271): "parameter_workspace.parametric_studies",
+            until(FluentVersion.v271): "parametric_studies",
+        },
+    ),
+    "DesignPoints": (
+        "Singleton",
+        {
+            since(
+                FluentVersion.v271
+            ): "parameter_workspace.parametric_studies.design_points",
+            until(FluentVersion.v271): "parametric_studies.design_points",
+        },
+    ),
+    "DesignPoint": (
+        "NamedObject",
+        {
+            since(
+                FluentVersion.v271
+            ): "parameter_workspace.parametric_studies.design_points",
+            until(FluentVersion.v271): "parametric_studies.design_points",
+        },
+    ),
+    "ParameterWorkspace": ("Singleton", "parameter_workspace"),
     "ReadCase": ("Command", "file.read_case"),
     "ReadData": ("Command", "file.read_data"),
     "ReadCaseData": ("Command", "file.read_case_data"),

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -291,14 +291,14 @@ def test_parameters_list_function(static_mixer_settings_session):
     unitless_quantity.output_parameter = True
     fluent_version = solver.get_fluent_version()
     input_parameters_list = (
-        solver.parameter_workspace.parameters.input_parameters.list()
+        solver.settings.parameter_workspace.parameters.input_parameters.list()
         if fluent_version >= FluentVersion.v271
-        else solver.parameters.input_parameters.list()
+        else solver.settings.parameters.input_parameters.list()
     )
     output_parameters_list = (
-        solver.parameter_workspace.parameters.output_parameters.list()
+        solver.settings.parameter_workspace.parameters.output_parameters.list()
         if fluent_version >= FluentVersion.v271
-        else solver.parameters.output_parameters.list()
+        else solver.settings.parameters.output_parameters.list()
     )
     if fluent_version >= FluentVersion.v261:
         assert input_parameters_list == {

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -289,14 +289,17 @@ def test_parameters_list_function(static_mixer_settings_session):
     unitless_quantity.field = "temperature"
     unitless_quantity.surface_names = ["outlet"]
     unitless_quantity.output_parameter = True
-
+    fluent_version = solver.get_fluent_version()
     input_parameters_list = (
         solver.parameter_workspace.parameters.input_parameters.list()
+        if fluent_version >= FluentVersion.v271
+        else solver.parameters.input_parameters.list()
     )
     output_parameters_list = (
         solver.parameter_workspace.parameters.output_parameters.list()
+        if fluent_version >= FluentVersion.v271
+        else solver.parameters.output_parameters.list()
     )
-    fluent_version = solver.get_fluent_version()
     if fluent_version >= FluentVersion.v261:
         assert input_parameters_list == {
             "inlet1_temp": [

--- a/tests/parametric/test_parametric_workflow.py
+++ b/tests/parametric/test_parametric_workflow.py
@@ -290,8 +290,12 @@ def test_parameters_list_function(static_mixer_settings_session):
     unitless_quantity.surface_names = ["outlet"]
     unitless_quantity.output_parameter = True
 
-    input_parameters_list = solver.parameters.input_parameters.list()
-    output_parameters_list = solver.parameters.output_parameters.list()
+    input_parameters_list = (
+        solver.parameter_workspace.parameters.input_parameters.list()
+    )
+    output_parameters_list = (
+        solver.parameter_workspace.parameters.output_parameters.list()
+    )
     fluent_version = solver.get_fluent_version()
     if fluent_version >= FluentVersion.v261:
         assert input_parameters_list == {

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -315,14 +315,24 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         SimulationReports(settings_source=solver)
         == solver.results.report.simulation_reports
     )
-    assert (
-        InputParameters(settings_source=solver)
-        == solver.parameter_workspace.parameters.input_parameters
-    )
-    assert (
-        OutputParameters(settings_source=solver)
-        == solver.parameter_workspace.parameters.output_parameters
-    )
+    if solver.get_fluent_version() >= FluentVersion.v271:
+        assert (
+            InputParameters(settings_source=solver)
+            == solver.parameter_workspace.parameters.input_parameters
+        )
+        assert (
+            OutputParameters(settings_source=solver)
+            == solver.parameter_workspace.parameters.output_parameters
+        )
+    else:
+        assert (
+            InputParameters(settings_source=solver)
+            == solver.parameters.input_parameters
+        )
+        assert (
+            OutputParameters(settings_source=solver)
+            == solver.parameters.output_parameters
+        )
     if fluent_version >= FluentVersion.v251:
         assert (
             CustomFieldFunctions(settings_source=solver)

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -315,23 +315,24 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         SimulationReports(settings_source=solver)
         == solver.results.report.simulation_reports
     )
-    parameter_container = None
-    if hasattr(solver, "parameter_workspace") and hasattr(
-        solver.parameter_workspace, "parameters"
-    ):
-        parameter_container = solver.parameter_workspace.parameters
-    elif hasattr(solver, "parameters"):
-        parameter_container = solver.parameters
-
-    assert parameter_container is not None
-    assert (
-        InputParameters(settings_source=solver)
-        == parameter_container.input_parameters
-    )
-    assert (
-        OutputParameters(settings_source=solver)
-        == parameter_container.output_parameters
-    )
+    if fluent_version >= FluentVersion.v271:
+        assert (
+            InputParameters(settings_source=solver)
+            == solver.parameter_workspace.parameters.input_parameters
+        )
+        assert (
+            OutputParameters(settings_source=solver)
+            == solver.parameter_workspace.parameters.output_parameters
+        )
+    else:
+        assert (
+            InputParameters(settings_source=solver)
+            == solver.parameters.input_parameters
+        )
+        assert (
+            OutputParameters(settings_source=solver)
+            == solver.parameters.output_parameters
+        )
     if fluent_version >= FluentVersion.v251:
         assert (
             CustomFieldFunctions(settings_source=solver)

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -315,24 +315,23 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         SimulationReports(settings_source=solver)
         == solver.results.report.simulation_reports
     )
-    if fluent_version >= FluentVersion.v271:
-        assert (
-            InputParameters(settings_source=solver)
-            == solver.parameter_workspace.parameters.input_parameters
-        )
-        assert (
-            OutputParameters(settings_source=solver)
-            == solver.parameter_workspace.parameters.output_parameters
-        )
-    else:
-        assert (
-            InputParameters(settings_source=solver)
-            == solver.parameters.input_parameters
-        )
-        assert (
-            OutputParameters(settings_source=solver)
-            == solver.parameters.output_parameters
-        )
+    parameter_container = None
+    if hasattr(solver, "parameter_workspace") and hasattr(
+        solver.parameter_workspace, "parameters"
+    ):
+        parameter_container = solver.parameter_workspace.parameters
+    elif hasattr(solver, "parameters"):
+        parameter_container = solver.parameters
+
+    assert parameter_container is not None
+    assert (
+        InputParameters(settings_source=solver)
+        == parameter_container.input_parameters
+    )
+    assert (
+        OutputParameters(settings_source=solver)
+        == parameter_container.output_parameters
+    )
     if fluent_version >= FluentVersion.v251:
         assert (
             CustomFieldFunctions(settings_source=solver)

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -317,12 +317,16 @@ def test_builtin_settings(mixing_elbow_case_data_session):
     )
     if fluent_version >= FluentVersion.v271:
         assert (
+            ParameterWorkspace(settings_source=solver)
+            == solver.settings.parameter_workspace
+        )
+        assert (
             InputParameters(settings_source=solver)
-            == solver.parameter_workspace.parameters.input_parameters
+            == solver.settings.parameter_workspace.parameters.input_parameters
         )
         assert (
             OutputParameters(settings_source=solver)
-            == solver.parameter_workspace.parameters.output_parameters
+            == solver.settings.parameter_workspace.parameters.output_parameters
         )
     else:
         assert (
@@ -345,23 +349,57 @@ def test_builtin_settings(mixing_elbow_case_data_session):
     solver.settings.parametric_studies.initialize(
         project_filename="mixing_elbow_param.flprj"
     )
-    assert ParametricStudies(settings_source=solver) == solver.parametric_studies
-    assert (
-        ParametricStudy(settings_source=solver, name="mixing_elbow-Solve")
-        == solver.parametric_studies["mixing_elbow-Solve"]
-    )
-    assert (
-        DesignPoints(settings_source=solver, parametric_studies="mixing_elbow-Solve")
-        == solver.parametric_studies["mixing_elbow-Solve"].design_points
-    )
-    assert (
-        DesignPoint(
-            settings_source=solver,
-            parametric_studies="mixing_elbow-Solve",
-            name="Base DP",
+    if fluent_version >= FluentVersion.v271:
+        assert (
+            ParametricStudies(settings_source=solver)
+            == solver.settings.parameter_workspace.parametric_studies
         )
-        == solver.parametric_studies["mixing_elbow-Solve"].design_points["Base DP"]
-    )
+        assert (
+            ParametricStudy(settings_source=solver, name="mixing_elbow-Solve")
+            == solver.settings.parameter_workspace.parametric_studies[
+                "mixing_elbow-Solve"
+            ]
+        )
+    else:
+        assert ParametricStudies(settings_source=solver) == solver.parametric_studies
+        assert (
+            ParametricStudy(settings_source=solver, name="mixing_elbow-Solve")
+            == solver.parametric_studies["mixing_elbow-Solve"]
+        )
+    if fluent_version >= FluentVersion.v271:
+        assert (
+            DesignPoints(
+                settings_source=solver, parametric_studies="mixing_elbow-Solve"
+            )
+            == solver.settings.parameter_workspace.parametric_studies[
+                "mixing_elbow-Solve"
+            ].design_points
+        )
+        assert (
+            DesignPoint(
+                settings_source=solver,
+                parametric_studies="mixing_elbow-Solve",
+                name="Base DP",
+            )
+            == solver.settings.parameter_workspace.parametric_studies[
+                "mixing_elbow-Solve"
+            ].design_points["Base DP"]
+        )
+    else:
+        assert (
+            DesignPoints(
+                settings_source=solver, parametric_studies="mixing_elbow-Solve"
+            )
+            == solver.parametric_studies["mixing_elbow-Solve"].design_points
+        )
+        assert (
+            DesignPoint(
+                settings_source=solver,
+                parametric_studies="mixing_elbow-Solve",
+                name="Base DP",
+            )
+            == solver.parametric_studies["mixing_elbow-Solve"].design_points["Base DP"]
+        )
     read_case_and_data = globals()["ReadCaseAndData"]
     write_case_and_data = globals()["WriteCaseAndData"]
     assert ReadCase(settings_source=solver) == solver.file.read_case

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -315,9 +315,13 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         SimulationReports(settings_source=solver)
         == solver.results.report.simulation_reports
     )
-    assert InputParameters(settings_source=solver) == solver.parameters.input_parameters
     assert (
-        OutputParameters(settings_source=solver) == solver.parameters.output_parameters
+        InputParameters(settings_source=solver)
+        == solver.parameter_workspace.parameters.input_parameters
+    )
+    assert (
+        OutputParameters(settings_source=solver)
+        == solver.parameter_workspace.parameters.output_parameters
     )
     if fluent_version >= FluentVersion.v251:
         assert (

--- a/tests/test_builtin_settings.py
+++ b/tests/test_builtin_settings.py
@@ -315,7 +315,7 @@ def test_builtin_settings(mixing_elbow_case_data_session):
         SimulationReports(settings_source=solver)
         == solver.results.report.simulation_reports
     )
-    if solver.get_fluent_version() >= FluentVersion.v271:
+    if fluent_version >= FluentVersion.v271:
         assert (
             InputParameters(settings_source=solver)
             == solver.parameter_workspace.parameters.input_parameters

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -638,8 +638,7 @@ def test_solver_methods(new_solver_session):
         "setup",
         "solution",
         "results",
-        "parametric_studies",
-        "current_parametric_study",
+        "parameter_workspace",
         "parallel",
     }
     assert api_keys.issubset(set(dir(solver.settings)))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -638,9 +638,13 @@ def test_solver_methods(new_solver_session):
         "setup",
         "solution",
         "results",
-        "parameter_workspace",
+        "parametric_studies",
+        "current_parametric_study",
         "parallel",
     }
+    if solver.get_fluent_version() >= FluentVersion.v271:
+        api_keys = api_keys - {"parametric_studies", "current_parametric_study"}
+        api_keys.add("parameter_workspace")
     assert api_keys.issubset(set(dir(solver.settings)))
 
 


### PR DESCRIPTION
## Context
In the server >> solver.settings.parameters -> solver.settings. parameter_workspace

## Change Summary
Updated tests.

## Impact
Users to use the new path.

Backwards compatibility is missing from server. Will file a bug.
