### PR TITLE
test: Catch errors from transcript within the PyConsole test

### DIFF
--- a/doc/changelog.d/5270.test.md
+++ b/doc/changelog.d/5270.test.md
@@ -1,0 +1,1 @@
+Catch errors from transcript for the PyConsole test

--- a/doc/changelog.d/5270.test.md
+++ b/doc/changelog.d/5270.test.md
@@ -1,1 +1,1 @@
-Catch errors from transcript for the PyConsole test
+Catch errors from transcript within the PyConsole test

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -50,20 +50,18 @@ def _is_pyconsole_activated(session):
     return session.scheme.eval("(%cx-pyconsole-activated?)")
 
 
-def _check_transcript_for_error(session):
+def _transcript_has_errors(session):
     cmd = """(%py-eval (format #f "open(r'~a').read()" (cx-get-session-transcript-filename)))"""
     transcript = session.scheme.eval(cmd)
     lines = transcript.splitlines()
-    status = False
     error_lines = []
     for line in lines:
         if line.startswith("Error:"):
-            status = True
             error_lines.append(line)
     print(f"Transcript contains {len(error_lines)} error lines:")
     for line in error_lines:
         print(line)
-    return status
+    return len(error_lines) > 0
 
 
 # Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied
@@ -97,7 +95,7 @@ def test_pyconsole_launch():
     )
     assert solver_session is not None
     assert _is_pyconsole_activated(solver_session) is True
-    assert _check_transcript_for_error(solver_session) is False
+    assert _transcript_has_errors(solver_session) is False
 
     meshing_container_dict = pyfluent.launch_fluent(
         start_container=True,
@@ -112,4 +110,4 @@ def test_pyconsole_launch():
     )
     assert meshing_session is not None
     assert _is_pyconsole_activated(meshing_session) is True
-    assert _check_transcript_for_error(meshing_session) is False
+    assert _transcript_has_errors(meshing_session) is False

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -54,11 +54,16 @@ def _check_transcript_for_error(session):
     cmd = """(%py-eval (format #f "open(r'~a').read()" (cx-get-session-transcript-filename)))"""
     transcript = session.scheme.eval(cmd)
     lines = transcript.splitlines()
+    status = False
+    error_lines = []
     for line in lines:
         if line.startswith("Error:"):
-            print(f"Error found in transcript: {line}")
-            return True
-    return False
+            status = True
+            error_lines.append(line)
+    print(f"Transcript contains {len(error_lines)} error lines:")
+    for line in error_lines:
+        print(line)
+    return status
 
 
 # Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -56,6 +56,7 @@ def _check_transcript_for_error(session):
     lines = transcript.splitlines()
     for line in lines:
         if line.startswith("Error:"):
+            print(f"Error found in transcript: {line}")
             return True
     return False
 

--- a/tests/test_pyconsole.py
+++ b/tests/test_pyconsole.py
@@ -50,6 +50,16 @@ def _is_pyconsole_activated(session):
     return session.scheme.eval("(%cx-pyconsole-activated?)")
 
 
+def _check_transcript_for_error(session):
+    cmd = """(%py-eval (format #f "open(r'~a').read()" (cx-get-session-transcript-filename)))"""
+    transcript = session.scheme.eval(cmd)
+    lines = transcript.splitlines()
+    for line in lines:
+        if line.startswith("Error:"):
+            return True
+    return False
+
+
 # Note: this test won't work with editable install of PyFluent because the PyFluent package files are not copied
 # to the expected location in the Fluent container. To run this test, install PyFluent without the -e option.
 @pytest.mark.fluent_version("dev")
@@ -81,6 +91,7 @@ def test_pyconsole_launch():
     )
     assert solver_session is not None
     assert _is_pyconsole_activated(solver_session) is True
+    assert _check_transcript_for_error(solver_session) is False
 
     meshing_container_dict = pyfluent.launch_fluent(
         start_container=True,
@@ -95,3 +106,4 @@ def test_pyconsole_launch():
     )
     assert meshing_session is not None
     assert _is_pyconsole_activated(meshing_session) is True
+    assert _check_transcript_for_error(meshing_session) is False


### PR DESCRIPTION
We have a PyConsole that catches any error during PyConsole startup with the current PyFluent changes. That test was not catching any error that were printed in the transcript. This PR changes will catch some errors (lines starting with `Error:`) from the transcript.

This changes are based on my observation on a local build.
