### PR TITLE
feat: Activate filtering mechanism based on exposure level.

### DIFF
--- a/doc/changelog.d/5204.added.md
+++ b/doc/changelog.d/5204.added.md
@@ -1,1 +1,1 @@
-Activate filtering mechanism base on exposure level.
+Activate filtering mechanism based on exposure level.

--- a/doc/changelog.d/5204.added.md
+++ b/doc/changelog.d/5204.added.md
@@ -1,0 +1,1 @@
+Activate filtering mechanism base on exposure level.

--- a/doc/source/user_guide/solver_settings/solver_settings_contents.rst
+++ b/doc/source/user_guide/solver_settings/solver_settings_contents.rst
@@ -54,9 +54,17 @@ Accessing solver settings
 Exposure levels
 ---------------
 
-Some solver settings objects are marked as stable, beta, or alpha. By default,
-only stable objects are visible. Use ``settings.set_exposure_level()`` on the
-settings root to expose beta or alpha objects.
+Every solver settings object, command, query, and command/query argument has an
+assigned exposure level: alpha, beta, or stable. You can query a exposed settings
+object's assigned exposure level with the ``exposure_level`` attribute.
+
+.. code-block:: python
+
+  >>> solver_session.settings.setup.exposure_level
+  <ExposureLevel.STABLE: 'stable'>
+
+By default, only stable objects are exposed. Use ``settings.set_exposure_level()`` on
+the settings root to expose beta or alpha objects.
 
 .. code-block:: python
 

--- a/doc/source/user_guide/solver_settings/solver_settings_contents.rst
+++ b/doc/source/user_guide/solver_settings/solver_settings_contents.rst
@@ -77,6 +77,12 @@ The available levels are:
 - ``ExposureLevel.BETA``: Shows stable and beta objects.
 - ``ExposureLevel.ALPHA``: Shows stable, beta, and alpha objects.
 
+.. note::
+  Exposure level settings are strictly session-based: they are not retained or
+  carried over from one session to the next, and each new session defaults to
+  exposing only stable items unless a different exposure level is explicitly
+  configured for that session.
+
 Show beta objects
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/source/user_guide/solver_settings/solver_settings_contents.rst
+++ b/doc/source/user_guide/solver_settings/solver_settings_contents.rst
@@ -51,6 +51,61 @@ Accessing solver settings
   >>> results = solver_session.settings.results
 
 
+Exposure levels
+---------------
+
+Some solver settings objects are marked as stable, beta, or alpha. By default,
+only stable objects are visible. Use ``settings.set_exposure_level()`` on the
+settings root to expose beta or alpha objects.
+
+.. code-block:: python
+
+  >>> from ansys.fluent.core import ExposureLevel
+  >>> solver_session.settings.set_exposure_level(ExposureLevel.STABLE)
+
+The available levels are:
+
+- ``ExposureLevel.STABLE``: Shows only stable objects.
+- ``ExposureLevel.BETA``: Shows stable and beta objects.
+- ``ExposureLevel.ALPHA``: Shows stable, beta, and alpha objects.
+
+Show beta objects
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+  >>> from ansys.fluent.core import ExposureLevel
+  >>> solver_session.settings.set_exposure_level(ExposureLevel.BETA)
+
+After enabling beta exposure, beta settings objects, commands, queries, and
+command/query arguments become accessible.
+
+Show alpha objects
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+  >>> solver_session.settings.set_exposure_level(ExposureLevel.ALPHA)
+
+This also keeps beta objects visible.
+
+.. note::
+
+  - ``set_exposure_level()`` is available only on the settings root.
+
+  .. code-block:: python
+
+    >>> from ansys.fluent.core import ExposureLevel
+    >>> solver_session.settings.set_exposure_level(ExposureLevel.BETA)
+    >>> solver_session.settings.setup.set_exposure_level(ExposureLevel.BETA)
+    Traceback (most recent call last):
+    ...
+    AttributeError: ...
+
+  - If you try to access a hidden object before enabling the required exposure
+    level, an ``AttributeError`` is raised.
+
+
 Types of settings objects
 -------------------------
 

--- a/doc/source/user_guide/solver_settings/solver_settings_contents.rst
+++ b/doc/source/user_guide/solver_settings/solver_settings_contents.rst
@@ -55,7 +55,7 @@ Exposure levels
 ---------------
 
 Every solver settings object, command, query, and command/query argument has an
