### PR TITLE
docs: connect to fluent user guide [skip tests]

### DIFF
--- a/doc/changelog.d/5290.documentation.md
+++ b/doc/changelog.d/5290.documentation.md
@@ -1,1 +1,1 @@
-Connect to fluent user guide
+Connect to fluent user guide [skip tests]

--- a/doc/changelog.d/5290.documentation.md
+++ b/doc/changelog.d/5290.documentation.md
@@ -1,0 +1,1 @@
+Connect to fluent user guide

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -88,22 +88,12 @@ Use this method when:
 
 **Prerequisites**
 
-Before connecting, you must launch Fluent externally with the gRPC server enabled. You can do this in several ways:
-
-1. **Command line with server info file**:
-
-   - **Linux/WSL**: ``ansys_inc/v261/fluent/bin/fluent 3ddp -sifile=server.txt``
-   - **Windows**: ``ANSYS Inc\v261\fluent\ntbin\win64\fluent.exe 3ddp -sifile=server.txt``
-
-2. **Within Fluent GUI**: Execute ``File`` → ``Applications`` → ``Server`` → ``Start...`` in solution mode.
-
-3. **Via TUI command**: Execute ``server/start-server`` in solution mode.
+Before connecting, you must launch Fluent externally with the gRPC server enabled.
 
 After starting the gRPC server, Fluent writes connection information to the server info file. The file contains the IP address, port, and password needed for connection.
+The recommended approach is to connect using the server info file path, which encapsulates all connection information.
 
 **Example:**
-
-The recommended approach is to connect using the server info file path, which encapsulates all connection information:
 
 .. code-block:: python
 
@@ -112,23 +102,10 @@ The recommended approach is to connect using the server info file path, which en
    # Connect to the session using the server info file
    solver = pyfluent.Solver.from_connection(server_info_file_name="server.txt")
 
-.. note::
-
-    **Health check behavior**: When ``from_connection()`` or ``connect_to_fluent()`` returns successfully, 
-    the connection to Fluent is already verified as healthy. A health check is performed automatically 
-    during connection initialization. Calling ``check_health()`` afterward is optional and not required 
-    to verify connection status.
 
 .. note::
 
-    **Multiple connections to the same Fluent instance**: If you create multiple session objects 
-    connected to the same Fluent instance, calling ``exit()`` on one session only closes that 
-    session's connection. Other session objects remain connected until they explicitly call ``exit()``. 
-    To cleanly close Fluent when using multiple connections, call ``exit()`` on all session objects.
-
-.. note::
-
-    **Meshing interfaces**: PyFluent offers two Python interfaces for meshing:
+    PyFluent offers two Python interfaces for meshing:
 
     - ``Meshing``: meshing interface with an additional method to switch to solver mode.
     - ``PureMeshing``: meshing interface without any solver switching features.

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -91,24 +91,13 @@ Use this method when:
 
    import ansys.fluent.core as pyfluent
 
-   # Launch to retrieve credentials
-   solver = pyfluent.Solver.from_install()
-   print(solver.health_check.check_health())
+   # Connect to the session using the server info file
+   solver = pyfluent.Solver.from_connection(server_info_file_name="server.txt")
 
-   ip = solver.connection_properties.ip
-   password = solver.connection_properties.password
-   port = solver.connection_properties.port
-
-   # Connect to the session
-   solver_connected = pyfluent.Solver.from_connection(ip=ip, password=password, port=port)
-   print(solver_connected.health_check.check_health())
-
-   solver.exit()
-   solver_connected.exit()
 
 .. note::
 
-    PyFluent offers two Python interfaces for meshing:
+    **Meshing interfaces**: PyFluent offers two Python interfaces for meshing:
 
     - ``Meshing``: meshing interface with an additional method to switch to solver mode.
     - ``PureMeshing``: meshing interface without any solver switching features.

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -92,8 +92,8 @@ Before connecting, you must launch Fluent externally with the gRPC server enable
 
 1. **Command line with server info file**:
 
-   - **Linux/WSL**: ``ansys_inc/v252/fluent/bin/fluent 3ddp -sifile=server.txt``
-   - **Windows**: ``ANSYS Inc\v252\fluent\ntbin\win64\fluent.exe 3ddp -sifile=server.txt``
+   - **Linux/WSL**: ``ansys_inc/v261/fluent/bin/fluent 3ddp -sifile=server.txt``
+   - **Windows**: ``ANSYS Inc\v261\fluent\ntbin\win64\fluent.exe 3ddp -sifile=server.txt``
 
 2. **Within Fluent GUI**: Execute ``File`` → ``Applications`` → ``Server`` → ``Start...`` in solution mode.
 

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -79,13 +79,31 @@ Connect to an existing session
 ------------------------------
 
 The :meth:`from_connection() <ansys.fluent.core.session_utilities.SessionBase.from_connection>` method connects to a previously launched Fluent session.
