### PR TITLE
build: Bump version to v0.40.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,7 +743,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # required for trusted publishing

--- a/doc/changelog.d/5257.dependencies.md
+++ b/doc/changelog.d/5257.dependencies.md
@@ -1,0 +1,1 @@
+Bump version to v0.40.2

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -51,7 +51,7 @@ from ansys.fluent.core.utils.context_managers import *
 from ansys.fluent.core.utils.fluent_version import *
 from ansys.fluent.core.utils.setup_for_fluent import *
 
-__version__ = "0.40.1"
+__version__ = "0.40.2"
 
 _VERSION_INFO = None
 """

--- a/src/ansys/fluent/core/launcher/standalone_launcher.py
+++ b/src/ansys/fluent/core/launcher/standalone_launcher.py
@@ -279,16 +279,19 @@ class StandaloneLauncher:
     @staticmethod
     def _disable_idle_timeout_guard(session):
         try:
+            default_idle_timeout = session.preferences.General.IdleTimeout()
+        except RuntimeError:
+            # This exception is raised only while running codegen locally before the preferences root is available.
+            default_idle_timeout = 0
+        try:
             if session.get_fluent_version() >= FluentVersion.v271:
-                session._app_utilities.set_idle_timeout(
-                    session.preferences.General.IdleTimeout() * 60
-                )
+                session._app_utilities.set_idle_timeout(default_idle_timeout * 60)
             else:
                 session.scheme_eval.eval(
-                    f"(set-session-idle-timeout {session.preferences.General.IdleTimeout()})"
+                    f"(set-session-idle-timeout {default_idle_timeout})"
                 )
         except Exception as ex:
-            logger.debug(f"Could not reset Idle Timeout: {ex}")
+            raise RuntimeError("Could not reset Idle Timeout") from ex
 
     def __call__(
         self,


### PR DESCRIPTION
Bump version to v0.40.2

This contains a patch for setting up Fluent's idle timeout when the preferences root is not available. This can only be faced if the user tries to run codegen locally after installing this release.

The original issue is fixed in main: https://github.com/ansys/pyfluent/pull/5254
