### PR TITLE
ci: Deploy release docs only when a tag is pushed [skip tests]

### DIFF
--- a/.github/workflows/doc-build-release.yml
+++ b/.github/workflows/doc-build-release.yml
@@ -106,6 +106,7 @@ jobs:
     name: "Deploy Release Documentation"
     runs-on: public-ubuntu-latest-8-cores
     needs: [build_release_docs]
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write # Required to push release documentation updates to the target repository/branch.
       pull-requests: write # Required when deployment action creates or updates pull requests.

--- a/doc/changelog.d/5205.maintenance.md
+++ b/doc/changelog.d/5205.maintenance.md
@@ -1,1 +1,1 @@
-Deploy release docs only when a tag is pushed.
+Deploy release docs only when a tag is pushed [skip tests]

--- a/doc/changelog.d/5205.maintenance.md
+++ b/doc/changelog.d/5205.maintenance.md
@@ -1,0 +1,1 @@
+Deploy release docs only when a tag is pushed.


### PR DESCRIPTION
Deploy release docs only when a tag is pushed.
