### PR TITLE
feat: Add dir for Workflow objects

### DIFF
--- a/doc/changelog.d/5293.added.md
+++ b/doc/changelog.d/5293.added.md
@@ -1,0 +1,1 @@
+Add dir for Workflow objects

--- a/src/ansys/fluent/core/workflow_new.py
+++ b/src/ansys/fluent/core/workflow_new.py
@@ -625,6 +625,7 @@ class Workflow:
             ) from ex
 
     def __dir__(self) -> list[str]:
+        """Updates the default dir(self) to include the task names added by ``__getattr__``"""
         return super().__dir__() + self.task_names()
 
     def __call__(self):

--- a/src/ansys/fluent/core/workflow_new.py
+++ b/src/ansys/fluent/core/workflow_new.py
@@ -624,6 +624,9 @@ class Workflow:
                 )
             ) from ex
 
+    def __dir__(self) -> list[str]:
+        return super().__dir__() + self.task_names()
+
     def __call__(self):
         """Get workflow state when called as a function."""
         return self._workflow_state()


### PR DESCRIPTION
## Context
Currently trying to use autocomplete in python console inside fluent won't show the `task_names()`

## Change Summary
Added `task_names()` to the `dir()`.

## Impact
Improves the usability of the new meshing workflow inside of fluent for engineers