-assigned exposure level: alpha, beta, or stable. You can query a exposed settings
+assigned exposure level: alpha, beta, or stable. You can query an exposed settings
 object's assigned exposure level with the ``exposure_level`` attribute.
 
 .. code-block:: python

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -43,6 +43,7 @@ from ansys.fluent.core.services.batch_ops import *
 from ansys.fluent.core.session import *
 from ansys.fluent.core.session import BaseSession as Fluent
 from ansys.fluent.core.session_utilities import *
+from ansys.fluent.core.solver.flobject import ExposureLevel  # noqa: E402
 from ansys.fluent.core.streaming_services.events_streaming import *
 from ansys.fluent.core.streaming_services.events_streaming_v1 import *
 from ansys.fluent.core.utils import *

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -153,14 +153,7 @@ def _is_exposure_level_hidden(child_cls, parent_obj) -> bool:
     bool
         True if the child should be hidden from dir and attribute access; False otherwise.
     """
-    root = parent_obj._root
-    if getattr(root, "_alpha_activated", False):
-        min_visible = ExposureLevel.ALPHA
-    elif getattr(root, "_beta_activated", False):
-        min_visible = ExposureLevel.BETA
-    else:
-        min_visible = ExposureLevel.STABLE
-    return child_cls.exposure_level < min_visible
+    return child_cls.exposure_level < parent_obj._root._root_exposure_level
 
 
 def _set_exposure_level(self, level: ExposureLevel) -> None:
@@ -174,8 +167,7 @@ def _set_exposure_level(self, level: ExposureLevel) -> None:
         ``ExposureLevel.BETA`` also exposes beta objects.
         ``ExposureLevel.ALPHA`` exposes all objects.
     """
-    self._setattr("_alpha_activated", level == ExposureLevel.ALPHA)
-    self._setattr("_beta_activated", level == ExposureLevel.BETA)
+    self._setattr("_root_exposure_level", level)
 
 
 def _get_hidden_names(names, child_classes, obj) -> set:
@@ -2703,8 +2695,7 @@ def get_root(
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
-    root._setattr("_beta_activated", False)
-    root._setattr("_alpha_activated", False)
+    root._setattr("_root_exposure_level", ExposureLevel.STABLE)
     root._setattr("set_exposure_level", types.MethodType(_set_exposure_level, root))
     root._setattr("_file_transfer_service", file_transfer_service)
     return root

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -153,7 +153,7 @@ def _is_exposure_level_hidden(child_cls, parent_obj) -> bool:
     bool
         True if the child should be hidden from dir and attribute access; False otherwise.
     """
-    return child_cls.exposure_level < parent_obj._root._root_exposure_level
+    return child_cls.exposure_level < parent_obj._root._min_exposure_level
 
 
 def _set_exposure_level(self, level: ExposureLevel) -> None:
@@ -167,7 +167,7 @@ def _set_exposure_level(self, level: ExposureLevel) -> None:
         ``ExposureLevel.BETA`` also exposes beta objects.
         ``ExposureLevel.ALPHA`` exposes all objects.
     """
-    self._setattr("_root_exposure_level", level)
+    self._setattr("_min_exposure_level", level)
 
 
 def _get_hidden_names(names, child_classes, obj) -> set:
@@ -2695,7 +2695,7 @@ def get_root(
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
-    root._setattr("_root_exposure_level", ExposureLevel.STABLE)
+    root._setattr("_min_exposure_level", ExposureLevel.STABLE)
     root._setattr("set_exposure_level", types.MethodType(_set_exposure_level, root))
     root._setattr("_file_transfer_service", file_transfer_service)
     return root

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -138,7 +138,7 @@ class ExposureLevel(Enum):
         return NotImplemented
 
 
-def _is_exposure_level_hidden(child_cls, parent_obj) -> bool:
+def _is_hidden_by_exposure_level(child_cls, parent_obj) -> bool:
     """Whether a child settings class should be hidden based on exposure level.
 
     Parameters
@@ -153,7 +153,7 @@ def _is_exposure_level_hidden(child_cls, parent_obj) -> bool:
     bool
         True if the child should be hidden from dir and attribute access; False otherwise.
     """
-    return child_cls.exposure_level < parent_obj._root._min_exposure_level
+    return child_cls.exposure_level < parent_obj._root._global_exposure_level
 
 
 def _set_exposure_level(self, level: ExposureLevel) -> None:
@@ -167,7 +167,7 @@ def _set_exposure_level(self, level: ExposureLevel) -> None:
         ``ExposureLevel.BETA`` also exposes beta objects.
         ``ExposureLevel.ALPHA`` exposes all objects.
     """
-    self._setattr("_min_exposure_level", level)
+    self._setattr("_global_exposure_level", level)
 
 
 def _get_hidden_names(names, child_classes, obj) -> set:
@@ -175,7 +175,7 @@ def _get_hidden_names(names, child_classes, obj) -> set:
     hidden = set()
     for name in names:
         child_cls = child_classes.get(name)
-        if child_cls is not None and _is_exposure_level_hidden(child_cls, obj):
+        if child_cls is not None and _is_hidden_by_exposure_level(child_cls, obj):
             hidden.add(name)
         elif _is_deprecated(object.__getattribute__(obj, name)):
             hidden.add(name)
@@ -185,7 +185,7 @@ def _get_hidden_names(names, child_classes, obj) -> set:
 def _raise_if_exposure_hidden(name, child_classes, obj) -> None:
     """Raise AttributeError if name is hidden due to exposure level."""
     child_cls = child_classes.get(name)
-    if child_cls is not None and _is_exposure_level_hidden(child_cls, obj):
+    if child_cls is not None and _is_hidden_by_exposure_level(child_cls, obj):
         raise AttributeError(
             f"'{name}' is not available at the current exposure level. "
             f"Call 'set_exposure_level(ExposureLevel.BETA)' or "
@@ -1278,7 +1278,7 @@ class Group(SettingsBase[DictStateType]):
         child_classes = type(self)._child_classes
         for child_name in self.child_names:
             child_cls = child_classes.get(child_name)
-            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
                 continue
             child = getattr(self, child_name)
             if child.is_active() and not _is_deprecated(child):
@@ -1291,7 +1291,7 @@ class Group(SettingsBase[DictStateType]):
         child_classes = type(self)._child_classes
         for command_name in self.command_names:
             child_cls = child_classes.get(command_name)
-            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
                 continue
             command = getattr(self, command_name)
             if command.is_active() and not _is_deprecated(command):
@@ -1304,7 +1304,7 @@ class Group(SettingsBase[DictStateType]):
         child_classes = type(self)._child_classes
         for query_name in self.query_names:
             child_cls = child_classes.get(query_name)
-            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
                 continue
             query = getattr(self, query_name)
             if query.is_active() and not _is_deprecated(query):
@@ -2695,7 +2695,7 @@ def get_root(
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
-    root._setattr("_min_exposure_level", ExposureLevel.STABLE)
+    root._setattr("_global_exposure_level", ExposureLevel.STABLE)
     root._setattr("set_exposure_level", types.MethodType(_set_exposure_level, root))
     root._setattr("_file_transfer_service", file_transfer_service)
     return root

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -138,6 +138,70 @@ class ExposureLevel(Enum):
         return NotImplemented
 
 
+def _is_exposure_level_hidden(child_cls, parent_obj) -> bool:
+    """Whether a child settings class should be hidden based on exposure level.
+
+    Parameters
+    ----------
+    child_cls : type
+        The child settings class to check.
+    parent_obj : Base
+        The parent object instance, used to traverse to the root for activation flags.
+
+    Returns
+    -------
+    bool
+        True if the child should be hidden from dir and attribute access; False otherwise.
+    """
+    root = parent_obj._root
+    if getattr(root, "_alpha_activated", False):
+        min_visible = ExposureLevel.ALPHA
+    elif getattr(root, "_beta_activated", False):
+        min_visible = ExposureLevel.BETA
+    else:
+        min_visible = ExposureLevel.STABLE
+    return child_cls.exposure_level < min_visible
+
+
+def _set_exposure_level(self, level: ExposureLevel) -> None:
+    """Set the minimum exposure level for accessible settings objects.
+
+    Parameters
+    ----------
+    level : ExposureLevel
+        The minimum exposure level to make accessible.
+        ``ExposureLevel.STABLE`` (default) hides all beta and alpha objects.
+        ``ExposureLevel.BETA`` also exposes beta objects.
+        ``ExposureLevel.ALPHA`` exposes all objects.
+    """
+    self._setattr("_alpha_activated", level == ExposureLevel.ALPHA)
+    self._setattr("_beta_activated", level == ExposureLevel.BETA)
+
+
+def _get_hidden_names(names, child_classes, obj) -> set:
+    """Return names that should be hidden due to exposure level or deprecation."""
+    hidden = set()
+    for name in names:
+        child_cls = child_classes.get(name)
+        if child_cls is not None and _is_exposure_level_hidden(child_cls, obj):
+            hidden.add(name)
+        elif _is_deprecated(object.__getattribute__(obj, name)):
+            hidden.add(name)
+    return hidden
+
+
+def _raise_if_exposure_hidden(name, child_classes, obj) -> None:
+    """Raise AttributeError if name is hidden due to exposure level."""
+    child_cls = child_classes.get(name)
+    if child_cls is not None and _is_exposure_level_hidden(child_cls, obj):
+        raise AttributeError(
+            f"'{name}' is not available at the current exposure level. "
+            f"Call 'set_exposure_level(ExposureLevel.BETA)' or "
+            f"'set_exposure_level(ExposureLevel.ALPHA)' on the settings root "
+            f"to enable access to beta or alpha objects."
+        )
+
+
 class _InlineConstants:
     is_active = "active?"
     is_read_only = "read-only?"
@@ -1219,7 +1283,11 @@ class Group(SettingsBase[DictStateType]):
     def get_active_child_names(self):
         """Names of children that are currently active."""
         ret = []
+        child_classes = type(self)._child_classes
         for child_name in self.child_names:
+            child_cls = child_classes.get(child_name)
+            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+                continue
             child = getattr(self, child_name)
             if child.is_active() and not _is_deprecated(child):
                 ret.append(child_name)
@@ -1228,7 +1296,11 @@ class Group(SettingsBase[DictStateType]):
     def get_active_command_names(self):
         """Names of commands that are currently active."""
         ret = []
+        child_classes = type(self)._child_classes
         for command_name in self.command_names:
+            child_cls = child_classes.get(command_name)
+            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+                continue
             command = getattr(self, command_name)
             if command.is_active() and not _is_deprecated(command):
                 ret.append(command_name)
@@ -1237,7 +1309,11 @@ class Group(SettingsBase[DictStateType]):
     def get_active_query_names(self):
         """Names of queries that are currently active."""
         ret = []
+        child_classes = type(self)._child_classes
         for query_name in self.query_names:
+            child_cls = child_classes.get(query_name)
+            if child_cls is not None and _is_exposure_level_hidden(child_cls, self):
+                continue
             query = getattr(self, query_name)
             if query.is_active() and not _is_deprecated(query):
                 ret.append(query_name)
@@ -1245,13 +1321,12 @@ class Group(SettingsBase[DictStateType]):
 
     def __dir__(self):
         dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
-        return dir_list - set(
-            [
-                child
-                for child in self.child_names + self.command_names + self.query_names
-                if _is_deprecated(getattr(self, child))
-            ]
+        hidden = _get_hidden_names(
+            self.child_names + self.command_names + self.query_names,
+            type(self)._child_classes,
+            self,
         )
+        return dir_list - hidden
 
     def __getattribute__(self, name):
         # Avoiding server queries for static attributes
@@ -1262,6 +1337,9 @@ class Group(SettingsBase[DictStateType]):
             and self.is_active() is False
         ):
             raise InactiveObjectError(self.python_path)
+        _raise_if_exposure_hidden(
+            name, super().__getattribute__("_child_classes"), self
+        )
         try:
             return super().__getattribute__(name)
         except AttributeError as ex:
@@ -1462,6 +1540,21 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
     command_names = []
     query_names = []
     _child_aliases = {}
+
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        hidden = _get_hidden_names(
+            self.command_names + self.query_names, type(self)._child_classes, self
+        )
+        return dir_list - hidden
+
+    def __getattribute__(self, name):
+        if name in _static_class_attributes:
+            return super().__getattribute__(name)
+        _raise_if_exposure_hidden(
+            name, super().__getattribute__("_child_classes"), self
+        )
+        return super().__getattribute__(name)
 
     def _create_child_object(self, cname: str):
         ret = self._objects.get(cname)
@@ -1720,6 +1813,21 @@ class ListObject(SettingsBase[ListStateType], Generic[ChildTypeT]):
     query_names = []
     _child_aliases = {}
 
+    def __dir__(self):
+        dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
+        hidden = _get_hidden_names(
+            self.command_names + self.query_names, type(self)._child_classes, self
+        )
+        return dir_list - hidden
+
+    def __getattribute__(self, name):
+        if name in _static_class_attributes:
+            return super().__getattribute__(name)
+        _raise_if_exposure_hidden(
+            name, super().__getattribute__("_child_classes"), self
+        )
+        return super().__getattribute__(name)
+
     def _update_objects(self):
         cls = self.__class__.child_object_type
         self._setattr(
@@ -1901,13 +2009,16 @@ class Action(Base):
 
     def __dir__(self):
         dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
-        return dir_list - set(
-            [
-                child
-                for child in self.argument_names
-                if _is_deprecated(getattr(self, child))
-            ]
+        hidden = _get_hidden_names(self.argument_names, type(self)._child_classes, self)
+        return dir_list - hidden
+
+    def __getattribute__(self, name):
+        if name in _static_class_attributes:
+            return super().__getattribute__(name)
+        _raise_if_exposure_hidden(
+            name, super().__getattribute__("_child_classes"), self
         )
+        return super().__getattribute__(name)
 
     def __getattr__(self, name: str):
         alias = self._child_aliases.get(name)
@@ -2592,6 +2703,9 @@ def get_root(
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval
+    root._setattr("_beta_activated", False)
+    root._setattr("_alpha_activated", False)
+    root._setattr("set_exposure_level", types.MethodType(_set_exposure_level, root))
     root._setattr("_file_transfer_service", file_transfer_service)
     return root
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -153,7 +153,9 @@ def _is_hidden_by_exposure_level(child_cls, parent_obj) -> bool:
     bool
         True if the child should be hidden from dir and attribute access; False otherwise.
     """
-    return child_cls.exposure_level < parent_obj._root._global_exposure_level
+    return child_cls.exposure_level < getattr(
+        parent_obj._root, "_global_exposure_level", ExposureLevel.STABLE
+    )
 
 
 def _set_exposure_level(self, level: ExposureLevel) -> None:

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -29,11 +29,11 @@ import weakref
 import pytest
 from test_utils import MockTracingInterceptor, count_key_recursive
 
+from ansys.fluent.core import ExposureLevel
 from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.services.interceptors import TracingInterceptor
 from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.solver.flobject import (
-    ExposureLevel,
     InactiveObjectError,
     _gethash,
     find_children,

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -33,6 +33,7 @@ from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.services.interceptors import TracingInterceptor
 from ansys.fluent.core.solver import flobject
 from ansys.fluent.core.solver.flobject import (
+    ExposureLevel,
     InactiveObjectError,
     _gethash,
     find_children,
@@ -604,6 +605,541 @@ def test_attrs():
     assert not r.g_1.s_4.get_attr("active?")
     with pytest.raises(InactiveObjectError):
         r.g_1.s_4.get_attr("allowed-values")
+
+
+def test_exposure_level_filtering(monkeypatch):
+    """Test that beta/alpha objects are hidden by default and revealed by activation."""
+    from ansys.fluent.core.module_config import config
+
+    monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
+
+    class ExposureRoot(Group):
+        children = {
+            "stable-child": Real,
+            "beta-child": Real,
+            "alpha-child": Real,
+        }
+
+        @classmethod
+        def get_static_info(cls):
+            return {
+                "type": "group",
+                "children": {
+                    "stable-child": {"type": "real"},
+                    "beta-child": {"type": "real", "api_exposure_level": "beta"},
+                    "alpha-child": {"type": "real", "api_exposure_level": "alpha"},
+                },
+            }
+
+    class ExposureProxy(Proxy):
+        root = ExposureRoot
+
+    r = flobject.get_root(ExposureProxy(), version="271")
+
+    assert "set_exposure_level" in dir(r)
+
+    # Default state
+    assert "stable_child" in dir(r)
+    assert "beta_child" not in dir(r)
+    assert "alpha_child" not in dir(r)
+
+    with pytest.raises(AttributeError):
+        _ = r.beta_child
+    with pytest.raises(AttributeError):
+        _ = r.alpha_child
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+    assert "beta_child" in dir(r)
+    assert "alpha_child" not in dir(r)
+    assert r.beta_child
+    with pytest.raises(AttributeError):
+        _ = r.alpha_child
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+    assert "beta_child" in dir(r)
+    assert "alpha_child" in dir(r)
+    assert r.beta_child
+    assert r.alpha_child
+
+    # Again stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+    assert "beta_child" not in dir(r)
+    assert "alpha_child" not in dir(r)
+
+    # Class generation is unaffected
+    root_cls = type(r)
+    assert root_cls.__name__ == "root"
+    root_child_classes = root_cls._child_classes
+    assert "stable_child" in root_child_classes
+    assert "beta_child" in root_child_classes
+    assert "alpha_child" in root_child_classes
+    assert root_child_classes["stable_child"].exposure_level == ExposureLevel.STABLE
+    assert root_child_classes["beta_child"].exposure_level == ExposureLevel.BETA
+    assert root_child_classes["alpha_child"].exposure_level == ExposureLevel.ALPHA
+
+
+def test_exposure_level_filtering_named_object_commands(monkeypatch):
+    """Test that beta/alpha commands and queries on NamedObject and ListObject are filtered."""
+    from ansys.fluent.core.module_config import config
+
+    monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
+
+    class ExposureNamedRoot(Group):
+        @classmethod
+        def get_static_info(cls):
+            return {
+                "type": "group",
+                "children": {
+                    "n-1": {
+                        "type": "named-object",
+                        "user_creatable": True,
+                        "object-type": {"type": "group"},
+                        "commands": {
+                            "stable-cmd": {"type": "command", "arguments": {}},
+                            "beta-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                            "alpha-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                    },
+                    "l-1": {
+                        "type": "list-object",
+                        "object-type": {"type": "group"},
+                        "commands": {
+                            "stable-cmd": {"type": "command", "arguments": {}},
+                            "beta-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                        },
+                    },
+                },
+            }
+
+    class ExposureProxy(Proxy):
+        root = ExposureNamedRoot
+
+    r = flobject.get_root(ExposureProxy(), version="271")
+
+    # Default state
+    assert "stable_cmd" in dir(r.n_1)
+    assert "beta_cmd" not in dir(r.n_1)
+    assert "alpha_cmd" not in dir(r.n_1)
+    with pytest.raises(AttributeError):
+        _ = r.n_1.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.n_1.alpha_cmd
+
+    assert "stable_cmd" in dir(r.l_1)
+    assert "beta_cmd" not in dir(r.l_1)
+    with pytest.raises(AttributeError):
+        _ = r.l_1.beta_cmd
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+    assert "beta_cmd" in dir(r.n_1)
+    assert "alpha_cmd" not in dir(r.n_1)
+    assert r.n_1.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.n_1.alpha_cmd
+    assert "beta_cmd" in dir(r.l_1)
+    assert r.l_1.beta_cmd
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+    assert "alpha_cmd" in dir(r.n_1)
+    assert r.n_1.alpha_cmd
+    assert r.n_1.beta_cmd
+    assert r.l_1.beta_cmd
+
+
+def test_exposure_level_filtering_complete_hierarchy(monkeypatch):
+    """Test exposure-level filtering across a complete hierarchy."""
+    from ansys.fluent.core.module_config import config
+
+    monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
+
+    class _StubCmd(Command):
+        """Stub command/query for proxy-side is_active() resolution."""
+
+        arguments = {}
+
+        def cb(self):
+            pass
+
+    class CompleteHierarchyRoot(Group):
+        class SomeNamedObj(NamedObject):
+            class NOType(Group):
+                children = {}
+
+            child_object_type = NOType
+
+        children = {
+            "stable-param": Real,
+            "beta-param": Real,
+            "alpha-param": Real,
+            "named-obj": SomeNamedObj,
+        }
+        commands = {
+            "stable-cmd": _StubCmd,
+            "beta-cmd": _StubCmd,
+            "alpha-cmd": _StubCmd,
+            "stable-qry": _StubCmd,
+            "beta-qry": _StubCmd,
+            "alpha-qry": _StubCmd,
+        }
+
+        @classmethod
+        def get_static_info(cls):
+            return {
+                "type": "group",
+                "children": {
+                    "stable-param": {"type": "real"},
+                    "beta-param": {"type": "real", "api_exposure_level": "beta"},
+                    "alpha-param": {"type": "real", "api_exposure_level": "alpha"},
+                    "named-obj": {
+                        "type": "named-object",
+                        "user_creatable": True,
+                        "object-type": {"type": "group"},
+                        "commands": {
+                            "stable-cmd": {"type": "command", "arguments": {}},
+                            "beta-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                            "alpha-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                        "queries": {
+                            "stable-qry": {"type": "query", "arguments": {}},
+                            "beta-qry": {
+                                "type": "query",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                            "alpha-qry": {
+                                "type": "query",
+                                "arguments": {},
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                    },
+                },
+                "commands": {
+                    "stable-cmd": {"type": "command", "arguments": {}},
+                    "beta-cmd": {
+                        "type": "command",
+                        "arguments": {},
+                        "api_exposure_level": "beta",
+                    },
+                    "alpha-cmd": {
+                        "type": "command",
+                        "arguments": {},
+                        "api_exposure_level": "alpha",
+                    },
+                },
+                "queries": {
+                    "stable-qry": {"type": "query", "arguments": {}},
+                    "beta-qry": {
+                        "type": "query",
+                        "arguments": {},
+                        "api_exposure_level": "beta",
+                    },
+                    "alpha-qry": {
+                        "type": "query",
+                        "arguments": {},
+                        "api_exposure_level": "alpha",
+                    },
+                },
+            }
+
+    class CompleteProxy(Proxy):
+        root = CompleteHierarchyRoot
+
+    r = flobject.get_root(CompleteProxy(), version="271")
+    no = r.named_obj
+
+    # Default state
+    assert "stable_param" in dir(r)
+    assert "beta_param" not in dir(r)
+    assert "alpha_param" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_param
+    with pytest.raises(AttributeError):
+        _ = r.alpha_param
+
+    assert "stable_cmd" in dir(r)
+    assert "beta_cmd" not in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.alpha_cmd
+
+    assert "stable_qry" in dir(r)
+    assert "beta_qry" not in dir(r)
+    assert "alpha_qry" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_qry
+    with pytest.raises(AttributeError):
+        _ = r.alpha_qry
+
+    assert "stable_cmd" in dir(no)
+    assert "beta_cmd" not in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    with pytest.raises(AttributeError):
+        _ = no.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = no.alpha_cmd
+
+    assert "stable_qry" in dir(no)
+    assert "beta_qry" not in dir(no)
+    assert "alpha_qry" not in dir(no)
+    with pytest.raises(AttributeError):
+        _ = no.beta_qry
+    with pytest.raises(AttributeError):
+        _ = no.alpha_qry
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+
+    assert "beta_param" in dir(r)
+    assert "alpha_param" not in dir(r)
+    assert r.beta_param
+    with pytest.raises(AttributeError):
+        _ = r.alpha_param
+
+    assert "beta_cmd" in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    assert r.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.alpha_cmd
+
+    assert "beta_qry" in dir(r)
+    assert "alpha_qry" not in dir(r)
+    assert r.beta_qry
+    with pytest.raises(AttributeError):
+        _ = r.alpha_qry
+
+    assert "beta_cmd" in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    assert no.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = no.alpha_cmd
+
+    assert "beta_qry" in dir(no)
+    assert "alpha_qry" not in dir(no)
+    assert no.beta_qry
+    with pytest.raises(AttributeError):
+        _ = no.alpha_qry
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+
+    assert "beta_param" in dir(r)
+    assert "alpha_param" in dir(r)
+    assert "beta_cmd" in dir(r)
+    assert "alpha_cmd" in dir(r)
+    assert "beta_qry" in dir(r)
+    assert "alpha_qry" in dir(r)
+    assert r.beta_param
+    assert r.alpha_param
+    assert r.beta_cmd
+    assert r.alpha_cmd
+    assert r.beta_qry
+    assert r.alpha_qry
+
+    assert "beta_cmd" in dir(no)
+    assert "alpha_cmd" in dir(no)
+    assert "beta_qry" in dir(no)
+    assert "alpha_qry" in dir(no)
+    assert no.beta_cmd
+    assert no.alpha_cmd
+    assert no.beta_qry
+    assert no.alpha_qry
+
+    # Back to stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+
+    assert "beta_param" not in dir(r)
+    assert "alpha_param" not in dir(r)
+    assert "beta_cmd" not in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    assert "beta_qry" not in dir(r)
+    assert "alpha_qry" not in dir(r)
+
+    assert "beta_cmd" not in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    assert "beta_qry" not in dir(no)
+    assert "alpha_qry" not in dir(no)
+
+    assert "stable_param" in dir(r)
+    assert "stable_cmd" in dir(r)
+    assert "stable_qry" in dir(r)
+    assert "stable_cmd" in dir(no)
+    assert "stable_qry" in dir(no)
+    assert r.stable_param
+    assert r.stable_cmd
+    assert r.stable_qry
+    assert no.stable_cmd
+    assert no.stable_qry
+
+    assert "set_exposure_level" in dir(r)
+    assert "set_exposure_level" not in dir(no)
+    with pytest.raises(AttributeError):
+        no.set_exposure_level(ExposureLevel.BETA)
+
+    r.set_exposure_level(ExposureLevel.STABLE)
+
+    active_params = r.get_active_child_names()
+    assert "stable_param" in active_params
+    assert "beta_param" not in active_params
+    assert "alpha_param" not in active_params
+
+    active_cmds = r.get_active_command_names()
+    assert "stable_cmd" in active_cmds
+    assert "beta_cmd" not in active_cmds
+    assert "alpha_cmd" not in active_cmds
+
+    active_qrys = r.get_active_query_names()
+    assert "stable_qry" in active_qrys
+    assert "beta_qry" not in active_qrys
+    assert "alpha_qry" not in active_qrys
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+    active_params = r.get_active_child_names()
+    assert "beta_param" in active_params
+    assert "alpha_param" not in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" in active_cmds
+    assert "alpha_cmd" not in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" in active_qrys
+    assert "alpha_qry" not in active_qrys
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+    active_params = r.get_active_child_names()
+    assert "beta_param" in active_params
+    assert "alpha_param" in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" in active_cmds
+    assert "alpha_cmd" in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" in active_qrys
+    assert "alpha_qry" in active_qrys
+
+    # Back to stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+    active_params = r.get_active_child_names()
+    assert "beta_param" not in active_params
+    assert "alpha_param" not in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" not in active_cmds
+    assert "alpha_cmd" not in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" not in active_qrys
+    assert "alpha_qry" not in active_qrys
+
+
+def test_exposure_level_filtering_command_arguments(monkeypatch):
+    """Test that beta/alpha command and query arguments are filtered by exposure level."""
+    from ansys.fluent.core.module_config import config
+
+    monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
+
+    class ArgsRoot(Group):
+        @classmethod
+        def get_static_info(cls):
+            return {
+                "type": "group",
+                "commands": {
+                    "my-cmd": {
+                        "type": "command",
+                        "arguments": {
+                            "stable-arg": {"type": "real"},
+                            "beta-arg": {"type": "real", "api_exposure_level": "beta"},
+                            "alpha-arg": {
+                                "type": "real",
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                    },
+                },
+                "queries": {
+                    "my-qry": {
+                        "type": "query",
+                        "arguments": {
+                            "stable-arg": {"type": "real"},
+                            "beta-arg": {"type": "real", "api_exposure_level": "beta"},
+                            "alpha-arg": {
+                                "type": "real",
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                    },
+                },
+            }
+
+    class ArgsProxy(Proxy):
+        root = ArgsRoot
+
+    r = flobject.get_root(ArgsProxy(), version="271")
+    cmd = r.my_cmd
+    qry = r.my_qry
+
+    for action in (cmd, qry):
+        # Default state
+        assert "stable_arg" in dir(action)
+        assert "beta_arg" not in dir(action)
+        assert "alpha_arg" not in dir(action)
+        with pytest.raises(AttributeError):
+            _ = action.beta_arg
+        with pytest.raises(AttributeError):
+            _ = action.alpha_arg
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+    for action in (cmd, qry):
+        assert "beta_arg" in dir(action)
+        assert "alpha_arg" not in dir(action)
+        assert action.beta_arg
+        with pytest.raises(AttributeError):
+            _ = action.alpha_arg
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+    for action in (cmd, qry):
+        assert "beta_arg" in dir(action)
+        assert "alpha_arg" in dir(action)
+        assert action.beta_arg
+        assert action.alpha_arg
+
+    # Back to stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+    for action in (cmd, qry):
+        assert "beta_arg" not in dir(action)
+        assert "alpha_arg" not in dir(action)
+        with pytest.raises(AttributeError):
+            _ = action.beta_arg
+        with pytest.raises(AttributeError):
+            _ = action.alpha_arg
+        assert "stable_arg" in dir(action)
+        assert action.stable_arg
 
 
 # The following test is commented out as codegen module is not packaged in the


### PR DESCRIPTION
## Context
The 'exposure_level' tag was part of the object hierarchy already but there was no mechanism to filter the objects based on this exposure level tag.

## Change Summary
Introduced a filtering mechanism based on the exposure level flags on each object.
The dir and getattribute methods have been implemented at each level for active filtering.

## Rationale
To hide alpha and beta settings objects by default, unless activated by user.

## Impact
The settings hierarchy.

See doc updates and tests for details.

<img width="832" height="822" alt="image" src="https://github.com/user-attachments/assets/94ce3fe2-2e91-4e2a-8782-f91da1b6ac7a" />

