### PR TITLE
refactor: Avoid writing out static-info's hash in settings_v<ver>.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,6 @@ jobs:
       - name: Print 24.2 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_242.py
-          python -c "from src.ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Pull 25.1 Fluent docker image
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -406,7 +405,6 @@ jobs:
       - name: Print 25.1 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_251.py
-          python -c "from src.ansys.fluent.core.generated.solver.settings_251 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Pull 25.2 Fluent docker image
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -424,7 +422,6 @@ jobs:
       - name: Print 25.2 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_252.py
-          python -c "from src.ansys.fluent.core.generated.solver.settings_252 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Pull 26.1 Fluent docker image
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -441,7 +438,6 @@ jobs:
       - name: Print 26.1 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_261.py
-          python -c "from src.ansys.fluent.core.generated.solver.settings_261 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Pull 27.1 Fluent docker image
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -458,7 +454,6 @@ jobs:
       - name: Print 27.1 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_271.py
-          python -c "from src.ansys.fluent.core.generated.solver.settings_271 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |

--- a/.github/workflows/test-fluent-journals.yml
+++ b/.github/workflows/test-fluent-journals.yml
@@ -90,7 +90,6 @@ jobs:
           VERSION: ${{ env.FLUENT_VERSION }}
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_${VERSION}.py
-          python -c "from ansys.fluent.core.generated.solver.settings_${VERSION} import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |

--- a/.github/workflows/test-run-dev-version-nightly.yml
+++ b/.github/workflows/test-run-dev-version-nightly.yml
@@ -87,7 +87,6 @@ jobs:
           VERSION: ${{ env.FLUENT_VERSION }}
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_${VERSION}.py
-          python -c "from ansys.fluent.core.generated.solver.settings_${VERSION} import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |

--- a/.github/workflows/test-run-nightly.yml
+++ b/.github/workflows/test-run-nightly.yml
@@ -87,7 +87,6 @@ jobs:
           VERSION: ${{ env.FLUENT_VERSION }}
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_${VERSION}.py
-          python -c "from ansys.fluent.core.generated.solver.settings_${VERSION} import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |

--- a/.github/workflows/test-run-old-versions-weekly.yml
+++ b/.github/workflows/test-run-old-versions-weekly.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Print 24.2 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_242.py
-          python -c "from ansys.fluent.core.generated.solver.settings_242 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Pull 25.1 Fluent docker image
         run: make docker-pull

--- a/.github/workflows/test-run-solvermode-weekly.yml
+++ b/.github/workflows/test-run-solvermode-weekly.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Print 26.1 Fluent version info
         run: |
           cat src/ansys/fluent/core/generated/fluent_version_261.py
-          python -c "from ansys.fluent.core.generated.solver.settings_261 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
       - name: Install again after codegen
         run: |

--- a/doc/changelog.d/5330.miscellaneous.md
+++ b/doc/changelog.d/5330.miscellaneous.md
@@ -1,0 +1,1 @@
+Avoid writing out static-info's hash in settings_v<ver>.py

--- a/src/ansys/fluent/core/codegen/settingsgen.py
+++ b/src/ansys/fluent/core/codegen/settingsgen.py
@@ -364,7 +364,6 @@ def generate(version: str, static_infos: dict, verbose: bool = False) -> None:
     start_time = time.time()
     api_tree = {}
     sinfo = static_infos.get(StaticInfoType.SETTINGS)
-    shash = _gethash(sinfo)
     if not sinfo:
         return {"<solver_session>": api_tree}
     output_dir = (pyfluent.config.codegen_outdir / "solver").resolve()
@@ -399,7 +398,6 @@ def generate(version: str, static_infos: dict, verbose: bool = False) -> None:
         f.write(header.getvalue())
         f_stub.write(header.getvalue())
         f_stub.write("from typing import Any, Final\n\n")
-        f.write(f'SHASH = "{shash}"\n\n')
         name = data["name"]
         _NAME_BY_HASH[_gethash(data)] = name
         _write_data(name, name, data, f, f_stub)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -26,7 +26,6 @@ import importlib
 from pathlib import Path
 import pickle
 import shutil
-import sys
 import tempfile
 
 import pytest
@@ -532,8 +531,6 @@ from ansys.fluent.core.solver.flobject import (
     _FlStringConstant,
 )
 
-SHASH = "b05d3c10ad4ac8aacf91abd5ea572d9bf93115cffc9ee5c33bfc7a3b9dcd2dea"
-
 class P3(Integer):
     """
     P3 help.
@@ -753,11 +750,6 @@ def test_codegen_with_settings_static_info(monkeypatch):
     }
     with open(codegen_outdir / "solver" / f"settings_{version}.py", "r") as f:
         expected_settings_api_output = _expected_settings_api_output
-        if sys.version_info >= (3, 14):
-            expected_settings_api_output = expected_settings_api_output.replace(
-                'SHASH = "3e6d76a4601701388ea8258912d145b7b7c436699a50b6c7fe9a29f41eeff194"',
-                'SHASH = "54828595751f83d80abe11673952397862edb1f6f1ff3c23b2c133b483561345"',
-            )
         assert f.read().strip() == expected_settings_api_output
     api_tree_file = get_api_tree_file_name(version)
     with open(api_tree_file, "rb") as f:


### PR DESCRIPTION
## Context
We used to write out the hash in the generated settings file.

## Change Summary
Cleaned up the code writing out hash in settingsgen.py.
Note that, the hash(es) is/are still computed and used to detect duplicate class structure within that file.

## Impact
None
