### PR TITLE
test: Add pyconsole test

### DIFF
--- a/.ci/print_fluent_grpc_version.py
+++ b/.ci/print_fluent_grpc_version.py
@@ -6,5 +6,5 @@ from ansys.fluent.core.docker.utils import get_grpc_launcher_args_for_gh_runs
 if __name__ == "__main__":
     kwds = get_grpc_launcher_args_for_gh_runs()
     session = pyfluent.launch_fluent(**kwds)
-    session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
-    print(session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")'))
+    session.scheme.eval('(%py-exec "import grpc")')
+    print(session.scheme.eval('(%py-eval "grpc.__version__")'))

--- a/.ci/print_fluent_grpc_version.py
+++ b/.ci/print_fluent_grpc_version.py
@@ -4,6 +4,8 @@ import ansys.fluent.core as pyfluent
 from ansys.fluent.core.docker.utils import get_grpc_launcher_args_for_gh_runs
 
 if __name__ == "__main__":
+    pyfluent.set_console_logging_level("ERROR")
+    pyfluent.warning.disable()
     kwds = get_grpc_launcher_args_for_gh_runs()
     session = pyfluent.launch_fluent(**kwds)
     session.scheme.eval('(%py-exec "import grpc")')

--- a/.ci/print_fluent_grpc_version.py
+++ b/.ci/print_fluent_grpc_version.py
@@ -1,8 +1,10 @@
 """Get gRPC version from Fluent image and print it to the console."""
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core.docker.utils import get_grpc_launcher_args_for_gh_runs
 
 if __name__ == "__main__":
-    session = pyfluent.launch_fluent()
+    kwds = get_grpc_launcher_args_for_gh_runs()
+    session = pyfluent.launch_fluent(**kwds)
     session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
     print(session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")'))

--- a/.ci/print_fluent_grpc_version.py
+++ b/.ci/print_fluent_grpc_version.py
@@ -1,0 +1,8 @@
+"""Get gRPC version from Fluent image and print it to the console."""
+
+import ansys.fluent.core as pyfluent
+
+if __name__ == "__main__":
+    session = pyfluent.launch_fluent()
+    session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
+    print(session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,7 +631,8 @@ jobs:
         id: grpc-pyfluent-version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
-          echo "GRPC_PYFLUENT_VERSION=$(python -c "import grpc; print(grpc.__version__)")" >> $GITHUB_OUTPUT
+          GRPC_PYFLUENT_VERSION=$(python -c "import grpc; print(grpc.__version__)")
+          echo "GRPC_PYFLUENT_VERSION=$GRPC_PYFLUENT_VERSION" >> $GITHUB_OUTPUT
           echo "Local gRPC version is: $GRPC_PYFLUENT_VERSION"
 
       - name: Generate certificates for gRPC
@@ -642,7 +643,8 @@ jobs:
         id: grpc-fluent-version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
-          echo "GRPC_FLUENT_VERSION=$(python .ci/print_fluent_grpc_version.py)" >> $GITHUB_OUTPUT
+          GRPC_FLUENT_VERSION=$(python .ci/print_fluent_grpc_version.py)
+          echo "GRPC_FLUENT_VERSION=$GRPC_FLUENT_VERSION" >> $GITHUB_OUTPUT
           echo "gRPC version in Fluent image is: $GRPC_FLUENT_VERSION"
 
       - name: Install gRPC dependencies with the same version as Fluent image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,10 @@ jobs:
           echo "GRPC_PYFLUENT_VERSION=$(python -c "import grpc; print(grpc.__version__)")" >> $GITHUB_OUTPUT
           echo "Local gRPC version is: $GRPC_PYFLUENT_VERSION"
 
+      - name: Generate certificates for gRPC
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: bash .ci/generate_certs.sh
+
       - name: Get gRPC version from Fluent image
         id: grpc-fluent-version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
@@ -644,10 +648,14 @@ jobs:
       - name: Install gRPC dependencies with the same version as Fluent image
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') && steps.grpc-pyfluent-version.outputs.GRPC_PYFLUENT_VERSION != steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}
         run: |
-          pip install "grpcio==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
-          pip install "grpcio-health-checking==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
-          pip install "grpcio-status==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
-          pip install "grpcio-reflection==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
+          echo "gRPC version mismatch: local Python environment has $GRPC_PYFLUENT_VERSION, Fluent image has $GRPC_FLUENT_VERSION. Installing gRPC packages with version $GRPC_FLUENT_VERSION to match Fluent image for testing."
+          pip install "grpcio==${GRPC_FLUENT_VERSION}"
+          pip install "grpcio-health-checking==${GRPC_FLUENT_VERSION}"
+          pip install "grpcio-status==${GRPC_FLUENT_VERSION}"
+          pip install "grpcio-reflection==${GRPC_FLUENT_VERSION}"
+        env:
+          GRPC_PYFLUENT_VERSION: ${{ steps.grpc-pyfluent-version.outputs.GRPC_PYFLUENT_VERSION }}
+          GRPC_FLUENT_VERSION: ${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}
 
       - name: Run PyConsole Tests
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,88 @@ jobs:
         env:
           FLUENT_STABLE_IMAGE_DEV: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
+  test-pyconsole:
+    name: Test PyConsole
+    if: ${{ always() }}
+    needs: build
+    runs-on: [public-ubuntu-latest-16-cores]
+    env:
+      FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Clean Docker Data
+        run: make docker-clean-all-except-supported-images
+        env:
+          FLUENT_STABLE_IMAGE_DEV: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+
+      - name: Download package
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: PyFluent-packages
+          path: dist
+
+      - name: Install pyfluent
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: pip install -q --force-reinstall dist/*.whl > /dev/null
+
+      - name: Retrieve PyFluent version
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)"
+        id: version
+
+      - name: Login to GitHub Container Registry
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ansys-bot
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Fluent docker image
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: make docker-pull
+
+      - name: Get gRPC version from local Python environment
+        id: grpc-pyfluent-version
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: |
+          echo "GRPC_PYFLUENT_VERSION=$(python -c "import grpc; print(grpc.__version__)")" >> $GITHUB_OUTPUT
+          echo "Local gRPC version is: $GRPC_PYFLUENT_VERSION"
+
+      - name: Get gRPC version from Fluent image
+        id: grpc-fluent-version
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: |
+          echo "GRPC_FLUENT_VERSION=$(python .ci/print_fluent_grpc_version.py)" >> $GITHUB_OUTPUT
+          echo "gRPC version in Fluent image is: $GRPC_FLUENT_VERSION"
+
+      - name: Install gRPC dependencies with the same version as Fluent image
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') && steps.grpc-pyfluent-version.outputs.GRPC_PYFLUENT_VERSION != steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}
+        run: |
+          pip install "grpcio==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
+          pip install "grpcio-health-checking==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
+          pip install "grpcio-status==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
+          pip install "grpcio-reflection==${{ steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}"
+
+      - name: Run PyConsole Tests
+        if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
+        run: |
+          make install-test
+          python -m pytest --fluent-version=27.1 tests/test_pyconsole.py
+
   nightly-dev-test:
     name: Release Testing
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,7 +674,7 @@ jobs:
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
           source .venv/bin/activate
-          make install-test
+          python -m pip install ansys-fluent-core[reader,tests]
           python -m pytest --fluent-version=27.1 tests/test_pyconsole.py
 
   nightly-dev-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,11 +606,15 @@ jobs:
 
       - name: Install pyfluent
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
-        run: pip install -q --force-reinstall dist/*.whl > /dev/null
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install -q --force-reinstall dist/*.whl > /dev/null
 
       - name: Retrieve PyFluent version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
+          source .venv/bin/activate
           echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)" >> $GITHUB_OUTPUT
           echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(); print(__version__)" | tail -1)"
         id: version
@@ -631,6 +635,7 @@ jobs:
         id: grpc-pyfluent-version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
+          source .venv/bin/activate
           GRPC_PYFLUENT_VERSION=$(python -c "import grpc; print(grpc.__version__)")
           echo "GRPC_PYFLUENT_VERSION=$GRPC_PYFLUENT_VERSION" >> $GITHUB_OUTPUT
           echo "Local gRPC version is: $GRPC_PYFLUENT_VERSION"
@@ -643,6 +648,7 @@ jobs:
         id: grpc-fluent-version
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
+          source .venv/bin/activate
           GRPC_FLUENT_VERSION=$(python .ci/print_fluent_grpc_version.py)
           echo "GRPC_FLUENT_VERSION=$GRPC_FLUENT_VERSION" >> $GITHUB_OUTPUT
           echo "gRPC version in Fluent image is: $GRPC_FLUENT_VERSION"
@@ -653,6 +659,7 @@ jobs:
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') && steps.grpc-pyfluent-version.outputs.GRPC_PYFLUENT_VERSION != steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}
         run: |
           echo "gRPC version mismatch: local Python environment has $GRPC_PYFLUENT_VERSION, Fluent image has $GRPC_FLUENT_VERSION. Installing gRPC packages with version $GRPC_FLUENT_VERSION to match Fluent image for testing."
+          source .venv/bin/activate
           pip install "grpcio==${GRPC_FLUENT_VERSION}"
           pip install "grpcio-health-checking==${GRPC_FLUENT_VERSION}"
           pip install "grpcio-status==${GRPC_FLUENT_VERSION}"
@@ -664,6 +671,7 @@ jobs:
       - name: Run PyConsole Tests
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
         run: |
+          source .venv/bin/activate
           make install-test
           python -m pytest --fluent-version=27.1 tests/test_pyconsole.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,7 @@ jobs:
     if: ${{ always() }}
     needs: build
     runs-on: [public-ubuntu-latest-16-cores]
+    timeout-minutes: 30
     env:
       FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,6 +646,8 @@ jobs:
           GRPC_FLUENT_VERSION=$(python .ci/print_fluent_grpc_version.py)
           echo "GRPC_FLUENT_VERSION=$GRPC_FLUENT_VERSION" >> $GITHUB_OUTPUT
           echo "gRPC version in Fluent image is: $GRPC_FLUENT_VERSION"
+        env:
+          PYFLUENT_LOGGING: 0
 
       - name: Install gRPC dependencies with the same version as Fluent image
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') && steps.grpc-pyfluent-version.outputs.GRPC_PYFLUENT_VERSION != steps.grpc-fluent-version.outputs.GRPC_FLUENT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,9 @@ jobs:
 
       - name: Pull Fluent docker image
         if: ${{ !contains(github.event.pull_request.title, '[skip tests]') }}
-        run: make docker-pull
+        run: |
+          source .venv/bin/activate
+          make docker-pull
 
       - name: Get gRPC version from local Python environment
         id: grpc-pyfluent-version

--- a/doc/changelog.d/5177.test.md
+++ b/doc/changelog.d/5177.test.md
@@ -1,0 +1,1 @@
+Add pyconsole test

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -484,7 +484,7 @@ def _server_supports_v1(channel) -> bool:
             method_desc.full_name
             == "ansys.api.fluent.v1.application_runtime.ApplicationRuntime.GetProductVersion"
         )
-    except KeyError:
+    except (KeyError, AttributeError):
         return False
 
 

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -484,7 +484,7 @@ def _server_supports_v1(channel) -> bool:
             method_desc.full_name
             == "ansys.api.fluent.v1.application_runtime.ApplicationRuntime.GetProductVersion"
         )
-    except (KeyError, AttributeError):
+    except KeyError:
         return False
 
 

--- a/src/ansys/fluent/core/module_config.py
+++ b/src/ansys/fluent/core/module_config.py
@@ -73,9 +73,9 @@ class _ConfigDescriptor(Generic[TConfig]):
 
 def _get_default_examples_path(instance: "Config") -> str:
     """Get the default examples path."""
-    parent_path = Path.home() / "Downloads"
-    parent_path.mkdir(exist_ok=True)
-    return str(parent_path / "ansys_fluent_core_examples")
+    default_path = Path.home() / "Downloads" / "ansys_fluent_core_examples"
+    default_path.mkdir(parents=True, exist_ok=True)
+    return str(default_path)
 
 
 class Config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def pytest_runtest_setup(item):
 
     version_specs = []
     fluent_release_version = FluentVersion.current_release().value
+    fluent_dev_version = FluentVersion.current_dev().value
     for mark in item.iter_markers(name="fluent_version"):
         spec = mark.args[0]
         # if a test is marked as fluent_version("latest")
@@ -122,6 +123,8 @@ def pytest_runtest_setup(item):
                 if is_nightly or is_solvermode_option
                 else f"=={fluent_release_version}"
             )
+        elif spec == "dev":
+            spec = f"=={fluent_dev_version}"
         version_specs.append(SpecifierSet(spec))
     if version_specs:
         combined_spec = functools.reduce(operator.and_, version_specs)

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -21,6 +21,9 @@ def _get_grpc_version_in_fluent_env():
     session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
     return session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")')
 
+def _is_pyconsole_activated(session):
+    return session.scheme_eval("(%cx-pyconsole-activated?)")
+
 
 # Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied
 # to the expected location in the Fluent container. To run this test, install PyFluent without the -e option.
@@ -43,12 +46,14 @@ def test_pyconsole_launch():
     src_pyfluent_dir = str(Path(pyfluent.__file__).parents[3])
     version_for_file_name = pyfluent.FluentVersion.current_dev().number
     dst_pyfluent_dir = f"/ansys_inc/v{version_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore"
-    print(f"src_pyfluent_dir: {src_pyfluent_dir}")
-    print(f"dst_pyfluent_dir: {dst_pyfluent_dir}")
-    container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True)
-    container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
-    session = pyfluent.launch_fluent(container_dict=container_dict, py=True)
-    import pdb
+    solver_container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True, py=True)
+    solver_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
+    solver_session = pyfluent.launch_fluent(container_dict=solver_container_dict)
+    assert solver_session is not None
+    assert _is_pyconsole_activated(solver_session) is True
 
-    pdb.set_trace()
-    assert session is not None
+    meshing_container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True, py=True, mode=pyfluent.FluentMode.MESHER)
+    meshing_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
+    meshing_session = pyfluent.launch_fluent(container_dict=meshing_container_dict)
+    assert meshing_session is not None
+    assert _is_pyconsole_activated(meshing_session) is True

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -21,6 +21,7 @@ def _get_grpc_version_in_fluent_env():
     session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
     return session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")')
 
+
 def _is_pyconsole_activated(session):
     return session.scheme_eval("(%cx-pyconsole-activated?)")
 
@@ -46,13 +47,17 @@ def test_pyconsole_launch():
     src_pyfluent_dir = str(Path(pyfluent.__file__).parents[3])
     version_for_file_name = pyfluent.FluentVersion.current_dev().number
     dst_pyfluent_dir = f"/ansys_inc/v{version_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore"
-    solver_container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True, py=True)
+    solver_container_dict = pyfluent.launch_fluent(
+        start_container=True, dry_run=True, py=True
+    )
     solver_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
     solver_session = pyfluent.launch_fluent(container_dict=solver_container_dict)
     assert solver_session is not None
     assert _is_pyconsole_activated(solver_session) is True
 
-    meshing_container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True, py=True, mode=pyfluent.FluentMode.MESHER)
+    meshing_container_dict = pyfluent.launch_fluent(
+        start_container=True, dry_run=True, py=True, mode=pyfluent.FluentMode.MESHER
+    )
     meshing_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
     meshing_session = pyfluent.launch_fluent(container_dict=meshing_container_dict)
     assert meshing_session is not None

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -85,7 +85,7 @@ def test_pyconsole_launch():
         start_container=True,
         dry_run=True,
         py=True,
-        mode=pyfluent.FluentMode.MESHER,
+        mode=pyfluent.FluentMode.MESHING,
         **grpc_kwds,
     )
     meshing_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -12,6 +12,7 @@ def _in_venv():
 
 def _get_grpc_version_in_pyfluent_env():
     import grpc
+
     return grpc.__version__
 
 
@@ -31,10 +32,13 @@ def test_pyconsole_launch():
     grpc_version_pyfluent = _get_grpc_version_in_pyfluent_env()
     grpc_version_fluent = _get_grpc_version_in_fluent_env()
     if grpc_version_pyfluent > grpc_version_fluent:
-        pytest.skip("gRPC version in PyFluent environment is higher than in Fluent environment. gRPC and related dependencies must be updated in Fluent environment.")
+        pytest.skip(
+            "gRPC version in PyFluent environment is higher than in Fluent environment. gRPC and related dependencies must be updated in Fluent environment."
+        )
     elif grpc_version_pyfluent < grpc_version_fluent:
-        pytest.skip("gRPC version in Fluent environment is higher than in PyFluent environment. gRPC and related dependencies must be updated in PyFluent environment.")
-
+        pytest.skip(
+            "gRPC version in Fluent environment is higher than in PyFluent environment. gRPC and related dependencies must be updated in PyFluent environment."
+        )
 
     src_pyfluent_dir = str(Path(pyfluent.__file__).parents[3])
     version_for_file_name = pyfluent.FluentVersion.current_dev().number
@@ -44,5 +48,7 @@ def test_pyconsole_launch():
     container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True)
     container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
     session = pyfluent.launch_fluent(container_dict=container_dict, py=True)
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     assert session is not None

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -26,6 +26,7 @@ import sys
 import pytest
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core.docker.utils import get_grpc_launcher_args_for_gh_runs
 
 
 def _in_venv():
@@ -38,8 +39,8 @@ def _get_grpc_version_in_pyfluent_env():
     return grpc.__version__
 
 
-def _get_grpc_version_in_fluent_env():
-    session = pyfluent.launch_fluent()
+def _get_grpc_version_in_fluent_env(launch_kwargs=None):
+    session = pyfluent.launch_fluent(**(launch_kwargs or {}))
     session.scheme.eval('(%py-exec "import grpc")')
     return session.scheme.eval('(%py-eval "grpc.__version__")')
 
@@ -55,8 +56,9 @@ def test_pyconsole_launch():
     if not _in_venv():
         pytest.skip("This test must be run in a virtual environment.")
 
+    grpc_kwds = get_grpc_launcher_args_for_gh_runs()
     grpc_version_pyfluent = _get_grpc_version_in_pyfluent_env()
-    grpc_version_fluent = _get_grpc_version_in_fluent_env()
+    grpc_version_fluent = _get_grpc_version_in_fluent_env(launch_kwargs=grpc_kwds)
     if grpc_version_pyfluent > grpc_version_fluent:
         pytest.skip(
             "gRPC version in PyFluent environment is higher than in Fluent environment. gRPC and related dependencies must be updated in Fluent environment."
@@ -70,17 +72,25 @@ def test_pyconsole_launch():
     version_for_file_name = pyfluent.FluentVersion.current_dev().number
     dst_pyfluent_dir = f"/ansys_inc/v{version_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore"
     solver_container_dict = pyfluent.launch_fluent(
-        start_container=True, dry_run=True, py=True
+        start_container=True, dry_run=True, py=True, **grpc_kwds
     )
     solver_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
-    solver_session = pyfluent.launch_fluent(container_dict=solver_container_dict)
+    solver_session = pyfluent.launch_fluent(
+        container_dict=solver_container_dict, **grpc_kwds
+    )
     assert solver_session is not None
     assert _is_pyconsole_activated(solver_session) is True
 
     meshing_container_dict = pyfluent.launch_fluent(
-        start_container=True, dry_run=True, py=True, mode=pyfluent.FluentMode.MESHER
+        start_container=True,
+        dry_run=True,
+        py=True,
+        mode=pyfluent.FluentMode.MESHER,
+        **grpc_kwds,
     )
     meshing_container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
-    meshing_session = pyfluent.launch_fluent(container_dict=meshing_container_dict)
+    meshing_session = pyfluent.launch_fluent(
+        container_dict=meshing_container_dict, **grpc_kwds
+    )
     assert meshing_session is not None
     assert _is_pyconsole_activated(meshing_session) is True

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -40,8 +40,8 @@ def _get_grpc_version_in_pyfluent_env():
 
 def _get_grpc_version_in_fluent_env():
     session = pyfluent.launch_fluent()
-    session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
-    return session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")')
+    session.scheme.eval('(%py-exec "import grpc")')
+    return session.scheme.eval('(%py-eval "grpc.__version__")')
 
 
 def _is_pyconsole_activated(session):

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+import ansys.fluent.core as pyfluent
+
+
+def _in_venv():
+    return sys.prefix != sys.base_prefix
+
+
+def _get_grpc_version_in_pyfluent_env():
+    import grpc
+    return grpc.__version__
+
+
+def _get_grpc_version_in_fluent_env():
+    session = pyfluent.launch_fluent()
+    session.scheme_eval.scheme_eval('(%py-exec "import grpc")')
+    return session.scheme_eval.scheme_eval('(%py-eval "grpc.__version__")')
+
+
+# Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied
+# to the expected location in the Fluent container. To run this test, install PyFluent without the -e option.
+@pytest.mark.fluent_version("dev")
+def test_pyconsole_launch():
+    if not _in_venv():
+        pytest.skip("This test must be run in a virtual environment.")
+
+    grpc_version_pyfluent = _get_grpc_version_in_pyfluent_env()
+    grpc_version_fluent = _get_grpc_version_in_fluent_env()
+    if grpc_version_pyfluent > grpc_version_fluent:
+        pytest.skip("gRPC version in PyFluent environment is higher than in Fluent environment. gRPC and related dependencies must be updated in Fluent environment.")
+    elif grpc_version_pyfluent < grpc_version_fluent:
+        pytest.skip("gRPC version in Fluent environment is higher than in PyFluent environment. gRPC and related dependencies must be updated in PyFluent environment.")
+
+
+    src_pyfluent_dir = str(Path(pyfluent.__file__).parents[3])
+    version_for_file_name = pyfluent.FluentVersion.current_dev().number
+    dst_pyfluent_dir = f"/ansys_inc/v{version_for_file_name}/commonfiles/CPython/3_10/linx64/Release/Ansys/PyFluentCore"
+    print(f"src_pyfluent_dir: {src_pyfluent_dir}")
+    print(f"dst_pyfluent_dir: {dst_pyfluent_dir}")
+    container_dict = pyfluent.launch_fluent(start_container=True, dry_run=True)
+    container_dict["volumes"].append(f"{src_pyfluent_dir}:{dst_pyfluent_dir}")
+    session = pyfluent.launch_fluent(container_dict=container_dict, py=True)
+    import pdb; pdb.set_trace()
+    assert session is not None

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -1,3 +1,25 @@
+# Copyright (C) 2021 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from pathlib import Path
 import sys
 

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -46,7 +46,7 @@ def _get_grpc_version_in_fluent_env(launch_kwargs=None):
 
 
 def _is_pyconsole_activated(session):
-    return session.scheme_eval("(%cx-pyconsole-activated?)")
+    return session.scheme.eval("(%cx-pyconsole-activated?)")
 
 
 # Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied


### PR DESCRIPTION
Add a test to verify PyConsole launch that will run with the PR CI so that any Fluent side incompatibility can be addressed before merging a PR. The test currently launches Fluent PyConsole in solver and meshing mode, however it can be extended to cover an end-to-end workflow.