### PR TITLE
build: Bump version to v0.39.1

### DIFF
--- a/doc/changelog.d/5193.dependencies.md
+++ b/doc/changelog.d/5193.dependencies.md
@@ -1,0 +1,1 @@
+Bump version to v0.39.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "ansys-api-fluent>=0.3.40",
+    "ansys-api-fluent>=0.3.40,<0.3.42",
     "ansys-platform-instancemanagement~=1.1",
     "ansys-tools-common>=0.4.0",
     "ansys-tools-filetransfer>=0.2,<1.0",

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -83,7 +83,7 @@ from ansys.fluent.core.utils.context_managers import using  # noqa: F401
 from ansys.fluent.core.utils.fluent_version import FluentVersion  # noqa: F401
 from ansys.fluent.core.utils.setup_for_fluent import setup_for_fluent  # noqa: F401
 
-__version__ = "0.39.0"
+__version__ = "0.39.1"
 
 _VERSION_INFO = None
 """


### PR DESCRIPTION
Bump version to v0.39.1

This contains the fix that is breaking PyFluent while being used with 27R1. This restricts the ansys-api-fluent version.