+You can also use the :func:`connect_to_fluent() <ansys.fluent.core.launcher.launcher.connect_to_fluent>` function for a more direct approach.
 
 Use this method when:
 
 - Fluent was launched externally or earlier.
 - You need to connect from a different process or system.
 
+**Prerequisites**
+
+Before connecting, you must launch Fluent externally with the gRPC server enabled. You can do this in several ways:
+
+1. **Command line with server info file**:
+
+   - **Linux/WSL**: ``ansys_inc/v252/fluent/bin/fluent 3ddp -sifile=server.txt``
+   - **Windows**: ``ANSYS Inc\v252\fluent\ntbin\win64\fluent.exe 3ddp -sifile=server.txt``
+
+2. **Within Fluent GUI**: Execute ``File`` → ``Applications`` → ``Server`` → ``Start...`` in solution mode.
+
+3. **Via TUI command**: Execute ``server/start-server`` in solution mode.
+
+After starting the gRPC server, Fluent writes connection information to the server info file. The file contains the IP address, port, and password needed for connection.
+
 **Example:**
+
+The recommended approach is to connect using the server info file path, which encapsulates all connection information:
 
 .. code-block:: python
 
@@ -94,6 +112,19 @@ Use this method when:
    # Connect to the session using the server info file
    solver = pyfluent.Solver.from_connection(server_info_file_name="server.txt")
 
+.. note::
+
+    **Health check behavior**: When ``from_connection()`` or ``connect_to_fluent()`` returns successfully, 
+    the connection to Fluent is already verified as healthy. A health check is performed automatically 
+    during connection initialization. Calling ``check_health()`` afterward is optional and not required 
+    to verify connection status.
+
+.. note::
+
+    **Multiple connections to the same Fluent instance**: If you create multiple session objects 
+    connected to the same Fluent instance, calling ``exit()`` on one session only closes that 
+    session's connection. Other session objects remain connected until they explicitly call ``exit()``. 
+    To cleanly close Fluent when using multiple connections, call ``exit()`` on all session objects.
 
 .. note::
 

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -79,7 +79,6 @@ Connect to an existing session
 ------------------------------
 
 The :meth:`from_connection() <ansys.fluent.core.session_utilities.SessionBase.from_connection>` method connects to a previously launched Fluent session.
-You can also use the :func:`connect_to_fluent() <ansys.fluent.core.launcher.launcher.connect_to_fluent>` function for a more direct approach.
 
 Use this method when:
 
@@ -90,8 +89,11 @@ Use this method when:
 
 Before connecting, you must launch Fluent externally with the gRPC server enabled.
 
-After starting the gRPC server, Fluent writes connection information to the server info file. The file contains the IP address, port, and password needed for connection.
-The recommended approach is to connect using the server info file path, which encapsulates all connection information.
+.. note::
+
+    After starting the gRPC server, Fluent writes connection information to the server info file. The file contains the IP address, port, and password needed for connection.
+    
+    The recommended approach is to connect using the server info file path, which encapsulates all connection information.
 
 **Example:**
 

--- a/doc/source/user_guide/session/launching_ansys_fluent.rst
+++ b/doc/source/user_guide/session/launching_ansys_fluent.rst
@@ -102,7 +102,7 @@ Before connecting, you must launch Fluent externally with the gRPC server enable
    import ansys.fluent.core as pyfluent
 
    # Connect to the session using the server info file
-   solver = pyfluent.Solver.from_connection(server_info_file_name="server.txt")
+   solver = pyfluent.Solver.from_connection(server_info_file_name=<server-info-file>)
 
 
 .. note::


### PR DESCRIPTION
## Context
The `connect_to_fluent` user guide documentation had several usability issues:

- The connection guidance unnecessarily depended on launching Fluent via PyFluent, which was frustrating for users who preferred to launch Fluent normally
- Users were shown how to access individual connection data from the launched session object instead of being directed to the simpler server info file path approach
- The example was overly long with only a small portion relevant to the core connection task
- The example had unclear behavior around calling `solver.exit()` while `solver_connected` was still active
- It included unnecessary `check_health()` calls when the connection health is already validated before returning

## Change Summary
Updated the `connect_to_fluent` user guide documentation to provide clearer, more user-friendly guidance for connecting to existing Fluent sessions. The documentation now focuses on the more encapsulated approach using server info file paths and streamlines the examples to be more concise and relevant.

## Impact

- User guide documentation for connecting to existing Fluent sessions
- User onboarding experience for developers connecting PyFluent to existing Fluent instances
- Documentation examples are now more focused and easier to follow
