### PR TITLE
build: Patch v0.39.1 to update ci to release without testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # required for trusted publishing

--- a/doc/changelog.d/5196.dependencies.md
+++ b/doc/changelog.d/5196.dependencies.md
@@ -1,0 +1,1 @@
+Patch v0.39.1 to update ci to release without testing.


### PR DESCRIPTION
Patch v0.39.1 to update ci to release without testing.
