### PR TITLE
fix: Boolean to Allowed Strings [skip tests]

### DIFF
--- a/doc/changelog.d/5213.fixed.md
+++ b/doc/changelog.d/5213.fixed.md
@@ -1,1 +1,1 @@
-Boolean to Allowed Strings
+Boolean to Allowed Strings [skip tests]

--- a/doc/changelog.d/5213.fixed.md
+++ b/doc/changelog.d/5213.fixed.md
@@ -1,0 +1,1 @@
+Boolean to Allowed Strings

--- a/examples/00-fluent/frozen_rotor_workflow.py
+++ b/examples/00-fluent/frozen_rotor_workflow.py
@@ -76,6 +76,12 @@ Impeller-Volute simulation using the Frozen Rotor Approach
 # *Saving the case file
 # *Closing the solver
 
+
+# .. note::
+# This example has been verified and validated using Ansys Fluent 2026 R1.
+# It is recommended to run this example with the same version.
+
+
 ################################################################################################################
 # Import required libraries/modules
 # ==============================================================================================================

--- a/examples/00-fluent/frozen_rotor_workflow.py
+++ b/examples/00-fluent/frozen_rotor_workflow.py
@@ -76,6 +76,10 @@ Impeller-Volute simulation using the Frozen Rotor Approach
 # *Saving the case file
 # *Closing the solver
 
+# .. note::
+# This example has been verified and validated using Ansys Fluent 2026 R1.
+# It is recommended to run this example with the same version.
+
 ################################################################################################################
 # Import required libraries/modules
 # ==============================================================================================================

--- a/examples/00-fluent/frozen_rotor_workflow.py
+++ b/examples/00-fluent/frozen_rotor_workflow.py
@@ -77,8 +77,9 @@ Impeller-Volute simulation using the Frozen Rotor Approach
 # *Closing the solver
 
 # .. note::
-# This example has been verified and validated using Ansys Fluent 2026 R1.
-# It is recommended to run this example with the same version.
+# This example has been verified and validated using Ansys Fluent 2025 R2.
+# It requires Ansys Fluent version 2025 R2 or later, as it uses features that are not available in 
+# earlier versions.
 
 ################################################################################################################
 # Import required libraries/modules

--- a/examples/00-fluent/frozen_rotor_workflow.py
+++ b/examples/00-fluent/frozen_rotor_workflow.py
@@ -232,7 +232,7 @@ impeller_hub = solver_session.settings.setup.boundary_conditions.wall[
     "impeller-hub"
 ].momentum
 impeller_hub.wall_motion = "Moving Wall"
-impeller_hub.relative = True
+impeller_hub.relative = "Relative to Adjacent Cell Zone"
 impeller_hub.velocity_spec = "Rotational"
 
 #  inblock-shroud
@@ -241,7 +241,7 @@ inblock_shroud = solver_session.settings.setup.boundary_conditions.wall[
     "inblock-shroud"
 ].momentum
 inblock_shroud.wall_motion = "Moving Wall"
-inblock_shroud.relative = False
+inblock_shroud.relative = "Absolute"
 inblock_shroud.velocity_spec = "Rotational"
 
 ################################################################################################################

--- a/examples/00-fluent/frozen_rotor_workflow.py
+++ b/examples/00-fluent/frozen_rotor_workflow.py
@@ -78,7 +78,7 @@ Impeller-Volute simulation using the Frozen Rotor Approach
 
 # .. note::
 # This example has been verified and validated using Ansys Fluent 2025 R2.
-# It requires Ansys Fluent version 2025 R2 or later, as it uses features that are not available in 
+# It requires Ansys Fluent version 2025 R2 or later, as it uses features that are not available in
 # earlier versions.
 
 ################################################################################################################


### PR DESCRIPTION
## Context
The existing implementation of wall motion used Boolean values (True/False) for the relative attribute in boundary condition setup:

``` python

impeller_hub.relative = True
inblock_shroud.relative = False

```
However, this approach does not align with the latest PyFluent API design. The relative field is not a Boolean, but a string-based setting with restricted allowed values. Using Booleans obscures the intended reference frame selection and can lead to incorrect or ambiguous physical interpretation in MRF/Frozen Rotor simulations.

## Change Summary
Updated the relative attribute from Boolean values to their corresponding explicit API options "Define wall motion relative to adjacent cell zone."

["Relative to Adjacent Cell Zone", "Absolute"]

## Rationale
The update aligns with the latest PyFluent API specification, where:

relative is defined as a String with AllowedValuesMixin
Valid values include:

"Relative to Adjacent Cell Zone"
"Absolute"

Reference: https://fluent.docs.pyansys.com/version/stable/api/solver/_autosummary/settings/relative.html#relative

## Impact
✅ Removes ambiguity introduced by Boolean mapping, earlier not transparent.
✅ Makes the code consistent with Fluent GUI terminology.
✅ Improves readability and maintainability.
✅ Prevents incorrect interpretation of reference frames in rotating machinery simulations.