### PR TITLE
chore: Update omw to 2.0 from 1.4 for nltk.

### DIFF
--- a/doc/changelog.d/5241.maintenance.md
+++ b/doc/changelog.d/5241.maintenance.md
@@ -1,0 +1,1 @@
+Update omw to 2.0 from 1.4 for nltk.

--- a/doc/changelog.d/5241.maintenance.md
+++ b/doc/changelog.d/5241.maintenance.md
@@ -1,1 +1,1 @@
-Update omw to 2.0 from 1.4 for nltk.
+Update omw to 2.0 from 1.4 for nltk data download.

--- a/doc/changelog.d/5241.maintenance.md
+++ b/doc/changelog.d/5241.maintenance.md
@@ -1,1 +1,1 @@
-Update omw to 2.0 from 1.4 for nltk data download.
+Update omw to 2.0 from 1.4 for nltk.

--- a/src/ansys/fluent/core/search.py
+++ b/src/ansys/fluent/core/search.py
@@ -386,7 +386,7 @@ def _download_nltk_data():
     else:
         ssl._create_default_https_context = _create_unverified_context
 
-    packages = ["wordnet", "omw-1.4"]
+    packages = ["wordnet", "omw-2.0"]
     for package in packages:
         nltk.download(
             package,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -41,7 +41,7 @@ from ansys.fluent.core.search import (
 def test_nltk_data_download():
     import nltk
 
-    packages = ["wordnet", "omw-1.4"]
+    packages = ["wordnet", "omw-2.0"]
     for package in packages:
         nltk.download(package, quiet=True)
 


### PR DESCRIPTION
## Context
Recently started getting the below error in our test run:
```
tests/test_search.py::test_chinese_semantic_search - LookupError: ********************************************************************** Resource 'omw-2.0' not found. Please use the NLTK Downloader to obtain the resource: >>> import nltk >>> nltk.download('omw-2.0')
```

## Change Summary
Use omw 2.0 instead of 1.4

## Impact
None
