### PR TITLE
feat: Add 'get_active_command_names' and 'get_active_query_names' methods in named and list objects

### DIFF
--- a/doc/changelog.d/5335.added.md
+++ b/doc/changelog.d/5335.added.md
@@ -1,0 +1,1 @@
+Add 'get_active_command_names' and 'get_active_query_names' methods in named and list objects

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -1687,6 +1687,32 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
         obj_names_list = obj_names if isinstance(obj_names, list) else list(obj_names)
         return obj_names_list
 
+    def get_active_command_names(self):
+        """Names of commands that are currently active."""
+        ret = []
+        child_classes = type(self)._child_classes
+        for command_name in self.command_names:
+            child_cls = child_classes.get(command_name)
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
+                continue
+            command = getattr(self, command_name)
+            if command.is_active() and not _is_deprecated(command):
+                ret.append(command_name)
+        return ret
+
+    def get_active_query_names(self):
+        """Names of queries that are currently active."""
+        ret = []
+        child_classes = type(self)._child_classes
+        for query_name in self.query_names:
+            child_cls = child_classes.get(query_name)
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
+                continue
+            query = getattr(self, query_name)
+            if query.is_active() and not _is_deprecated(query):
+                ret.append(query_name)
+        return ret
+
     def __getitem__(self, name: str) -> ChildTypeT:
         if name not in self.get_object_names():
             if self.flproxy.has_wildcard(name):
@@ -1950,6 +1976,32 @@ class ListObject(SettingsBase[ListStateType], Generic[ChildTypeT]):
     def __iter__(self):
         self._update_objects()
         return iter(self._objects)
+
+    def get_active_command_names(self):
+        """Names of commands that are currently active."""
+        ret = []
+        child_classes = type(self)._child_classes
+        for command_name in self.command_names:
+            child_cls = child_classes.get(command_name)
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
+                continue
+            command = getattr(self, command_name)
+            if command.is_active() and not _is_deprecated(command):
+                ret.append(command_name)
+        return ret
+
+    def get_active_query_names(self):
+        """Names of queries that are currently active."""
+        ret = []
+        child_classes = type(self)._child_classes
+        for query_name in self.query_names:
+            child_cls = child_classes.get(query_name)
+            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
+                continue
+            query = getattr(self, query_name)
+            if query.is_active() and not _is_deprecated(query):
+                ret.append(query_name)
+        return ret
 
     def get_size(self) -> int:
         """Return the number of elements in a list object.

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -243,6 +243,20 @@ def _get_hidden_names(names, child_classes, obj) -> set:
     return hidden
 
 
+def _get_active_names(obj, names: list) -> list:
+    """Return entries from ``names`` that are active and visible at the current exposure level."""
+    ret = []
+    child_classes = type(obj)._child_classes
+    for name in names:
+        child_cls = child_classes.get(name)
+        if child_cls is not None and _is_hidden_by_exposure_level(child_cls, obj):
+            continue
+        child = getattr(obj, name)
+        if child.is_active() and not _is_deprecated(child):
+            ret.append(name)
+    return ret
+
+
 def _raise_if_exposure_hidden(name, child_classes, obj) -> None:
     """Raise AttributeError if name is hidden due to exposure level."""
     child_cls = child_classes.get(name)
@@ -1364,29 +1378,11 @@ class Group(SettingsBase[DictStateType]):
 
     def get_active_command_names(self):
         """Names of commands that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for command_name in self.command_names:
