### PR TITLE
chore: Weight not to be a property of Reduction.

### DIFF
--- a/doc/changelog.d/5153.maintenance.md
+++ b/doc/changelog.d/5153.maintenance.md
@@ -1,0 +1,1 @@
+Weight not to be a property of Reduction.

--- a/doc/source/user_guide/fields/reduction.rst
+++ b/doc/source/user_guide/fields/reduction.rst
@@ -311,10 +311,11 @@ Object-Oriented:
 
 .. code-block:: python
 
+  >>> from ansys.fluent.core.services.reduction import Weight
   >>> reduction.sum(
   >>>   expression=VariableCatalog.ABSOLUTE_PRESSURE,
   >>>   locations=solver_session.settings.setup.boundary_conditions.velocity_inlet,
-  >>>   weight=reduction.weight.AREA
+  >>>   weight=Weight.AREA
   >>> )
   80349034.56621933
 
@@ -326,7 +327,7 @@ Object-Oriented:
   >>>   expression=VariableCatalog.ABSOLUTE_PRESSURE,
   >>>   condition="AbsolutePressure > 0[Pa]",
   >>>   locations=solver_session.settings.setup.boundary_conditions.velocity_inlet,
-  >>>   weight=reduction.weight.AREA
+  >>>   weight=Weight.AREA
   >>> )
   80349034.56621933
 

--- a/src/ansys/fluent/core/services/reduction.py
+++ b/src/ansys/fluent/core/services/reduction.py
@@ -280,6 +280,21 @@ class Reduction:
 
     _proto_module = ReductionProtoModule
 
+    weight = Weight
+    """Enum of available weighting options for :meth:`sum` and :meth:`sum_if`.
+
+    Provides access to the :class:`~ansys.fluent.core.solver.function.reduction.Weight`
+    enum without requiring a separate import. Use a member of this enum as the
+    ``weight`` argument to :meth:`sum` or :meth:`sum_if`.
+
+    Available members: ``AREA``, ``VOLUME``, ``MASS``, ``MASS_FLOW_RATE``,
+    ``ABS_MASS_FLOW_RATE``.
+
+    Examples
+    --------
+    >>> solver.fields.reduction.sum(expr, locations, weight=solver.fields.reduction.weight.AREA)
+    """
+
     def __init__(self, service: ReductionService, ctxt=None):
         """__init__ method of Reduction class."""
         self.service = service
@@ -329,11 +344,6 @@ class Reduction:
             request.condition = condition
         request.locations.extend(self._get_location_string(locations, ctxt))
         return request
-
-    @property
-    def weight(self):
-        """Weight for calculating sum."""
-        return Weight
 
     def area(self, locations, ctxt=None) -> Any:
         """Get area."""

--- a/src/ansys/fluent/core/services/reduction.py
+++ b/src/ansys/fluent/core/services/reduction.py
@@ -280,8 +280,6 @@ class Reduction:
 
     _proto_module = ReductionProtoModule
 
-    weight = Weight
-
     def __init__(self, service: ReductionService, ctxt=None):
         """__init__ method of Reduction class."""
         self.service = service

--- a/src/ansys/fluent/core/services/reduction.py
+++ b/src/ansys/fluent/core/services/reduction.py
@@ -281,19 +281,6 @@ class Reduction:
     _proto_module = ReductionProtoModule
 
     weight = Weight
-    """Enum of available weighting options for :meth:`sum` and :meth:`sum_if`.
-
-    Provides access to the :class:`~ansys.fluent.core.solver.function.reduction.Weight`
-    enum without requiring a separate import. Use a member of this enum as the
-    ``weight`` argument to :meth:`sum` or :meth:`sum_if`.
-
-    Available members: ``AREA``, ``VOLUME``, ``MASS``, ``MASS_FLOW_RATE``,
-    ``ABS_MASS_FLOW_RATE``.
-
-    Examples
-    --------
-    >>> solver.fields.reduction.sum(expr, locations, weight=solver.fields.reduction.weight.AREA)
-    """
 
     def __init__(self, service: ReductionService, ctxt=None):
         """__init__ method of Reduction class."""

