### PR TITLE
docs: Update docs w.r.t. grpc refactorings [skip tests]

### DIFF
--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -68,7 +68,6 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     exceptions
     file_session
     fields/fields_contents
-    fields/field_data_interfaces
     fluent_connection
     journaling
     logger
@@ -200,6 +199,7 @@ hierarchy = {
         "setup_for_fluent",
     ],
     "fields": [
+        "field_data_interfaces",
         "live_field_data",
         "reduction",
         "solution_variables",
@@ -208,7 +208,6 @@ hierarchy = {
         "module_config",
         "exceptions",
         "file_session",
-        "fields.field_data_interfaces",
         "fluent_connection",
         "journaling",
         "logger",
@@ -295,7 +294,7 @@ solver_workflows_toctree_display_names = {
 # Optional display-name overrides for toctree node/page titles.
 # Keys should match generated node names (for example: meshing_utilities).
 NODE_DISPLAY_NAMES = {
-    "fields.field_data_interfaces": "Field Data Interfaces",
+    # "key": "value",
 }
 
 

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -294,7 +294,6 @@ solver_workflows_toctree_display_names = {
 # Optional display-name overrides for toctree node/page titles.
 # Keys should match generated node names (for example: meshing_utilities).
 NODE_DISPLAY_NAMES = {
-    # "key": "value",
 }
 
 

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -208,7 +208,7 @@ hierarchy = {
         "module_config",
         "exceptions",
         "file_session",
-        "fields/field_data_interfaces",
+        "fields.field_data_interfaces",
         "fluent_connection",
         "journaling",
         "logger",
@@ -295,7 +295,7 @@ solver_workflows_toctree_display_names = {
 # Optional display-name overrides for toctree node/page titles.
 # Keys should match generated node names (for example: meshing_utilities).
 NODE_DISPLAY_NAMES = {
-    # "meshing_utilities": "Meshing Utilities",
+    "fields.field_data_interfaces": "Field Data Interfaces",
 }
 
 

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -151,7 +151,6 @@ hierarchy = {
     ],
     "scheduler": ["load_machines", "machine_list"],
     "services": [
-        "api_upgrade",
         "application_runtime",
         "batch_ops",
         "object_model",
@@ -293,8 +292,7 @@ solver_workflows_toctree_display_names = {
 
 # Optional display-name overrides for toctree node/page titles.
 # Keys should match generated node names (for example: meshing_utilities).
-NODE_DISPLAY_NAMES = {
-}
+NODE_DISPLAY_NAMES = {}
 
 
 def _get_display_name(node_name: str) -> str:

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -68,7 +68,6 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     exceptions
     file_session
     fields/fields_contents
-    fields/field_data_interfaces
     fluent_connection
     journaling
     logger

--- a/doc/api_rstgen.py
+++ b/doc/api_rstgen.py
@@ -67,7 +67,8 @@ The solver :ref:`settings API <ref_root>` is the main interface for controlling 
     data_model_cache
     exceptions
     file_session
-    field_data_interfaces
+    fields/fields_contents
+    fields/field_data_interfaces
     fluent_connection
     journaling
     logger
@@ -152,19 +153,19 @@ hierarchy = {
     "scheduler": ["load_machines", "machine_list"],
     "services": [
         "api_upgrade",
+        "application_runtime",
         "batch_ops",
-        "datamodel_se",
+        "object_model",
         "text_interface",
         "events",
         "field_data",
         "health_check",
         "interceptors",
-        "monitor",
+        "monitors",
         "reduction",
-        "scheme_eval",
+        "scheme_interpreter",
         "settings",
         "solution_variables",
-        "streaming",
         "transcript",
     ],
     "solver": [
@@ -198,11 +199,16 @@ hierarchy = {
         "networking",
         "setup_for_fluent",
     ],
+    "fields": [
+        "live_field_data",
+        "reduction",
+        "solution_variables",
+    ],
     "other": [
         "module_config",
         "exceptions",
         "file_session",
-        "field_data_interfaces",
+        "fields/field_data_interfaces",
         "fluent_connection",
         "journaling",
         "logger",

--- a/doc/changelog.d/5288.documentation.md
+++ b/doc/changelog.d/5288.documentation.md
@@ -1,0 +1,1 @@
+Update docs w.r.t. grpc refactorings.

--- a/doc/changelog.d/5288.documentation.md
+++ b/doc/changelog.d/5288.documentation.md
@@ -1,1 +1,1 @@
-Update docs w.r.t. grpc refactorings.
+Update docs w.r.t. grpc refactorings [skip tests]


### PR DESCRIPTION
## Context
After the recent grpc refactoring some of the items in the API Reference were not pointing to the correct locations. They have been updated here.

## Change Summary
1. Some of the items has been renamed in services like object_model, scheme_interpreter, text_interface and some things added like application runtime. 
2. The entire fields block has been added now which was missing earlier. 

## Impact
Users can navigate properly without encountering broken doc links.
