### PR TITLE
feat: Include UDS path in connection properties.

### DIFF
--- a/doc/changelog.d/5172.added.md
+++ b/doc/changelog.d/5172.added.md
@@ -1,0 +1,1 @@
+Include UDS path in connection properties.

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -248,11 +248,34 @@ class ErrorState:
         self._details = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class FluentConnectionProperties:
-    """Stores Fluent connection properties, including connection IP, port and password;
+    """Stores Fluent connection properties, including connection IP/port or UDS path and password;
     Fluent Cortex working directory, process ID and hostname; and whether Fluent was
     launched in a docker container.
+
+    Attributes
+    ----------
+    ip : str | None
+        IP address used to connect to Fluent.
+    port : int | None
+        Port used to connect to Fluent.
+    uds_fullpath : str | Path | None
+        Full path to the Unix Domain Socket used for local connections on Linux.
+    password : str | None
+        Password used for authentication when calling Fluent services.
+    cortex_pwd : str | None
+        Fluent Cortex working directory.
+    cortex_pid : int | None
+        Process ID of the Cortex process.
+    cortex_host : str | None
+        Hostname of the Cortex process.
+    fluent_host_pid : int | None
+        Process ID of the Fluent solver host process.
+    inside_container : bool | ContainerT | None
+        Container context for Fluent.
+        Returns ``False`` when not running in a container,
+        and the container instance when running in one.
 
     Examples
     --------
@@ -268,6 +291,7 @@ class FluentConnectionProperties:
 
     ip: str | None = None
     port: int | None = None
+    uds_fullpath: str | Path | None = None
     password: str | None = None
     cortex_pwd: str | None = None
     cortex_pid: int | None = None
@@ -584,14 +608,14 @@ class FluentConnection:
         self._channel_str = None
         self._slurm_job_id = None
         self.finalizer_cbs = []
+        self._uds_fullpath = None
         if channel is not None:
             self._channel = channel
         else:
-            uds_fullpath = None
             if address is not None:
                 self._channel_str = address
-                uds_fullpath = get_uds_path(address)
-                if uds_fullpath is None:
+                self._uds_fullpath = get_uds_path(address)
+                if self._uds_fullpath is None:
                     ip, port = address.rsplit(":", 1)
                     port = int(port)
             else:
@@ -600,7 +624,7 @@ class FluentConnection:
             self._channel = _get_channel(
                 ip=ip,
                 port=port,
-                uds_fullpath=uds_fullpath,
+                uds_fullpath=self._uds_fullpath,
                 allow_remote_host=allow_remote_host,
                 certificates_folder=certificates_folder,
                 insecure_mode=insecure_mode,
@@ -665,14 +689,15 @@ class FluentConnection:
                 )
 
         self.connection_properties = FluentConnectionProperties(
-            ip,
-            port,
-            password,
-            cortex_pwd,
-            cortex_pid,
-            cortex_host,
-            fluent_host_pid,
-            inside_container,
+            ip=ip,
+            port=port,
+            uds_fullpath=self._uds_fullpath,
+            password=password,
+            cortex_pwd=cortex_pwd,
+            cortex_pid=cortex_pid,
+            cortex_host=cortex_host,
+            fluent_host_pid=fluent_host_pid,
+            inside_container=inside_container,
         )
 
         self._remote_instance = remote_instance


### PR DESCRIPTION
## Context
For local-connection on Linux, ip+port is replaced by UDS path which should be available within session's connection properties.

## Change Summary
Include the UDS full-path in session's connection properties.

<img width="816" height="102" alt="image" src="https://github.com/user-attachments/assets/a48c7760-c298-4270-a45e-f128b31c1bb7" />

## Rationale
The connection properties are useful to connect another client session to the same server and the UDS path is required to connect  locally in Linux.

## Impact
The UDS path info will be available within session's connection properties.