--- a/src/ansys/fluent/core/solver/function/reduction.py
+++ b/src/ansys/fluent/core/solver/function/reduction.py
@@ -97,8 +97,7 @@ class Weight(Enum):
 
     Examples
     --------
-    >>> from ansys.fluent.core.solver.function import reduction
-    >>> reduction.sum(expr, locations, weight=reduction.weight.AREA)
+    >>> <solver-session>.fields.reduction.sum(expr, locations, weight=<solver-session>.fields.reduction.weight.AREA)
     """
 
     AREA = "Area"

--- a/src/ansys/fluent/core/solver/function/reduction.py
+++ b/src/ansys/fluent/core/solver/function/reduction.py
@@ -93,12 +93,7 @@ from ansys.fluent.core.variable_strategies import (
 
 
 class Weight(Enum):
-    """Enum of available weighting options for `sum` and `sum_if`.
-
-    Examples
-    --------
-    >>> <solver-session>.fields.reduction.sum(expr, locations, weight=<solver-session>.fields.reduction.weight.AREA)
-    """
+    """Enum of available weighting options for `sum` and `sum_if`."""
 
     AREA = "Area"
     VOLUME = "Volume"

--- a/src/ansys/fluent/core/solver/function/reduction.py
+++ b/src/ansys/fluent/core/solver/function/reduction.py
@@ -97,7 +97,8 @@ class Weight(Enum):
 
     Examples
     --------
-    >>> solver.fields.reduction.sum(expr, locations, weight=solver.fields.reduction.weight.AREA)
+    >>> from ansys.fluent.core.solver.function import reduction
+    >>> reduction.sum(expr, locations, weight=reduction.weight.AREA)
     """
 
     AREA = "Area"

--- a/src/ansys/fluent/core/solver/function/reduction.py
+++ b/src/ansys/fluent/core/solver/function/reduction.py
@@ -93,7 +93,12 @@ from ansys.fluent.core.variable_strategies import (
 
 
 class Weight(Enum):
-    """Weight for sum."""
+    """Enum of available weighting options for `sum` and `sum_if`.
+
+    Examples
+    --------
+    >>> solver.fields.reduction.sum(expr, locations, weight=solver.fields.reduction.weight.AREA)
+    """
 
     AREA = "Area"
     VOLUME = "Volume"

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -27,7 +27,7 @@ import pytest
 from ansys.fluent.core import FluentVersion
 from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.exceptions import DisallowedValuesError
-from ansys.fluent.core.services.reduction import _locn_names_and_objs
+from ansys.fluent.core.services.reduction import Weight, _locn_names_and_objs
 from ansys.fluent.core.solver.function import reduction
 from ansys.units import VariableCatalog
 
@@ -397,7 +397,7 @@ def _test_sum_if(solver):
         expression=VariableCatalog.ABSOLUTE_PRESSURE,
         condition="AbsolutePressure > 0[Pa]",
         locations=[solver.setup.boundary_conditions.velocity_inlet["inlet1"]],
-        weight=solver.fields.reduction.weight.AREA,
+        weight=Weight.AREA,
     )
 
     assert val == expr_val
@@ -568,7 +568,7 @@ def test_named_expression_as_input(static_mixer_case_session):
         expression=absolute_pressure_expression,
         condition="AbsolutePressure > 0[Pa]",
         locations=[solver.setup.boundary_conditions.velocity_inlet["inlet1"]],
-        weight=solver.fields.reduction.weight.AREA,
+        weight=Weight.AREA,
     )
     assert val == expr_val
 


### PR DESCRIPTION
## Context
'weight' was a property of Reduction class. It was causing it to be improperly documented in the Api docs.

## Change Summary
'weight' is just an attribute of Reduction class now. Added a bit more context to docstring.

## Impact
The api docs to be updated now correctly.
