### PR TITLE
docs: update .vale.ini configuration to fix doc-style

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -17,7 +17,7 @@ SkippedScopes = script, style, pre, figure
 WordTemplate = \b(?:%s)\b
 
 # List of Packages to be used for our guidelines
-Packages = Google
+Packages = https://github.com/vale-cli/Google/releases/download/v0.6.3/Google.zip
 
 # Define the Ansys vocabulary
 Vocab = ANSYS

--- a/doc/changelog.d/5299.documentation.md
+++ b/doc/changelog.d/5299.documentation.md
@@ -1,0 +1,1 @@
+Update .vale.ini configuration to fix doc-style


### PR DESCRIPTION
As title says, fix the current CI doc-style issue