-            child_cls = child_classes.get(command_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            command = getattr(self, command_name)
-            if command.is_active() and not _is_deprecated(command):
-                ret.append(command_name)
-        return ret
+        return _get_active_names(self, self.command_names)
 
     def get_active_query_names(self):
         """Names of queries that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for query_name in self.query_names:
-            child_cls = child_classes.get(query_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            query = getattr(self, query_name)
-            if query.is_active() and not _is_deprecated(query):
-                ret.append(query_name)
-        return ret
+        return _get_active_names(self, self.query_names)
 
     def __dir__(self):
         dir_list = set(list(self.__dict__.keys()) + dir(type(self)))
@@ -1689,29 +1685,11 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
 
     def get_active_command_names(self):
         """Names of commands that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for command_name in self.command_names:
-            child_cls = child_classes.get(command_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            command = getattr(self, command_name)
-            if command.is_active() and not _is_deprecated(command):
-                ret.append(command_name)
-        return ret
+        return _get_active_names(self, self.command_names)
 
     def get_active_query_names(self):
         """Names of queries that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for query_name in self.query_names:
-            child_cls = child_classes.get(query_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            query = getattr(self, query_name)
-            if query.is_active() and not _is_deprecated(query):
-                ret.append(query_name)
-        return ret
+        return _get_active_names(self, self.query_names)
 
     def __getitem__(self, name: str) -> ChildTypeT:
         if name not in self.get_object_names():
@@ -1979,29 +1957,11 @@ class ListObject(SettingsBase[ListStateType], Generic[ChildTypeT]):
 
     def get_active_command_names(self):
         """Names of commands that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for command_name in self.command_names:
-            child_cls = child_classes.get(command_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            command = getattr(self, command_name)
-            if command.is_active() and not _is_deprecated(command):
-                ret.append(command_name)
-        return ret
+        return _get_active_names(self, self.command_names)
 
     def get_active_query_names(self):
         """Names of queries that are currently active."""
-        ret = []
-        child_classes = type(self)._child_classes
-        for query_name in self.query_names:
-            child_cls = child_classes.get(query_name)
-            if child_cls is not None and _is_hidden_by_exposure_level(child_cls, self):
-                continue
-            query = getattr(self, query_name)
-            if query.is_active() and not _is_deprecated(query):
-                ret.append(query_name)
-        return ret
+        return _get_active_names(self, self.query_names)
 
     def get_size(self) -> int:
         """Return the number of elements in a list object.

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -2116,3 +2116,42 @@ def test_list_and_list_properties(new_solver_session):
         assert {"list", "list_properties"}.issubset(
             solver.settings.setup.materials.mixture.command_names
         )
+
+
+def test_get_active_command_names_in_named_objects(new_solver_session):
+    solver = new_solver_session
+    case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    solver.file.read_case_data(file_name=case_path)
+    active_command_names = (
+        solver.settings.results.graphics.contour.get_active_command_names()
+    )
+    assert {"create", "delete", "make_a_copy", "display", "add_to_graphics"}.issubset(
+        set(active_command_names)
+    )
+    all_command_names = solver.settings.results.graphics.contour.command_names
+    assert {
+        "create",
+        "delete",
+        "rename",
+        "list",
+        "list_properties",
+        "make_a_copy",
+        "display",
+        "add_to_graphics",
+    }.issubset(set(all_command_names))
+
+    solver.settings.results.graphics.contour.create("c-1")
+    active_command_names = (
+        solver.settings.results.graphics.contour.get_active_command_names()
+    )
+    assert {
+        "create",
+        "delete",
+        "rename",
+        "list",
+        "list_properties",
+        "make_a_copy",
+        "display",
+        "add_to_graphics",
+    }.issubset(set(active_command_names))

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -956,104 +956,298 @@ def test_exposure_level_filtering_named_object_commands(monkeypatch):
     assert r.l_1.beta_cmd
 
 
-def test_get_active_command_and_query_names(monkeypatch):
-    """Test get_active_command_names and get_active_query_names on NamedObject and ListObject."""
+def test_exposure_level_filtering_complete_hierarchy(monkeypatch):
+    """Test exposure-level filtering across a complete hierarchy."""
     from ansys.fluent.core.module_config import config
 
     monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
 
     class _StubCmd(Command):
+        """Stub command/query for proxy-side is_active() resolution."""
+
         arguments = {}
 
         def cb(self):
             pass
 
-    _stub_cmds = {
-        "stable-cmd": _StubCmd,
-        "beta-cmd": _StubCmd,
-        "stable-qry": _StubCmd,
-        "beta-qry": _StubCmd,
-    }
-
-    class TestRoot(Group):
-        class SomeNO(NamedObject):
+    class CompleteHierarchyRoot(Group):
+        class SomeNamedObj(NamedObject):
             class NOType(Group):
                 children = {}
 
             child_object_type = NOType
-            commands = _stub_cmds
 
-        class SomeLO(ListObject):
-            class LOType(Group):
-                children = {}
-
-            child_object_type = LOType
-            commands = _stub_cmds
-
-            def get_child(self, c):
-                try:
-                    return self._objs[int(c)]
-                except (ValueError, IndexError):
-                    raise KeyError(c)
-
-        children = {"no-1": SomeNO, "lo-1": SomeLO}
+        children = {
+            "stable-param": Real,
+            "beta-param": Real,
+            "alpha-param": Real,
+            "named-obj": SomeNamedObj,
+        }
+        commands = {
+            "stable-cmd": _StubCmd,
+            "beta-cmd": _StubCmd,
+            "alpha-cmd": _StubCmd,
+            "stable-qry": _StubCmd,
+            "beta-qry": _StubCmd,
+            "alpha-qry": _StubCmd,
+        }
 
         @classmethod
         def get_static_info(cls):
-            cmd_info = {
-                "stable-cmd": {"type": "command", "arguments": {}},
-                "beta-cmd": {
-                    "type": "command",
-                    "arguments": {},
-                    "api_exposure_level": "beta",
-                },
-            }
-            qry_info = {
-                "stable-qry": {"type": "query", "arguments": {}},
-                "beta-qry": {
-                    "type": "query",
-                    "arguments": {},
-                    "api_exposure_level": "beta",
-                },
-            }
             return {
                 "type": "group",
                 "children": {
-                    "no-1": {
+                    "stable-param": {"type": "real"},
+                    "beta-param": {"type": "real", "api_exposure_level": "beta"},
+                    "alpha-param": {"type": "real", "api_exposure_level": "alpha"},
+                    "named-obj": {
                         "type": "named-object",
                         "user_creatable": True,
                         "object_type": {"type": "group"},
-                        "commands": cmd_info,
-                        "queries": qry_info,
+                        "commands": {
+                            "stable-cmd": {"type": "command", "arguments": {}},
+                            "beta-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                            "alpha-cmd": {
+                                "type": "command",
+                                "arguments": {},
+                                "api_exposure_level": "alpha",
+                            },
+                        },
+                        "queries": {
+                            "stable-qry": {"type": "query", "arguments": {}},
+                            "beta-qry": {
+                                "type": "query",
+                                "arguments": {},
+                                "api_exposure_level": "beta",
+                            },
+                            "alpha-qry": {
+                                "type": "query",
+                                "arguments": {},
+                                "api_exposure_level": "alpha",
+                            },
+                        },
                     },
-                    "lo-1": {
-                        "type": "list-object",
-                        "object_type": {"type": "group"},
-                        "commands": cmd_info,
-                        "queries": qry_info,
+                },
+                "commands": {
+                    "stable-cmd": {"type": "command", "arguments": {}},
+                    "beta-cmd": {
+                        "type": "command",
+                        "arguments": {},
+                        "api_exposure_level": "beta",
+                    },
+                    "alpha-cmd": {
+                        "type": "command",
+                        "arguments": {},
+                        "api_exposure_level": "alpha",
+                    },
+                },
+                "queries": {
+                    "stable-qry": {"type": "query", "arguments": {}},
+                    "beta-qry": {
+                        "type": "query",
+                        "arguments": {},
+                        "api_exposure_level": "beta",
+                    },
+                    "alpha-qry": {
+                        "type": "query",
+                        "arguments": {},
+                        "api_exposure_level": "alpha",
                     },
                 },
             }
 
-    class TestProxy(Proxy):
-        root = TestRoot
+    class CompleteProxy(Proxy):
+        root = CompleteHierarchyRoot
 
-    r = flobject.get_root(TestProxy(), version="271")
+    r = flobject.get_root(CompleteProxy(), version="271")
+    no = r.named_obj
 
-    for obj in (r.no_1, r.lo_1):
-        # Stable (default) — only stable names returned
-        assert obj.get_active_command_names() == ["stable_cmd"]
-        assert obj.get_active_query_names() == ["stable_qry"]
+    # Default state
+    assert "stable_param" in dir(r)
+    assert "beta_param" not in dir(r)
+    assert "alpha_param" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_param
+    with pytest.raises(AttributeError):
+        _ = r.alpha_param
 
-        # Beta activated — both stable and beta returned
-        r.set_exposure_level(ExposureLevel.BETA)
-        assert set(obj.get_active_command_names()) == {"stable_cmd", "beta_cmd"}
-        assert set(obj.get_active_query_names()) == {"stable_qry", "beta_qry"}
+    assert "stable_cmd" in dir(r)
+    assert "beta_cmd" not in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.alpha_cmd
 
-        # Back to stable — beta hidden again
-        r.set_exposure_level(ExposureLevel.STABLE)
-        assert obj.get_active_command_names() == ["stable_cmd"]
-        assert obj.get_active_query_names() == ["stable_qry"]
+    assert "stable_qry" in dir(r)
+    assert "beta_qry" not in dir(r)
+    assert "alpha_qry" not in dir(r)
+    with pytest.raises(AttributeError):
+        _ = r.beta_qry
+    with pytest.raises(AttributeError):
+        _ = r.alpha_qry
+
+    assert "stable_cmd" in dir(no)
+    assert "beta_cmd" not in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    with pytest.raises(AttributeError):
+        _ = no.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = no.alpha_cmd
+
+    assert "stable_qry" in dir(no)
+    assert "beta_qry" not in dir(no)
+    assert "alpha_qry" not in dir(no)
+    with pytest.raises(AttributeError):
+        _ = no.beta_qry
+    with pytest.raises(AttributeError):
+        _ = no.alpha_qry
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+
+    assert "beta_param" in dir(r)
+    assert "alpha_param" not in dir(r)
+    assert r.beta_param
+    with pytest.raises(AttributeError):
+        _ = r.alpha_param
+
+    assert "beta_cmd" in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    assert r.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = r.alpha_cmd
+
+    assert "beta_qry" in dir(r)
+    assert "alpha_qry" not in dir(r)
+    assert r.beta_qry
+    with pytest.raises(AttributeError):
+        _ = r.alpha_qry
+
+    assert "beta_cmd" in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    assert no.beta_cmd
+    with pytest.raises(AttributeError):
+        _ = no.alpha_cmd
+
+    assert "beta_qry" in dir(no)
+    assert "alpha_qry" not in dir(no)
+    assert no.beta_qry
+    with pytest.raises(AttributeError):
+        _ = no.alpha_qry
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+
+    assert "beta_param" in dir(r)
+    assert "alpha_param" in dir(r)
+    assert "beta_cmd" in dir(r)
+    assert "alpha_cmd" in dir(r)
+    assert "beta_qry" in dir(r)
+    assert "alpha_qry" in dir(r)
+    assert r.beta_param
+    assert r.alpha_param
+    assert r.beta_cmd
+    assert r.alpha_cmd
+    assert r.beta_qry
+    assert r.alpha_qry
+
+    assert "beta_cmd" in dir(no)
+    assert "alpha_cmd" in dir(no)
+    assert "beta_qry" in dir(no)
+    assert "alpha_qry" in dir(no)
+    assert no.beta_cmd
+    assert no.alpha_cmd
+    assert no.beta_qry
+    assert no.alpha_qry
+
+    # Back to stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+
+    assert "beta_param" not in dir(r)
+    assert "alpha_param" not in dir(r)
+    assert "beta_cmd" not in dir(r)
+    assert "alpha_cmd" not in dir(r)
+    assert "beta_qry" not in dir(r)
+    assert "alpha_qry" not in dir(r)
+
+    assert "beta_cmd" not in dir(no)
+    assert "alpha_cmd" not in dir(no)
+    assert "beta_qry" not in dir(no)
+    assert "alpha_qry" not in dir(no)
+
+    assert "stable_param" in dir(r)
+    assert "stable_cmd" in dir(r)
+    assert "stable_qry" in dir(r)
+    assert "stable_cmd" in dir(no)
+    assert "stable_qry" in dir(no)
+    assert r.stable_param
+    assert r.stable_cmd
+    assert r.stable_qry
+    assert no.stable_cmd
+    assert no.stable_qry
+
+    assert "set_exposure_level" in dir(r)
+    assert "set_exposure_level" not in dir(no)
+    with pytest.raises(AttributeError):
+        no.set_exposure_level(ExposureLevel.BETA)
+
+    r.set_exposure_level(ExposureLevel.STABLE)
+
+    active_params = r.get_active_child_names()
+    assert "stable_param" in active_params
+    assert "beta_param" not in active_params
+    assert "alpha_param" not in active_params
+
+    active_cmds = r.get_active_command_names()
+    assert "stable_cmd" in active_cmds
+    assert "beta_cmd" not in active_cmds
+    assert "alpha_cmd" not in active_cmds
+
+    active_qrys = r.get_active_query_names()
+    assert "stable_qry" in active_qrys
+    assert "beta_qry" not in active_qrys
+    assert "alpha_qry" not in active_qrys
+
+    # Activate beta
+    r.set_exposure_level(ExposureLevel.BETA)
+    active_params = r.get_active_child_names()
+    assert "beta_param" in active_params
+    assert "alpha_param" not in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" in active_cmds
+    assert "alpha_cmd" not in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" in active_qrys
+    assert "alpha_qry" not in active_qrys
+
+    # Activate alpha
+    r.set_exposure_level(ExposureLevel.ALPHA)
+    active_params = r.get_active_child_names()
+    assert "beta_param" in active_params
+    assert "alpha_param" in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" in active_cmds
+    assert "alpha_cmd" in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" in active_qrys
+    assert "alpha_qry" in active_qrys
+
+    # Back to stable
+    r.set_exposure_level(ExposureLevel.STABLE)
+    active_params = r.get_active_child_names()
+    assert "beta_param" not in active_params
+    assert "alpha_param" not in active_params
+    active_cmds = r.get_active_command_names()
+    assert "beta_cmd" not in active_cmds
+    assert "alpha_cmd" not in active_cmds
+    active_qrys = r.get_active_query_names()
+    assert "beta_qry" not in active_qrys
+    assert "alpha_qry" not in active_qrys
 
 
 def test_exposure_level_filtering_command_arguments(monkeypatch):
@@ -1922,42 +2116,3 @@ def test_list_and_list_properties(new_solver_session):
         assert {"list", "list_properties"}.issubset(
             solver.settings.setup.materials.mixture.command_names
         )
-
-
-def test_get_active_command_names_in_named_objects(new_solver_session):
-    solver = new_solver_session
-    case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
-    download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
-    solver.file.read_case_data(file_name=case_path)
-    active_command_names = (
-        solver.settings.results.graphics.contour.get_active_command_names()
-    )
-    assert {"create", "delete", "make_a_copy", "display", "add_to_graphics"}.issubset(
-        set(active_command_names)
-    )
-    all_command_names = solver.settings.results.graphics.contour.command_names
-    assert {
-        "create",
-        "delete",
-        "rename",
-        "list",
-        "list_properties",
-        "make_a_copy",
-        "display",
-        "add_to_graphics",
-    }.issubset(set(all_command_names))
-
-    solver.settings.results.graphics.contour.create("c-1")
-    active_command_names = (
-        solver.settings.results.graphics.contour.get_active_command_names()
-    )
-    assert {
-        "create",
-        "delete",
-        "rename",
-        "list",
-        "list_properties",
-        "make_a_copy",
-        "display",
-        "add_to_graphics",
-    }.issubset(set(active_command_names))

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -956,298 +956,104 @@ def test_exposure_level_filtering_named_object_commands(monkeypatch):
     assert r.l_1.beta_cmd
 
 
-def test_exposure_level_filtering_complete_hierarchy(monkeypatch):
-    """Test exposure-level filtering across a complete hierarchy."""
+def test_get_active_command_and_query_names(monkeypatch):
+    """Test get_active_command_names and get_active_query_names on NamedObject and ListObject."""
     from ansys.fluent.core.module_config import config
 
     monkeypatch.setattr(config, "_use_runtime_python_classes", True, raising=False)
 
     class _StubCmd(Command):
-        """Stub command/query for proxy-side is_active() resolution."""
-
         arguments = {}
 
         def cb(self):
             pass
 
-    class CompleteHierarchyRoot(Group):
-        class SomeNamedObj(NamedObject):
+    _stub_cmds = {
+        "stable-cmd": _StubCmd,
+        "beta-cmd": _StubCmd,
+        "stable-qry": _StubCmd,
+        "beta-qry": _StubCmd,
+    }
+
+    class TestRoot(Group):
+        class SomeNO(NamedObject):
             class NOType(Group):
                 children = {}
 
             child_object_type = NOType
+            commands = _stub_cmds
 
-        children = {
-            "stable-param": Real,
-            "beta-param": Real,
-            "alpha-param": Real,
-            "named-obj": SomeNamedObj,
-        }
-        commands = {
-            "stable-cmd": _StubCmd,
-            "beta-cmd": _StubCmd,
-            "alpha-cmd": _StubCmd,
-            "stable-qry": _StubCmd,
-            "beta-qry": _StubCmd,
-            "alpha-qry": _StubCmd,
-        }
+        class SomeLO(ListObject):
+            class LOType(Group):
+                children = {}
+
+            child_object_type = LOType
+            commands = _stub_cmds
+
+            def get_child(self, c):
+                try:
+                    return self._objs[int(c)]
+                except (ValueError, IndexError):
+                    raise KeyError(c)
+
+        children = {"no-1": SomeNO, "lo-1": SomeLO}
 
         @classmethod
         def get_static_info(cls):
+            cmd_info = {
+                "stable-cmd": {"type": "command", "arguments": {}},
+                "beta-cmd": {
+                    "type": "command",
+                    "arguments": {},
+                    "api_exposure_level": "beta",
+                },
+            }
+            qry_info = {
+                "stable-qry": {"type": "query", "arguments": {}},
+                "beta-qry": {
+                    "type": "query",
+                    "arguments": {},
+                    "api_exposure_level": "beta",
+                },
+            }
             return {
                 "type": "group",
                 "children": {
-                    "stable-param": {"type": "real"},
-                    "beta-param": {"type": "real", "api_exposure_level": "beta"},
-                    "alpha-param": {"type": "real", "api_exposure_level": "alpha"},
-                    "named-obj": {
+                    "no-1": {
                         "type": "named-object",
                         "user_creatable": True,
                         "object_type": {"type": "group"},
-                        "commands": {
-                            "stable-cmd": {"type": "command", "arguments": {}},
-                            "beta-cmd": {
-                                "type": "command",
-                                "arguments": {},
-                                "api_exposure_level": "beta",
-                            },
-                            "alpha-cmd": {
-                                "type": "command",
-                                "arguments": {},
-                                "api_exposure_level": "alpha",
-                            },
-                        },
-                        "queries": {
-                            "stable-qry": {"type": "query", "arguments": {}},
-                            "beta-qry": {
-                                "type": "query",
-                                "arguments": {},
-                                "api_exposure_level": "beta",
-                            },
-                            "alpha-qry": {
-                                "type": "query",
-                                "arguments": {},
-                                "api_exposure_level": "alpha",
-                            },
-                        },
+                        "commands": cmd_info,
+                        "queries": qry_info,
                     },
-                },
-                "commands": {
-                    "stable-cmd": {"type": "command", "arguments": {}},
-                    "beta-cmd": {
-                        "type": "command",
-                        "arguments": {},
-                        "api_exposure_level": "beta",
-                    },
-                    "alpha-cmd": {
-                        "type": "command",
-                        "arguments": {},
-                        "api_exposure_level": "alpha",
-                    },
-                },
-                "queries": {
-                    "stable-qry": {"type": "query", "arguments": {}},
-                    "beta-qry": {
-                        "type": "query",
-                        "arguments": {},
-                        "api_exposure_level": "beta",
-                    },
-                    "alpha-qry": {
-                        "type": "query",
-                        "arguments": {},
-                        "api_exposure_level": "alpha",
+                    "lo-1": {
+                        "type": "list-object",
+                        "object_type": {"type": "group"},
+                        "commands": cmd_info,
+                        "queries": qry_info,
                     },
                 },
             }
 
-    class CompleteProxy(Proxy):
-        root = CompleteHierarchyRoot
+    class TestProxy(Proxy):
+        root = TestRoot
 
-    r = flobject.get_root(CompleteProxy(), version="271")
-    no = r.named_obj
+    r = flobject.get_root(TestProxy(), version="271")
 
-    # Default state
-    assert "stable_param" in dir(r)
-    assert "beta_param" not in dir(r)
-    assert "alpha_param" not in dir(r)
-    with pytest.raises(AttributeError):
-        _ = r.beta_param
-    with pytest.raises(AttributeError):
-        _ = r.alpha_param
+    for obj in (r.no_1, r.lo_1):
+        # Stable (default) — only stable names returned
+        assert obj.get_active_command_names() == ["stable_cmd"]
+        assert obj.get_active_query_names() == ["stable_qry"]
 
-    assert "stable_cmd" in dir(r)
-    assert "beta_cmd" not in dir(r)
-    assert "alpha_cmd" not in dir(r)
-    with pytest.raises(AttributeError):
-        _ = r.beta_cmd
-    with pytest.raises(AttributeError):
-        _ = r.alpha_cmd
+        # Beta activated — both stable and beta returned
+        r.set_exposure_level(ExposureLevel.BETA)
+        assert set(obj.get_active_command_names()) == {"stable_cmd", "beta_cmd"}
+        assert set(obj.get_active_query_names()) == {"stable_qry", "beta_qry"}
 
-    assert "stable_qry" in dir(r)
-    assert "beta_qry" not in dir(r)
-    assert "alpha_qry" not in dir(r)
-    with pytest.raises(AttributeError):
-        _ = r.beta_qry
-    with pytest.raises(AttributeError):
-        _ = r.alpha_qry
-
-    assert "stable_cmd" in dir(no)
-    assert "beta_cmd" not in dir(no)
-    assert "alpha_cmd" not in dir(no)
-    with pytest.raises(AttributeError):
-        _ = no.beta_cmd
-    with pytest.raises(AttributeError):
-        _ = no.alpha_cmd
-
-    assert "stable_qry" in dir(no)
-    assert "beta_qry" not in dir(no)
-    assert "alpha_qry" not in dir(no)
-    with pytest.raises(AttributeError):
-        _ = no.beta_qry
-    with pytest.raises(AttributeError):
-        _ = no.alpha_qry
-
-    # Activate beta
-    r.set_exposure_level(ExposureLevel.BETA)
-
-    assert "beta_param" in dir(r)
-    assert "alpha_param" not in dir(r)
-    assert r.beta_param
-    with pytest.raises(AttributeError):
-        _ = r.alpha_param
-
-    assert "beta_cmd" in dir(r)
-    assert "alpha_cmd" not in dir(r)
-    assert r.beta_cmd
-    with pytest.raises(AttributeError):
-        _ = r.alpha_cmd
-
-    assert "beta_qry" in dir(r)
-    assert "alpha_qry" not in dir(r)
-    assert r.beta_qry
-    with pytest.raises(AttributeError):
-        _ = r.alpha_qry
-
-    assert "beta_cmd" in dir(no)
-    assert "alpha_cmd" not in dir(no)
-    assert no.beta_cmd
-    with pytest.raises(AttributeError):
-        _ = no.alpha_cmd
-
-    assert "beta_qry" in dir(no)
-    assert "alpha_qry" not in dir(no)
-    assert no.beta_qry
-    with pytest.raises(AttributeError):
-        _ = no.alpha_qry
-
-    # Activate alpha
-    r.set_exposure_level(ExposureLevel.ALPHA)
-
-    assert "beta_param" in dir(r)
-    assert "alpha_param" in dir(r)
-    assert "beta_cmd" in dir(r)
-    assert "alpha_cmd" in dir(r)
-    assert "beta_qry" in dir(r)
-    assert "alpha_qry" in dir(r)
-    assert r.beta_param
-    assert r.alpha_param
-    assert r.beta_cmd
-    assert r.alpha_cmd
-    assert r.beta_qry
-    assert r.alpha_qry
-
-    assert "beta_cmd" in dir(no)
-    assert "alpha_cmd" in dir(no)
-    assert "beta_qry" in dir(no)
-    assert "alpha_qry" in dir(no)
-    assert no.beta_cmd
-    assert no.alpha_cmd
-    assert no.beta_qry
-    assert no.alpha_qry
-
-    # Back to stable
-    r.set_exposure_level(ExposureLevel.STABLE)
-
-    assert "beta_param" not in dir(r)
-    assert "alpha_param" not in dir(r)
-    assert "beta_cmd" not in dir(r)
-    assert "alpha_cmd" not in dir(r)
-    assert "beta_qry" not in dir(r)
-    assert "alpha_qry" not in dir(r)
-
-    assert "beta_cmd" not in dir(no)
-    assert "alpha_cmd" not in dir(no)
-    assert "beta_qry" not in dir(no)
-    assert "alpha_qry" not in dir(no)
-
-    assert "stable_param" in dir(r)
-    assert "stable_cmd" in dir(r)
-    assert "stable_qry" in dir(r)
-    assert "stable_cmd" in dir(no)
-    assert "stable_qry" in dir(no)
-    assert r.stable_param
-    assert r.stable_cmd
-    assert r.stable_qry
-    assert no.stable_cmd
-    assert no.stable_qry
-
-    assert "set_exposure_level" in dir(r)
-    assert "set_exposure_level" not in dir(no)
-    with pytest.raises(AttributeError):
-        no.set_exposure_level(ExposureLevel.BETA)
-
-    r.set_exposure_level(ExposureLevel.STABLE)
-
-    active_params = r.get_active_child_names()
-    assert "stable_param" in active_params
-    assert "beta_param" not in active_params
-    assert "alpha_param" not in active_params
-
-    active_cmds = r.get_active_command_names()
-    assert "stable_cmd" in active_cmds
-    assert "beta_cmd" not in active_cmds
-    assert "alpha_cmd" not in active_cmds
-
-    active_qrys = r.get_active_query_names()
-    assert "stable_qry" in active_qrys
-    assert "beta_qry" not in active_qrys
-    assert "alpha_qry" not in active_qrys
-
-    # Activate beta
-    r.set_exposure_level(ExposureLevel.BETA)
-    active_params = r.get_active_child_names()
-    assert "beta_param" in active_params
-    assert "alpha_param" not in active_params
-    active_cmds = r.get_active_command_names()
-    assert "beta_cmd" in active_cmds
-    assert "alpha_cmd" not in active_cmds
-    active_qrys = r.get_active_query_names()
-    assert "beta_qry" in active_qrys
-    assert "alpha_qry" not in active_qrys
-
-    # Activate alpha
-    r.set_exposure_level(ExposureLevel.ALPHA)
-    active_params = r.get_active_child_names()
-    assert "beta_param" in active_params
-    assert "alpha_param" in active_params
-    active_cmds = r.get_active_command_names()
-    assert "beta_cmd" in active_cmds
-    assert "alpha_cmd" in active_cmds
-    active_qrys = r.get_active_query_names()
-    assert "beta_qry" in active_qrys
-    assert "alpha_qry" in active_qrys
-
-    # Back to stable
-    r.set_exposure_level(ExposureLevel.STABLE)
-    active_params = r.get_active_child_names()
-    assert "beta_param" not in active_params
-    assert "alpha_param" not in active_params
-    active_cmds = r.get_active_command_names()
-    assert "beta_cmd" not in active_cmds
-    assert "alpha_cmd" not in active_cmds
-    active_qrys = r.get_active_query_names()
-    assert "beta_qry" not in active_qrys
-    assert "alpha_qry" not in active_qrys
+        # Back to stable — beta hidden again
+        r.set_exposure_level(ExposureLevel.STABLE)
+        assert obj.get_active_command_names() == ["stable_cmd"]
+        assert obj.get_active_query_names() == ["stable_qry"]
 
 
 def test_exposure_level_filtering_command_arguments(monkeypatch):
@@ -2116,3 +1922,42 @@ def test_list_and_list_properties(new_solver_session):
         assert {"list", "list_properties"}.issubset(
             solver.settings.setup.materials.mixture.command_names
         )
+
+
+def test_get_active_command_names_in_named_objects(new_solver_session):
+    solver = new_solver_session
+    case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    solver.file.read_case_data(file_name=case_path)
+    active_command_names = (
+        solver.settings.results.graphics.contour.get_active_command_names()
+    )
+    assert {"create", "delete", "make_a_copy", "display", "add_to_graphics"}.issubset(
+        set(active_command_names)
+    )
+    all_command_names = solver.settings.results.graphics.contour.command_names
+    assert {
+        "create",
+        "delete",
+        "rename",
+        "list",
+        "list_properties",
+        "make_a_copy",
+        "display",
+        "add_to_graphics",
+    }.issubset(set(all_command_names))
+
+    solver.settings.results.graphics.contour.create("c-1")
+    active_command_names = (
+        solver.settings.results.graphics.contour.get_active_command_names()
+    )
+    assert {
+        "create",
+        "delete",
+        "rename",
+        "list",
+        "list_properties",
+        "make_a_copy",
+        "display",
+        "add_to_graphics",
+    }.issubset(set(active_command_names))

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -2106,6 +2106,7 @@ def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
     )
 
 
+@pytest.mark.fluent_version(">=26.1")
 def test_list_and_list_properties(new_solver_session):
     solver = new_solver_session
     if solver.get_fluent_version() < FluentVersion.v261:

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -2106,7 +2106,6 @@ def test_concatenation_of_named_objects(mixing_elbow_case_data_session):
     )
 
 
-@pytest.mark.fluent_version(">=26.1")
 def test_list_and_list_properties(new_solver_session):
     solver = new_solver_session
     if solver.get_fluent_version() < FluentVersion.v261:
@@ -2119,6 +2118,7 @@ def test_list_and_list_properties(new_solver_session):
         )
 
 
+@pytest.mark.fluent_version(">=26.1")
 def test_get_active_command_names_in_named_objects(new_solver_session):
     solver = new_solver_session
     case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")


### PR DESCRIPTION
## Context
get_active_command_names/get_active_query_names are not available at named objects

## Change Summary
Added `get_active_command_names` and `get_active_query_names` are made available at named object and list object levels.

Appropriate testing has been added.