### PR TITLE
build: Bump version to v0.41.0

### DIFF
--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -51,7 +51,7 @@ from ansys.fluent.core.utils.context_managers import *
 from ansys.fluent.core.utils.fluent_version import *
 from ansys.fluent.core.utils.setup_for_fluent import *
 
-__version__ = "0.41.dev2"
+__version__ = "0.41.0"
 
 _VERSION_INFO = None
 """


### PR DESCRIPTION
Bump version to v0.41.0

This branch will be base for Fluent's PyConsole in 27R1 release.
