### PR TITLE
fix: Deprecation behavior.

### DIFF
--- a/doc/changelog.d/5322.fixed.md
+++ b/doc/changelog.d/5322.fixed.md
@@ -1,0 +1,1 @@
+Deprecation behavior.

--- a/src/ansys/fluent/core/utils/deprecate.py
+++ b/src/ansys/fluent/core/utils/deprecate.py
@@ -111,12 +111,12 @@ def deprecate_arguments(
         reason = f"Argument {old_str} is deprecated; use {new_str} instead."
 
     def decorator(func: Callable):
-        deprecated_func = deprecated(version=version, reason=reason)(func)
-
-        @functools.wraps(deprecated_func)
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            # Warn only if any old arg(s) present
-            if any(arg in kwargs for arg in old_args):
+            has_deprecated_args = any(arg in kwargs for arg in old_args)
+
+            # Warn and convert only when deprecated arg(s) are actually present.
+            if has_deprecated_args:
                 warnings.warn(
                     reason,
                     warning_cls,
@@ -135,7 +135,8 @@ def deprecate_arguments(
                         f"Converter must accept either (kwargs) or (kwargs, old_args, new_args), "
                         f"but got {n_params} parameter(s): {list(params)}"
                     )
-            return deprecated_func(*args, **kwargs)
+
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -36,6 +36,9 @@ from ansys.fluent.core import examples
 from ansys.fluent.core._grpc_services._command_arguments_mixin import (
     CommandArgumentsCleanupMixin,
 )
+from ansys.fluent.core._grpc_services.object_model_service import (
+    _convert_variant_to_value as _convert_variant_to_value_v1,
+)
 from ansys.fluent.core._grpc_services.object_model_service_v0 import (
     _convert_value_to_variant,
     _convert_variant_to_value,
@@ -348,7 +351,10 @@ def test_datamodel_streaming_full_diff_state(
 
     def cb(state, deleted_paths):
         if state:
-            state = _convert_variant_to_value(state)
+            if meshing.get_fluent_version() < FluentVersion.v271:
+                state = _convert_variant_to_value(state)
+            else:
+                state = _convert_variant_to_value_v1(state)
         cb.states.append(state)
 
     cb.states = []
@@ -374,7 +380,10 @@ def test_datamodel_streaming_no_commands_diff_state(
 
     def cb(state, deleted_paths):
         if state:
-            state = _convert_variant_to_value(state)
+            if meshing.get_fluent_version() < FluentVersion.v271:
+                state = _convert_variant_to_value(state)
+            else:
+                state = _convert_variant_to_value_v1(state)
         cb.states.append(state)
 
     cb.states = []

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -132,7 +132,6 @@ def test_command_arguments_cleanup_mixin_deletes_and_stops_tracking():
 
 
 @pytest.mark.fluent_version(">=23.2")
-@pytest.mark.codegen_required
 def test_event_subscription(new_meshing_session):
     session = new_meshing_session
     session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")

--- a/tests/test_deprecate.py
+++ b/tests/test_deprecate.py
@@ -49,7 +49,7 @@ def test_deprecate_argument_warns():
         result = example_func(a=1, b=2, c=3, x1=2, x2=4)
 
     # Check that the warnings were raised
-    assert len(w) == 6
+    assert len(w) == 3
     warning = w[0]
     assert issubclass(warning.category, PyFluentDeprecationWarning)
     assert "'a', 'b'" in str(warning.message)
@@ -92,13 +92,28 @@ def test_deprecate_argument_warns_with_custom_converter():
         result = example_func(a=1, b=2, c=3)
 
     # Check that the warnings were raised
-    assert len(w) == 4
+    assert len(w) == 2
     warning = w[0]
     assert issubclass(warning.category, PyFluentDeprecationWarning)
     assert "'a', 'b'" in str(warning.message)
     assert "'d'" in str(warning.message)
 
     assert result == {"d": (1, 2), "e": 3}
+
+
+def test_deprecate_argument_does_not_warn_without_deprecated_args():
+    """Test that no warning is emitted when deprecated arguments are not passed."""
+
+    @deprecate_arguments(old_args="a", new_args="b", version="3.0.0")
+    def example_func(**kwargs):
+        return kwargs
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = example_func(b=10)
+
+    assert result == {"b": 10}
+    assert len(w) == 0
 
 
 def test_deprecate_argument_raises_value_error_without_converter():

--- a/tests/test_rp_vars.py
+++ b/tests/test_rp_vars.py
@@ -25,7 +25,7 @@ from conftest import SKIP_INVESTIGATING
 import pytest
 
 from ansys.fluent.core.examples import download_file, path
-from ansys.fluent.core.filereader.casereader import CaseReader
+from ansys.fluent.core.filereader.case_file import CaseFile as CaseReader
 from ansys.fluent.core.rpvars import RPVarType
 
 


### PR DESCRIPTION
## Context
An incorrect import path was used for `convert_variant_to_value` for 27R1 tests.

## Change Summary
Updated import paths.
Resolved a few deprecated imports.
