### PR TITLE
fix: Fluent's idle timeout setup.

### DIFF
--- a/doc/changelog.d/5254.fixed.md
+++ b/doc/changelog.d/5254.fixed.md
@@ -1,0 +1,1 @@
+Fluent's idle timeout setup.

--- a/src/ansys/fluent/core/_grpc_services/application_runtime_service.py
+++ b/src/ansys/fluent/core/_grpc_services/application_runtime_service.py
@@ -270,3 +270,15 @@ class ApplicationRuntimeService(ServiceProtocol):
         request = application_runtime_pb2.SetWorkingDirectoryRequest()
         request.path = os.fspath(path)
         self._stub.SetWorkingDirectory(request, metadata=self._metadata)
+
+    def set_idle_timeout(self, timeout: int) -> None:
+        """Set the Fluent session idle timeout.
+
+        Parameters
+        ----------
+        timeout : int
+            Idle timeout duration in seconds. Pass 0 to disable the idle timeout.
+        """
+        request = application_runtime_pb2.SetIdleTimeoutRequest()
+        request.timeout.seconds = timeout
+        self._stub.SetIdleTimeout(request, metadata=self._metadata)

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -280,9 +280,12 @@ class StandaloneLauncher:
     @staticmethod
     def _disable_idle_timeout_guard(session):
         try:
-            session.application_runtime.set_idle_timeout(
-                session.preferences.General.IdleTimeout() * 60
-            )
+            default_idle_timeout = session.preferences.General.IdleTimeout()
+        except RuntimeError:
+            # This exception is raised only while running codegen locally before the preferences root is available.
+            default_idle_timeout = 0
+        try:
+            session.application_runtime.set_idle_timeout(default_idle_timeout * 60)
         except Exception as ex:
             raise RuntimeError("Could not reset Idle Timeout") from ex
 

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -280,16 +280,11 @@ class StandaloneLauncher:
     @staticmethod
     def _disable_idle_timeout_guard(session):
         try:
-            if session.get_fluent_version() >= FluentVersion.v271:
-                session._app_utilities.set_idle_timeout(
-                    session.preferences.General.IdleTimeout() * 60
-                )
-            else:
-                session.scheme_eval.eval(
-                    f"(set-session-idle-timeout {session.preferences.General.IdleTimeout()})"
-                )
+            session.application_runtime.set_idle_timeout(
+                session.preferences.General.IdleTimeout() * 60
+            )
         except Exception as ex:
-            logger.debug(f"Could not reset Idle Timeout: {ex}")
+            raise RuntimeError("Could not reset Idle Timeout") from ex
 
     def __call__(
         self,

--- a/src/ansys/fluent/core/services/abstract_application_runtime.py
+++ b/src/ansys/fluent/core/services/abstract_application_runtime.py
@@ -78,6 +78,48 @@ class AbstractApplicationRuntime(ABC):
         pass
 
     @abstractmethod
+    def get_dimension(self) -> Enum:
+        """Get dimension."""
+        pass
+
+    @abstractmethod
+    def get_precision(self) -> Enum:
+        """Get precision."""
+        pass
+
+    @abstractmethod
+    def get_processor_count(self) -> int:
+        """Get processor count."""
+        pass
+
+    @abstractmethod
+    def get_ui_mode(self) -> Enum:
+        """Get UI mode."""
+        pass
+
+    @abstractmethod
+    def get_graphics_driver(self) -> Enum:
+        """Get graphics driver.
+
+        Raises
+        ------
+        ValueError
+            If the graphics driver is unknown.
+        """
+        pass
+
+    @abstractmethod
+    def get_gpu_config(self) -> bool | list[int]:
+        """Get GPU config.
+
+        Raises
+        ------
+        ValueError
+            If the GPU ID string cannot be parsed.
+        """
+        pass
+
+    @abstractmethod
     def start_python_journal(self, journal_name: str | None = None) -> int:
         """Start python journal."""
         pass
@@ -105,4 +147,15 @@ class AbstractApplicationRuntime(ABC):
     @abstractmethod
     def set_working_directory(self, path: Any) -> None:
         """Change the client cortex working directory."""
+        pass
+
+    @abstractmethod
+    def set_idle_timeout(self, timeout: int) -> None:
+        """Set the Fluent session idle timeout.
+
+        Parameters
+        ----------
+        timeout : int
+            Idle timeout duration in seconds. Pass 0 to disable the idle timeout.
+        """
         pass

--- a/src/ansys/fluent/core/services/application_runtime.py
+++ b/src/ansys/fluent/core/services/application_runtime.py
@@ -169,6 +169,10 @@ class ApplicationRuntime(AbstractApplicationRuntime):
         """Change the client cortex working directory."""
         self.service.set_working_directory(path=path)
 
+    def set_idle_timeout(self, timeout: int) -> None:
+        """Set the Fluent session idle timeout."""
+        self.service.set_idle_timeout(timeout=timeout)
+
 
 class ApplicationRuntimeV261V252:
     """Application runtime for Fluent 26R1 and 25R2.
@@ -350,6 +354,10 @@ class ApplicationRuntimeV261V252:
     def set_working_directory(self, path: PathType) -> None:
         """Change the client cortex working directory."""
         self.service.set_working_directory(path=path)
+
+    def set_idle_timeout(self, timeout: int) -> None:
+        """Set the Fluent session idle timeout."""
+        self.scheme.eval(f"(set-session-idle-timeout {timeout/60})")
 
     def is_wildcard(self, input: str | None = None) -> bool:
         """Return whether *input* contains a wildcard pattern."""
@@ -662,3 +670,7 @@ class ApplicationRuntimeOld:
     def set_working_directory(self, path: PathType) -> None:
         """Change the client cortex working directory."""
         self.scheme.eval(f'(syncdir "{os.fspath(path)}")')
+
+    def set_idle_timeout(self, timeout: int) -> None:
+        """Set the Fluent session idle timeout."""
+        self.scheme.eval(f"(set-session-idle-timeout {timeout/60})")


### PR DESCRIPTION
## Context
`session._app_utilities.set_idle_timeout` didn't exist. `set_idle_timeout` is in the proto, but not in the client side. The Error when idle timeout was not getting set was getting swallowed. These has been addressed.

## Change Summary
Client side implementation of `set_idle_timeout` was added (which was removed mistakenly during refactoring).
`RuntimeError` is getting raised if the idle timeout is not reset-ed after the successful fluent launch.

## Impact
Users to get the correct behavior now.
