### PR TITLE
docs: Updated issue posting guidelines. [skip tests]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
           required: true
         - label: I am using a Python virtual environment.
           required: true
-        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
           required: true
         - label: I am using a Python virtual environment.
           required: true
-        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent. See the [posting issues guide](https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues).
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
           required: true
         - label: I am using a Python virtual environment.
           required: true
-        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself.
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself. ([Contributing Guidelines](https://github.com/ansys/pyfluent?tab=contributing-ov-file#))
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
           required: true
         - label: I am using a Python virtual environment.
           required: true
-        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself. ([Contributing Guidelines](https://github.com/ansys/pyfluent?tab=contributing-ov-file#))
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent itself. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
           required: true
         - label: I am using a Python virtual environment.
           required: true
-        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))
+        - label: I have confirmed this is a PyFluent issue, not a problem with Ansys Fluent. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the usual support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the usual support channel."
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the usual support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent?tab=contributing-ov-file#))"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through Ansys customer support. For details, see the [posting issues guide](https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)."
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys developer forum or through Ansys customer support. For details, see the [posting issues guide](https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the usual support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent?tab=contributing-ov-file#))"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the usual support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through Ansys customer support. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through Ansys customer support. For details, see the [posting issues guide](https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support channel. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support. ([Contributing Guidelines](https://github.com/ansys/pyfluent/blob/main/CONTRIBUTING.md))"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,4 +6,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Fluent issue
     url: https://discuss.ansys.com/
-    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through the Ansys customer support. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)"
+    about: "Experiencing a problem in Fluent or its API? Please report it on the Ansys Developer Forum or through Ansys customer support. (https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html#post-issues)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Follow this checklist to decide where to open a report.
      or translate the Python calls into a Scheme journal.
    - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
    - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
-2. If the issue is only visible when using Python (e.g., wrong parameter mapping, malformed request sent to Fluent, missing API convenience),
+2. If the issue is only visible when using Python (for example, wrong parameter mapping, malformed request sent to Fluent, missing API convenience),
    it is likely a PyFluent issue.
 
 ### When to contact which channel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,47 @@ PyFluent.
 
 The following contribution information is specific to PyFluent.
 
-> **Note:** The PyFluent GitHub repository is intended for issues with the **PyFluent client library** itself.
-> Experiencing a problem in Fluent or its API? Please report it on the
-> [Ansys Developer Forum](https://discuss.ansys.com) or through [Ansys Support](https://support.ansys.com).
+Use the [PyFluent Issues](https://github.com/ansys/pyfluent/issues) page to
+submit questions, bug reports, and feature requests directly pertaining to PyFluent.
+
+## Triage guidance: Is the problem in PyFluent or in Fluent?
+
+Follow this checklist to decide where to open a report.
+
+### Quick checklist
+
+- If the behavior concerns Python packaging, installation, import errors,
+  or issues specific to Python → open a PyFluent GitHub issue.
+- If the issue relates to a particular Fluent physics model, solver behaviour,
+  meshing or solver results, or can be reproduced inside Fluent without Python → raise
+  it with Ansys ([Support](https://support.ansys.com) or [Developer Forum](https://discuss.ansys.com)).
+
+### How to check
+
+1. Try to reproduce inside Fluent without PyFluent:
+   - Use Fluent's journaling/recording capability to record your actions as a Scheme (.jou) or TUI script,
+     or translate the Python calls into a Scheme journal.
+   - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
+   - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
+2. If the issue is only visible when using Python (e.g., wrong parameter mapping, malformed request sent to Fluent, missing API convenience),
+   it is likely a PyFluent issue.
+
+### When to contact which channel
+
+- [Ansys Support](https://support.ansys.com): product defects affecting simulation correctness, licensing, installation, or if you need formal tracking.
+- [Ansys Developer Forum](https://discuss.ansys.com): general Fluent usage questions, workflow discussion, or community help.
+- [PyFluent GitHub](https://github.com/ansys/pyfluent/issues): PyFluent installation, packaging, Python API mapping, client-side bugs, examples, or where there is genuine uncertainty.
+
+### Opening a PyFluent issue
+
+If you open a PyFluent issue (recommended when unsure), please include:
+
+- PyFluent version, Python version, OS.
+- Fluent product/version, and whether running Fluent GUI, batch, or headless.
+- Short description of expected vs actual behavior.
+- Minimal reproduction steps (Python snippet) and, if available, the equivalent Scheme/TUI journal produced by Fluent.
+- Attach logs, error output, screenshots, and a small case/mesh if possible and allowed by your policies.
+- Mark clearly if you have already reproduced the issue by running the Scheme/TUI journal in Fluent.
 
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,18 +7,9 @@ PyFluent.
 
 The following contribution information is specific to PyFluent.
 
-Use the [PyFluent Issues](https://github.com/ansys/pyfluent/issues) page to
-submit questions, bug reports, and feature requests directly pertaining to PyFluent.
-
-## Triage and issue reporting
-
-For guidance on whether to open a PyFluent issue or use Fluent support
-channels, follow the canonical instructions in the [Contributing] topic in
-the *PyAnsys developer's guide*.
-
-Use the [PyFluent Issues](https://github.com/ansys/pyfluent/issues) page to
-open issues that are specific to PyFluent, or when the appropriate reporting
-channel is unclear.
+Additional information can be found in the
+[PyFluent Contributing](https://fluent.docs.pyansys.com/version/stable/contributing/contributing_contents.html)
+documentation.
 
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Follow this checklist to decide where to open a report.
 
 - If the behavior concerns Python packaging, installation, import errors,
   or issues specific to Python → open a PyFluent GitHub issue.
-- If the issue relates to a particular Fluent physics model, solver behaviour,
+- If the issue relates to a particular Fluent physics model, solver behavior,
   meshing or solver results, or can be reproduced inside Fluent without Python → raise
   it with Ansys ([Support](https://support.ansys.com) or [Developer Forum](https://discuss.ansys.com)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,44 +10,15 @@ The following contribution information is specific to PyFluent.
 Use the [PyFluent Issues](https://github.com/ansys/pyfluent/issues) page to
 submit questions, bug reports, and feature requests directly pertaining to PyFluent.
 
-## Triage guidance: Is the problem in PyFluent or in Fluent?
+## Triage and issue reporting
 
-Follow this checklist to decide where to open a report.
+For guidance on whether to open a PyFluent issue or use Fluent support
+channels, follow the canonical instructions in the [Contributing] topic in
+the *PyAnsys developer's guide*.
 
-### Quick checklist
-
-- If the behavior concerns Python packaging, installation, import errors,
-  or issues specific to Python → open a PyFluent GitHub issue.
-- If the issue relates to a particular Fluent physics model, solver behavior,
-  meshing or solver results, or can be reproduced inside Fluent without Python → raise
-  it with Ansys ([Support](https://support.ansys.com) or [Developer Forum](https://discuss.ansys.com)).
-
-### How to check
-
-1. Try to reproduce inside Fluent without PyFluent:
-   - Use Fluent's journaling/recording capability to record your actions as a Scheme (.jou) or TUI script,
-     or translate the Python calls into a Scheme journal.
-   - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
-   - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
-2. If the issue is only visible when using Python (for example, wrong parameter mapping, malformed request sent to Fluent, missing API convenience),
-   it is likely a PyFluent issue.
-
-### When to contact which channel
-
-- [Ansys Support](https://support.ansys.com): product defects affecting simulation correctness, licensing, installation, or if you need formal tracking.
-- [Ansys Developer Forum](https://discuss.ansys.com): general Fluent usage questions, workflow discussion, or community help.
-- [PyFluent GitHub](https://github.com/ansys/pyfluent/issues): PyFluent installation, packaging, Python API mapping, client-side bugs, examples, or where there is genuine uncertainty.
-
-### Opening a PyFluent issue
-
-If you open a PyFluent issue (recommended when unsure), please include:
-
-- PyFluent version, Python version, OS.
-- Fluent product/version, and whether running Fluent GUI, batch, or headless.
-- Short description of expected vs actual behavior.
-- Minimal reproduction steps (Python snippet) and, if available, the equivalent Scheme/TUI journal produced by Fluent.
-- Attach logs, error output, screenshots, and a small case/mesh if possible and allowed by your policies.
-- Mark clearly if you have already reproduced the issue by running the Scheme/TUI journal in Fluent.
+Use the [PyFluent Issues](https://github.com/ansys/pyfluent/issues) page to
+open issues that are specific to PyFluent, or when the appropriate reporting
+channel is unclear.
 
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
 

--- a/doc/changelog.d/5154.documentation.md
+++ b/doc/changelog.d/5154.documentation.md
@@ -1,0 +1,1 @@
+Updated issue posting guidelines. [skip tests]

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -85,18 +85,6 @@ You can clear all HTML files from the ``_build/html`` directory with:
 
     make clean
 
-Post issues
------------
-Use the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page to
-submit questions, bug reports, and feature requests directly pertaining to PyFluent.
-
-.. note::
-
-    For questions and issues concerning Fluent or its API, please use the
-   `Ansys Developer Forum <https://discuss.ansys.com>`_ or
-   `Ansys Support <https://support.ansys.com>`_.
-
-
 Adhere to code style
 --------------------
 PyFluent is compliant with the `PyAnsys code style
@@ -126,3 +114,43 @@ the branch and commit names conventions as described in the *PyAnsys Developer's
 `branch <https://dev.docs.pyansys.com/how-to/contributing.html#branch-naming-conventions>`_ and 
 `commit <https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions>`_ naming
 sections.
+
+Post issues
+-----------
+Use the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page to
+submit questions, bug reports, and feature requests directly pertaining to PyFluent.
+
+Triage guidance: Is the problem in PyFluent or in Fluent?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Follow this checklist to decide where to open a report.
+
+Quick checklist
+^^^^^^^^^^^^^^^
+- If the behavior concerns Python packaging, installation, import errors,
+or issues specific to Python → open a PyFluent GitHub issue.
+- If the issue relates to a particular Fluent physics model, solver behaviour,
+meshing or solver results, or can be reproduced inside Fluent without Python → raise
+it with Ansys (`Support <https://support.ansys.com>`_ or `Developer Forum <https://discuss.ansys.com>`_).
+
+How to check
+^^^^^^^^^^^^
+1. Try to reproduce inside Fluent without PyFluent:
+   - Use Fluent's journaling/recording capability to record your actions as a Scheme (.jou) or TUI script,
+   or translate the Python calls into a Scheme journal.
+   - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
+   - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
+2. If the issue is only visible when using Python (e.g., wrong parameter mapping, malformed request sent to Fluent, missing API convenience) it is likely a PyFluent issue.
+
+When to contact which channel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Ansys `Support <https://support.ansys.com>`_: product defects affecting simulation correctness, licensing, installation, or if you need formal tracking.
+- Ansys `Developer Forum <https://discuss.ansys.com>`_: general Fluent usage questions, workflow discussion, or community help.
+- PyFluent `GitHub <https://github.com/ansys/pyfluent/issues>`_: PyFluent installation, packaging, Python API mapping, client-side bugs, examples, or where there is genuine uncertainty.
+
+If you open a PyFluent issue (recommended when unsure), please include:
+- PyFluent version, Python version, OS.
+- Fluent product/version, and whether running Fluent GUI, batch, or headless.
+- Short description of expected vs actual behavior.
+- Minimal reproduction steps (Python snippet) and, if available, the equivalent Scheme/TUI journal produced by Fluent.
+- Attach logs, error output, screenshots, and a small case/mesh if possible and allowed by your policies.
+- Mark clearly if you have already reproduced the issue by running the Scheme/TUI journal in Fluent.

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -120,39 +120,11 @@ Post issues
 Use the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page to
 submit bug reports and feature requests directly pertaining to PyFluent.
 
-Triage guidance: Is the problem in PyFluent or in Fluent?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Follow this checklist to decide where to open a report.
-
-Quick checklist
-^^^^^^^^^^^^^^^
-- If the behavior concerns Python packaging, installation, import errors,
-  or issues specific to Python → open a PyFluent GitHub issue.
+Triage guidance
+~~~~~~~~~~~~~~~
+Follow this checklist to decide whether the issue belongs to PyFluent or Fluent:
 - If the issue relates to a particular Fluent physics model, solver behavior,
   meshing or solver results, or can be reproduced inside Fluent without Python → raise
-  it with Ansys (`Support <https://support.ansys.com>`_ or `Developer Forum <https://discuss.ansys.com>`_).
-
-How to check
-^^^^^^^^^^^^
-1. Try to reproduce inside Fluent without PyFluent:
-   - Use Fluent's journaling/recording capability to record your actions as a Scheme (.jou) or TUI script,
-     or translate the Python calls into a Scheme journal.
-   - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
-   - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
-2. If the issue is only visible when using Python (for example, wrong
-   parameter mapping, malformed request sent to Fluent, missing API
-   convenience) it is likely a PyFluent issue.
-
-When to contact which channel
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- Ansys `Support <https://support.ansys.com>`_: product defects affecting simulation correctness, licensing, installation, or if you need formal tracking.
-- Ansys `Developer Forum <https://discuss.ansys.com>`_: general Fluent usage questions, workflow discussion, or community help.
-- PyFluent `GitHub <https://github.com/ansys/pyfluent/issues>`_: PyFluent installation, packaging, Python API mapping, client-side bugs, examples, or where there is genuine uncertainty.
-
-If you open a PyFluent issue (recommended when unsure), please include:
-- PyFluent version, Python version, OS.
-- Fluent product/version, and whether running Fluent GUI, batch, or headless.
-- Short description of expected vs actual behavior.
-- Minimal reproduction steps (Python snippet) and, if available, the equivalent Scheme/TUI journal produced by Fluent.
-- Attach logs, error output, screenshots, and a small case/mesh if possible and allowed by your policies.
-- Mark clearly if you have already reproduced the issue by running the Scheme/TUI journal in Fluent.
+  it with (`Ansys customer support <https://support.ansys.com>`_ or `Ansys Developer forum <https://discuss.ansys.com>`_).
+- If the behavior concerns Python packaging, installation, import errors,
+  or issues specific to PyFluent → open a PyFluent GitHub issue.

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -126,6 +126,6 @@ Follow this checklist to decide whether the issue belongs to PyFluent or Fluent:
 
 - If the issue relates to a particular Fluent physics model, solver behavior,
   meshing or solver results, or can be reproduced inside Fluent without Python → raise
-  it with (`Ansys customer support <https://support.ansys.com>`_ or `Ansys Developer forum <https://discuss.ansys.com>`_).
+  it with (`Ansys customer support <https://support.ansys.com>`_ or `Ansys developer forum <https://discuss.ansys.com>`_).
 - If the behavior concerns Python packaging, installation, import errors,
   or issues specific to PyFluent → open a PyFluent GitHub issue.

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -127,16 +127,16 @@ Follow this checklist to decide where to open a report.
 Quick checklist
 ^^^^^^^^^^^^^^^
 - If the behavior concerns Python packaging, installation, import errors,
-or issues specific to Python → open a PyFluent GitHub issue.
+  or issues specific to Python → open a PyFluent GitHub issue.
 - If the issue relates to a particular Fluent physics model, solver behaviour,
-meshing or solver results, or can be reproduced inside Fluent without Python → raise
-it with Ansys (`Support <https://support.ansys.com>`_ or `Developer Forum <https://discuss.ansys.com>`_).
+  meshing or solver results, or can be reproduced inside Fluent without Python → raise
+  it with Ansys (`Support <https://support.ansys.com>`_ or `Developer Forum <https://discuss.ansys.com>`_).
 
 How to check
 ^^^^^^^^^^^^
 1. Try to reproduce inside Fluent without PyFluent:
    - Use Fluent's journaling/recording capability to record your actions as a Scheme (.jou) or TUI script,
-   or translate the Python calls into a Scheme journal.
+     or translate the Python calls into a Scheme journal.
    - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
    - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
 2. If the issue is only visible when using Python (e.g., wrong parameter mapping, malformed request sent to Fluent, missing API convenience) it is likely a PyFluent issue.

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -118,7 +118,7 @@ sections.
 Post issues
 -----------
 Use the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page to
-submit questions, bug reports, and feature requests directly pertaining to PyFluent.
+submit bug reports, and feature requests directly pertaining to PyFluent.
 
 Triage guidance: Is the problem in PyFluent or in Fluent?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -128,7 +128,7 @@ Quick checklist
 ^^^^^^^^^^^^^^^
 - If the behavior concerns Python packaging, installation, import errors,
   or issues specific to Python → open a PyFluent GitHub issue.
-- If the issue relates to a particular Fluent physics model, solver behaviour,
+- If the issue relates to a particular Fluent physics model, solver behavior,
   meshing or solver results, or can be reproduced inside Fluent without Python → raise
   it with Ansys (`Support <https://support.ansys.com>`_ or `Developer Forum <https://discuss.ansys.com>`_).
 

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -118,7 +118,7 @@ sections.
 Post issues
 -----------
 Use the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page to
-submit bug reports, and feature requests directly pertaining to PyFluent.
+submit bug reports and feature requests directly pertaining to PyFluent.
 
 Triage guidance: Is the problem in PyFluent or in Fluent?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -139,7 +139,7 @@ How to check
      or translate the Python calls into a Scheme journal.
    - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
    - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
-2. If the issue is only visible when using Python (e.g., wrong parameter mapping, malformed request sent to Fluent, missing API convenience) it is likely a PyFluent issue.
+2. If the issue is only visible when using Python (for example, wrong parameter mapping, malformed request sent to Fluent, missing API convenience) it is likely a PyFluent issue.
 
 When to contact which channel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -123,6 +123,7 @@ submit bug reports and feature requests directly pertaining to PyFluent.
 Triage guidance
 ~~~~~~~~~~~~~~~
 Follow this checklist to decide whether the issue belongs to PyFluent or Fluent:
+
 - If the issue relates to a particular Fluent physics model, solver behavior,
   meshing or solver results, or can be reproduced inside Fluent without Python → raise
   it with (`Ansys customer support <https://support.ansys.com>`_ or `Ansys Developer forum <https://discuss.ansys.com>`_).

--- a/doc/source/contributing/contributing_contents.rst
+++ b/doc/source/contributing/contributing_contents.rst
@@ -139,7 +139,9 @@ How to check
      or translate the Python calls into a Scheme journal.
    - Run the recorded Scheme journal (or equivalent TUI commands) directly in Fluent.
    - If the problem reproduces in Fluent with the Scheme/TUI journal, it is almost certainly a Fluent-side issue.
-2. If the issue is only visible when using Python (for example, wrong parameter mapping, malformed request sent to Fluent, missing API convenience) it is likely a PyFluent issue.
+2. If the issue is only visible when using Python (for example, wrong
+   parameter mapping, malformed request sent to Fluent, missing API
+   convenience) it is likely a PyFluent issue.
 
 When to contact which channel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Provided a detailed issue posting guidelines to allow users to decide where to create a particular issue.

Linked the contributing page to bug creation and Fluent issue creation parts.
