### PR TITLE
fix: Restrict rp var creation length.

### DIFF
--- a/doc/changelog.d/5321.fixed.md
+++ b/doc/changelog.d/5321.fixed.md
@@ -1,0 +1,1 @@
+Restrict rp var creation length.

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -193,7 +193,7 @@ class RPVars:
         Parameters
         ----------
         name : str
-            Name of the rpvar to create.
+            Name of the rpvar to create. Must not exceed `62` characters.
         value : Any
             Initial value for the rpvar.
         var_type : RPVarType | type | None

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -76,6 +76,8 @@ class RPVarType(Enum):
 class RPVars:
     """Access to rpvars in a specific session."""
 
+    _MAX_NEW_RPVAR_NAME_LENGTH = 62
+
     def __init__(self, eval_fn):
         """Initialize RPVars."""
         self._eval_fn = eval_fn
@@ -206,7 +208,15 @@ class RPVars:
             If the value type doesn't match the specified var_type.
         RuntimeError
             If 'make-new-rpvar' returns #f for a reason other than the variable name already matching an existing entry.
+        ValueError
+            If the rpvar name exceeds Fluent's length limit.
         """
+        if len(name) > self._MAX_NEW_RPVAR_NAME_LENGTH:
+            raise ValueError(
+                f"RPVar name '{name}' exceeds maximum allowed length of "
+                f"{self._MAX_NEW_RPVAR_NAME_LENGTH} characters."
+            )
+
         if var_type is None:
             var_type = RPVarType.CUSTOM
             python_type = None

--- a/src/ansys/fluent/core/rpvars.py
+++ b/src/ansys/fluent/core/rpvars.py
@@ -209,7 +209,7 @@ class RPVars:
         RuntimeError
             If 'make-new-rpvar' returns #f for a reason other than the variable name already matching an existing entry.
         ValueError
-            If the rpvar name exceeds Fluent's length limit.
+            If the rpvar name exceeds Fluent's length limit of 62.
         """
         if len(name) > self._MAX_NEW_RPVAR_NAME_LENGTH:
             raise ValueError(

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -26,7 +26,7 @@ import pytest
 
 from ansys.fluent.core.examples import download_file, path
 from ansys.fluent.core.filereader.casereader import CaseReader
-from ansys.fluent.core.rpvars import RPVarType
+from ansys.fluent.core.rpvars import RPVars, RPVarType
 
 
 def test_get_and_set_rp_vars(new_solver_session) -> None:
@@ -124,8 +124,28 @@ def test_rp_vars_boolean(new_solver_session) -> None:
         assert rp_vars(var_name) == var_val
 
 
-@pytest.mark.skip(reason=SKIP_INVESTIGATING)
-# https://github.com/ansys/pyfluent/issues/4298
+def test_create_rp_var_name_length_limit():
+    calls = []
+
+    def _eval_fn(cmd):
+        calls.append(cmd)
+        return "()"
+
+    rp_vars = RPVars(_eval_fn)
+    too_long_name = "x" * 63
+
+    with pytest.raises(ValueError, match="maximum allowed length of 62"):
+        rp_vars.create(name=too_long_name, value=1, var_type=int)
+
+    assert calls == []
+
+    long_name = "x" * 62
+    rp_vars.create(name=long_name, value=1, var_type=int)
+
+    # Validation happens before any Fluent command is issued.
+    assert calls != []
+
+
 @pytest.mark.fluent_version(">=25.1")
 def test_create_rp_vars(new_solver_session) -> None:
     solver = new_solver_session


### PR DESCRIPTION
## Context
Fluent has a limit of 62 chars for new rp var names.

## Change Summary
Restricted creating rp vars longer than this limit from PyFluent.

```python
>>> var_name = 62 * 'a'              
>>> solver.rp_vars.create(var_name, "", str)
'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
>>> var_name = 63 * 'a' 
>>> solver.rp_vars.create(var_name, "", str)
ValueError
```