### PR TITLE
ci: Pin test dependencies relevant to docs and tests.

### DIFF
--- a/doc/changelog.d/5235.maintenance.md
+++ b/doc/changelog.d/5235.maintenance.md
@@ -1,0 +1,1 @@
+Pin test dependencies relevant to docs and tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
     "defusedxml>=0.7.1",
     "deprecated>=1.2.18",
     "docker>=7.1.0",
-    "grpcio>=1.30.0",
-    "grpcio-health-checking>=1.30.0",
-    "grpcio-status>=1.26.0",
-    "grpcio-reflection>=1.30.0",
+    "grpcio>=1.30.0,<1.82.0",
+    "grpcio-health-checking>=1.30.0,<1.82.0",
+    "grpcio-status>=1.26.0,<1.82.0",
+    "grpcio-reflection>=1.30.0,<1.82.0",
     "numpy>=1.14.0,<3.0.0",
     "pandas>=1.1.0,<3.0.0",
     "pandas-stubs>=1.1.0,<3.0.0",
@@ -51,7 +51,8 @@ tests = [
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",
     "pytest-xdist==3.8.0",
-    "pyfakefs==6.2.0"
+    "pyfakefs==6.2.0",
+    { include-group = "general-all" },
 ]
 docs = [
     "Sphinx==8.1.3",
@@ -77,7 +78,18 @@ docs = [
     "python-pptx>=0.6.23",
     "quarto-cli==1.9.38",
     "pdf2image==1.17.0",
-    "seaborn>=0.13.2"
+    "seaborn>=0.13.2",
+    { include-group = "general-all" },
+]
+general-all = [
+  "ansys-platform-instancemanagement==1.1.2",
+  "ansys-tools-common==0.5.1",
+  "docker==7.1.0",
+  "grpcio==1.81.1",
+  "grpcio-health-checking==1.81.1",
+  "grpcio-status==1.81.1",
+  "grpcio-reflection==1.81.1",
+  "numpy==2.5.0",
 ]
 ci_types = [
     "basedpyright==1.39.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,14 @@ tests = [
     "pytest-mock==3.15.1",
     "pytest-xdist==3.8.0",
     "pyfakefs==6.2.0",
-    { include-group = "general-all" },
+    "ansys-platform-instancemanagement==1.1.2",
+    "ansys-tools-common==0.5.1",
+    "docker==7.1.0",
+    "grpcio==1.81.1",
+    "grpcio-health-checking==1.81.1",
+    "grpcio-status==1.81.1",
+    "grpcio-reflection==1.81.1",
+    "numpy==2.5.0",
 ]
 docs = [
     "Sphinx==8.1.3",
@@ -79,17 +86,14 @@ docs = [
     "quarto-cli==1.9.38",
     "pdf2image==1.17.0",
     "seaborn>=0.13.2",
-    { include-group = "general-all" },
-]
-general-all = [
-  "ansys-platform-instancemanagement==1.1.2",
-  "ansys-tools-common==0.5.1",
-  "docker==7.1.0",
-  "grpcio==1.81.1",
-  "grpcio-health-checking==1.81.1",
-  "grpcio-status==1.81.1",
-  "grpcio-reflection==1.81.1",
-  "numpy==2.5.0",
+    "ansys-platform-instancemanagement==1.1.2",
+    "ansys-tools-common==0.5.1",
+    "docker==7.1.0",
+    "grpcio==1.81.1",
+    "grpcio-health-checking==1.81.1",
+    "grpcio-status==1.81.1",
+    "grpcio-reflection==1.81.1",
+    "numpy==2.5.0",
 ]
 ci_types = [
     "basedpyright==1.39.8",


### PR DESCRIPTION
## Context
Dependencies need to be specifically pinned for tests and doc as we are testing the CICD with those optional dependencies.

(+ An additional dependency for limiting the grpc version  as per Roberto's comment in the related issue).

## Change Summary
Pinned test and doc dependencies.
Set upper limit for grpc based dependencies.