### PR TITLE
refactor: Avoid v0 import when proto v1 is active.

### DIFF
--- a/doc/changelog.d/5336.miscellaneous.md
+++ b/doc/changelog.d/5336.miscellaneous.md
@@ -1,0 +1,1 @@
+Avoid v0 import when proto v1 is active.

--- a/src/ansys/fluent/core/_grpc_services/__init__.py
+++ b/src/ansys/fluent/core/_grpc_services/__init__.py
@@ -31,64 +31,6 @@ from grpc_reflection.v1alpha.proto_reflection_descriptor_database import (
     ProtoReflectionDescriptorDatabase,
 )
 
-from ansys.fluent.core._grpc_services._chunk_parser import ChunkParser, ChunkParserV0
-from ansys.fluent.core._grpc_services.application_runtime_service import (
-    ApplicationRuntimeService,
-)
-from ansys.fluent.core._grpc_services.application_runtime_service_v0 import (
-    ApplicationRuntimeService as ApplicationRuntimeServiceV0,
-)
-from ansys.fluent.core._grpc_services.batch_ops_service_v0 import (
-    BatchOpsService as BatchOpsServiceV0,
-)
-from ansys.fluent.core._grpc_services.events_service import EventsService
-from ansys.fluent.core._grpc_services.events_service_v0 import (
-    EventsService as EventsServiceV0,
-)
-from ansys.fluent.core._grpc_services.field_data_service import FieldDataService
-from ansys.fluent.core._grpc_services.field_data_service_v0 import (
-    FieldDataService as FieldDataServiceV0,
-)
-from ansys.fluent.core._grpc_services.health_check_service import HealthCheckService
-from ansys.fluent.core._grpc_services.health_check_service_v0 import (
-    HealthCheckService as HealthCheckServiceV0,
-)
-from ansys.fluent.core._grpc_services.monitor_service import MonitorService
-from ansys.fluent.core._grpc_services.monitor_service_v0 import (
-    MonitorService as MonitorServiceV0,
-)
-from ansys.fluent.core._grpc_services.object_model_service import ObjectModelService
-from ansys.fluent.core._grpc_services.object_model_service_v0 import (
-    ObjectModelService as ObjectModelServiceV0,
-)
-from ansys.fluent.core._grpc_services.reduction_service import ReductionService
-from ansys.fluent.core._grpc_services.reduction_service_v0 import (
-    ReductionService as ReductionServiceV0,
-)
-from ansys.fluent.core._grpc_services.scheme_interpreter_service import (
-    SchemeInterpreterService,
-)
-from ansys.fluent.core._grpc_services.scheme_interpreter_service_v0 import (
-    SchemeInterpreterService as SchemeInterpreterServiceV0,
-)
-from ansys.fluent.core._grpc_services.settings_service import SettingsService
-from ansys.fluent.core._grpc_services.settings_service_v0 import (
-    SettingsService as SettingsServiceV0,
-)
-from ansys.fluent.core._grpc_services.solution_variable_service import (
-    SolutionVariableService,
-)
-from ansys.fluent.core._grpc_services.solution_variable_service_v0 import (
-    SolutionVariableService as SolutionVariableServiceV0,
-)
-from ansys.fluent.core._grpc_services.text_interface_service import TextInterfaceService
-from ansys.fluent.core._grpc_services.text_interface_service_v0 import (
-    TextInterfaceService as TextInterfaceServiceV0,
-)
-from ansys.fluent.core._grpc_services.transcript_service import TranscriptService
-from ansys.fluent.core._grpc_services.transcript_service_v0 import (
-    TranscriptService as TranscriptServiceV0,
-)
 from ansys.fluent.core.services.interceptors import (
     BatchInterceptor,
     ErrorStateInterceptor,
@@ -196,8 +138,12 @@ class GRPCServiceFactory:
         raise NotImplementedError
 
     @cached_property
-    def batch_ops(self) -> BatchOpsServiceV0:
+    def batch_ops(self):
         """gRPC stub for batch RPC operations (v0 only — no v1 implementation)."""
+        from ansys.fluent.core._grpc_services.batch_ops_service_v0 import (
+            BatchOpsService as BatchOpsServiceV0,
+        )
+
         return BatchOpsServiceV0(
             intercept_channel=grpc.intercept_channel(
                 self._channel,
@@ -227,216 +173,6 @@ class GRPCServiceFactory:
         raise NotImplementedError
 
 
-class GRPCServiceFactoryV1(GRPCServiceFactory):
-    """Factory for v1 proto (Fluent >= 27R1) gRPC service stubs."""
-
-    @cached_property
-    def scheme_interpreter(self) -> SchemeInterpreterService:
-        """gRPC stub for Scheme expression evaluation."""
-        return SchemeInterpreterService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def application_runtime(self) -> ApplicationRuntimeService:
-        """gRPC stub for application runtime and product version queries."""
-        return ApplicationRuntimeService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def health_check(self) -> HealthCheckService:
-        """gRPC stub for server health/readiness checks."""
-        return HealthCheckService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def reduction(self) -> ReductionService:
-        """gRPC stub for data-reduction operations (forces, moments, etc.)."""
-        return ReductionService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def settings(self) -> SettingsService:
-        """gRPC stub for reading and writing solver settings."""
-        return SettingsService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def field_data(self) -> FieldDataService:
-        """gRPC stub for field data operations."""
-        return FieldDataService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def _chunk_parser(self) -> type[ChunkParser]:
-        """Chunk parser class for field data operations."""
-        return ChunkParser
-
-    @cached_property
-    def object_model(self) -> ObjectModelService:
-        """gRPC stub for object model operations."""
-        return ObjectModelService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def events(self) -> EventsService:
-        """gRPC stub for events operations."""
-        return EventsService(
-            channel=self._channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def transcript(self) -> TranscriptService:
-        """gRPC stub for transcript operations."""
-        return TranscriptService(
-            channel=self._channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def text_interface(self) -> TextInterfaceService:
-        """gRPC stub for text interface operations."""
-        return TextInterfaceService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def monitor(self) -> MonitorService:
-        """gRPC stub for monitor operations."""
-        return MonitorService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def solution_variable(self) -> SolutionVariableService:
-        """gRPC stub for solution variable operations."""
-        return SolutionVariableService(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-
-class GRPCServiceFactoryV0(GRPCServiceFactory):
-    """Factory for v0 proto (Fluent < 27R1) gRPC service stubs."""
-
-    @cached_property
-    def scheme_interpreter(self) -> SchemeInterpreterServiceV0:
-        """gRPC stub for Scheme expression evaluation."""
-        return SchemeInterpreterServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def application_runtime(self) -> ApplicationRuntimeServiceV0:
-        """gRPC stub for application runtime and product version queries."""
-        return ApplicationRuntimeServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def health_check(self) -> HealthCheckServiceV0:
-        """gRPC stub for server health/readiness checks."""
-        return HealthCheckServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def reduction(self) -> ReductionServiceV0:
-        """gRPC stub for data-reduction operations (forces, moments, etc.)."""
-        return ReductionServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def settings(self) -> SettingsServiceV0:
-        """gRPC stub for reading and writing solver settings."""
-        return SettingsServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def field_data(self) -> FieldDataServiceV0:
-        """gRPC stub for field data operations."""
-        return FieldDataServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def _chunk_parser(self) -> type[ChunkParserV0]:
-        """Chunk parser class for field data operations."""
-        return ChunkParserV0
-
-    @cached_property
-    def object_model(self) -> ObjectModelServiceV0:
-        """gRPC stub for object model operations."""
-        return ObjectModelServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def events(self) -> EventsServiceV0:
-        """gRPC stub for events operations."""
-        return EventsServiceV0(
-            channel=self._channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def transcript(self) -> TranscriptServiceV0:
-        """gRPC stub for transcript operations."""
-        return TranscriptServiceV0(
-            channel=self._channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def text_interface(self) -> TextInterfaceServiceV0:
-        """gRPC stub for text interface operations."""
-        return TextInterfaceServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def monitor(self) -> MonitorServiceV0:
-        """gRPC stub for monitor operations."""
-        return MonitorServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-    @cached_property
-    def solution_variable(self) -> SolutionVariableServiceV0:
-        """gRPC stub for solution variable operations."""
-        return SolutionVariableServiceV0(
-            intercept_channel=self._intercept_channel,
-            metadata=self._metadata,
-        )
-
-
 def create_grpc_service_factory(
     channel,
     metadata,
@@ -460,5 +196,11 @@ def create_grpc_service_factory(
     version = proto_version or (
         ProtoVersion.V1 if _server_supports_v1(channel) else ProtoVersion.V0
     )
-    cls = GRPCServiceFactoryV1 if version == ProtoVersion.V1 else GRPCServiceFactoryV0
-    return cls(channel, metadata, error_state)
+    if version == ProtoVersion.V1:
+        from ansys.fluent.core._grpc_services._factory_v1 import GRPCServiceFactoryV1
+
+        return GRPCServiceFactoryV1(channel, metadata, error_state)
+    else:
+        from ansys.fluent.core._grpc_services._factory_v0 import GRPCServiceFactoryV0
+
+        return GRPCServiceFactoryV0(channel, metadata, error_state)

--- a/src/ansys/fluent/core/_grpc_services/_chunk_parser.py
+++ b/src/ansys/fluent/core/_grpc_services/_chunk_parser.py
@@ -30,13 +30,6 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 
-from ansys.api.fluent.v0 import field_data_pb2 as field_data_pb2_v0
-from ansys.api.fluent.v1 import field_data_pb2 as field_data_pb2_v1
-from ansys.fluent.core._grpc_services.field_data_service import _FieldDataConstants
-from ansys.fluent.core._grpc_services.field_data_service_v0 import (
-    _FieldDataConstants as _FieldDataConstantsV0,
-)
-
 
 class ChunkParserV0:
     """Class for parsing field data stream received from Fluent.
@@ -74,6 +67,8 @@ class ChunkParserV0:
         def _get_tag_for_scalar_field_request(
             scalar_field_request,
         ) -> tuple[tuple[str, str], tuple[str, Any], tuple[str, Any]]:
+            from ansys.api.fluent.v0 import field_data_pb2
+
             return (
                 ("type", "scalar-field"),
                 (
@@ -81,7 +76,7 @@ class ChunkParserV0:
                     (
                         1
                         if scalar_field_request.dataLocation
-                        == field_data_pb2_v0.DataLocation.Nodes
+                        == field_data_pb2.DataLocation.Nodes
                         else 0
                     ),
                 ),
@@ -131,6 +126,10 @@ class ChunkParserV0:
 
         fields_data = dict[Any, dict[str, npt.NDArray[Any]]]()
         for chunk in chunk_iterator:
+            from ansys.fluent.core._grpc_services.field_data_service_v0 import (
+                _FieldDataConstants,
+            )
+
             payload_info = chunk.payloadInfo
             surface_id = payload_info.surfaceId
             field_request_info = payload_info.fieldRequestInfo
@@ -162,7 +161,7 @@ class ChunkParserV0:
                     payload_tag_id = reduce(
                         lambda x, y: x | y,
                         [
-                            _FieldDataConstantsV0.payloadTags[tag]
+                            _FieldDataConstants.payloadTags[tag]
                             for tag in payload_info.payloadTag
                         ]
                         or [0],
@@ -173,7 +172,7 @@ class ChunkParserV0:
             if payload_tag_id is not None:
                 if payload_info.fieldSize > 0:
                     field = _extract_field(
-                        _FieldDataConstantsV0.proto_field_type_to_np_data_type[
+                        _FieldDataConstants.proto_field_type_to_np_data_type[
                             payload_info.fieldType
                         ],
                         payload_info.fieldSize,
@@ -222,6 +221,8 @@ class ChunkParser(ChunkParserV0):
             return (("type", "vector-field"),)
 
         def _get_tag_for_scalar_field_request(scalar_field_request):
+            from ansys.api.fluent.v1 import field_data_pb2
+
             return (
                 ("type", "scalar-field"),
                 (
@@ -229,7 +230,7 @@ class ChunkParser(ChunkParserV0):
                     (
                         1
                         if scalar_field_request.data_location
-                        == field_data_pb2_v1.DataLocation.DATA_LOCATION_NODES
+                        == field_data_pb2.DataLocation.DATA_LOCATION_NODES
                         else 0
                     ),
                 ),
@@ -275,6 +276,10 @@ class ChunkParser(ChunkParserV0):
 
         fields_data = {}
         for chunk in chunk_iterator:
+            from ansys.fluent.core._grpc_services.field_data_service import (
+                _FieldDataConstants,
+            )
+
             payload_info = chunk.payload_info
             surface_id = payload_info.surface_id
             field_request_info = payload_info.field_request_info

--- a/src/ansys/fluent/core/_grpc_services/_factory_v0.py
+++ b/src/ansys/fluent/core/_grpc_services/_factory_v0.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2021 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""gRPC service factory for v0 proto (Fluent < 27R1)."""
+
+from functools import cached_property
+
+from ansys.fluent.core._grpc_services import GRPCServiceFactory
+from ansys.fluent.core._grpc_services._chunk_parser import ChunkParserV0
+from ansys.fluent.core._grpc_services.application_runtime_service_v0 import (
+    ApplicationRuntimeService as ApplicationRuntimeServiceV0,
+)
+from ansys.fluent.core._grpc_services.events_service_v0 import (
+    EventsService as EventsServiceV0,
+)
+from ansys.fluent.core._grpc_services.field_data_service_v0 import (
+    FieldDataService as FieldDataServiceV0,
+)
+from ansys.fluent.core._grpc_services.health_check_service_v0 import (
+    HealthCheckService as HealthCheckServiceV0,
+)
+from ansys.fluent.core._grpc_services.monitor_service_v0 import (
+    MonitorService as MonitorServiceV0,
+)
+from ansys.fluent.core._grpc_services.object_model_service_v0 import (
+    ObjectModelService as ObjectModelServiceV0,
+)
+from ansys.fluent.core._grpc_services.reduction_service_v0 import (
+    ReductionService as ReductionServiceV0,
+)
+from ansys.fluent.core._grpc_services.scheme_interpreter_service_v0 import (
+    SchemeInterpreterService as SchemeInterpreterServiceV0,
+)
+from ansys.fluent.core._grpc_services.settings_service_v0 import (
+    SettingsService as SettingsServiceV0,
+)
+from ansys.fluent.core._grpc_services.solution_variable_service_v0 import (
+    SolutionVariableService as SolutionVariableServiceV0,
+)
+from ansys.fluent.core._grpc_services.text_interface_service_v0 import (
+    TextInterfaceService as TextInterfaceServiceV0,
+)
+from ansys.fluent.core._grpc_services.transcript_service_v0 import (
+    TranscriptService as TranscriptServiceV0,
+)
+
+
+class GRPCServiceFactoryV0(GRPCServiceFactory):
+    """Factory for v0 proto (Fluent < 27R1) gRPC service stubs."""
+
+    @cached_property
+    def scheme_interpreter(self) -> SchemeInterpreterServiceV0:
+        """gRPC stub for Scheme expression evaluation."""
+        return SchemeInterpreterServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def application_runtime(self) -> ApplicationRuntimeServiceV0:
+        """gRPC stub for application runtime and product version queries."""
+        return ApplicationRuntimeServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def health_check(self) -> HealthCheckServiceV0:
+        """gRPC stub for server health/readiness checks."""
+        return HealthCheckServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def reduction(self) -> ReductionServiceV0:
+        """gRPC stub for data-reduction operations (forces, moments, etc.)."""
+        return ReductionServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def settings(self) -> SettingsServiceV0:
+        """gRPC stub for reading and writing solver settings."""
+        return SettingsServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def field_data(self) -> FieldDataServiceV0:
+        """gRPC stub for field data operations."""
+        return FieldDataServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def _chunk_parser(self) -> type[ChunkParserV0]:
+        """Chunk parser class for field data operations."""
+        return ChunkParserV0
+
+    @cached_property
+    def object_model(self) -> ObjectModelServiceV0:
+        """gRPC stub for object model operations."""
+        return ObjectModelServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def events(self) -> EventsServiceV0:
+        """gRPC stub for events operations."""
+        return EventsServiceV0(
+            channel=self._channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def transcript(self) -> TranscriptServiceV0:
+        """gRPC stub for transcript operations."""
+        return TranscriptServiceV0(
+            channel=self._channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def text_interface(self) -> TextInterfaceServiceV0:
+        """gRPC stub for text interface operations."""
+        return TextInterfaceServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def monitor(self) -> MonitorServiceV0:
+        """gRPC stub for monitor operations."""
+        return MonitorServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def solution_variable(self) -> SolutionVariableServiceV0:
+        """gRPC stub for solution variable operations."""
+        return SolutionVariableServiceV0(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )

--- a/src/ansys/fluent/core/_grpc_services/_factory_v1.py
+++ b/src/ansys/fluent/core/_grpc_services/_factory_v1.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2021 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""gRPC service factory for v1 proto (Fluent >= 27R1)."""
+
+from functools import cached_property
+
+from ansys.fluent.core._grpc_services import GRPCServiceFactory
+from ansys.fluent.core._grpc_services._chunk_parser import ChunkParser
+from ansys.fluent.core._grpc_services.application_runtime_service import (
+    ApplicationRuntimeService,
+)
+from ansys.fluent.core._grpc_services.events_service import EventsService
+from ansys.fluent.core._grpc_services.field_data_service import FieldDataService
+from ansys.fluent.core._grpc_services.health_check_service import HealthCheckService
+from ansys.fluent.core._grpc_services.monitor_service import MonitorService
+from ansys.fluent.core._grpc_services.object_model_service import ObjectModelService
+from ansys.fluent.core._grpc_services.reduction_service import ReductionService
+from ansys.fluent.core._grpc_services.scheme_interpreter_service import (
+    SchemeInterpreterService,
+)
+from ansys.fluent.core._grpc_services.settings_service import SettingsService
+from ansys.fluent.core._grpc_services.solution_variable_service import (
+    SolutionVariableService,
+)
+from ansys.fluent.core._grpc_services.text_interface_service import TextInterfaceService
+from ansys.fluent.core._grpc_services.transcript_service import TranscriptService
+
+
+class GRPCServiceFactoryV1(GRPCServiceFactory):
+    """Factory for v1 proto (Fluent >= 27R1) gRPC service stubs."""
+
+    @cached_property
+    def scheme_interpreter(self) -> SchemeInterpreterService:
+        """gRPC stub for Scheme expression evaluation."""
+        return SchemeInterpreterService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def application_runtime(self) -> ApplicationRuntimeService:
+        """gRPC stub for application runtime and product version queries."""
+        return ApplicationRuntimeService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def health_check(self) -> HealthCheckService:
+        """gRPC stub for server health/readiness checks."""
+        return HealthCheckService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def reduction(self) -> ReductionService:
+        """gRPC stub for data-reduction operations (forces, moments, etc.)."""
+        return ReductionService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def settings(self) -> SettingsService:
+        """gRPC stub for reading and writing solver settings."""
+        return SettingsService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def field_data(self) -> FieldDataService:
+        """gRPC stub for field data operations."""
+        return FieldDataService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def _chunk_parser(self) -> type[ChunkParser]:
+        """Chunk parser class for field data operations."""
+        return ChunkParser
+
+    @cached_property
+    def object_model(self) -> ObjectModelService:
+        """gRPC stub for object model operations."""
+        return ObjectModelService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def events(self) -> EventsService:
+        """gRPC stub for events operations."""
+        return EventsService(
+            channel=self._channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def transcript(self) -> TranscriptService:
+        """gRPC stub for transcript operations."""
+        return TranscriptService(
+            channel=self._channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def text_interface(self) -> TextInterfaceService:
+        """gRPC stub for text interface operations."""
+        return TextInterfaceService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def monitor(self) -> MonitorService:
+        """gRPC stub for monitor operations."""
+        return MonitorService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )
+
+    @cached_property
+    def solution_variable(self) -> SolutionVariableService:
+        """gRPC stub for solution variable operations."""
+        return SolutionVariableService(
+            intercept_channel=self._intercept_channel,
+            metadata=self._metadata,
+        )

--- a/src/ansys/fluent/core/_grpc_services/batch_ops_service_v0.py
+++ b/src/ansys/fluent/core/_grpc_services/batch_ops_service_v0.py
@@ -28,8 +28,6 @@ import logging
 import sys
 from types import ModuleType
 
-import ansys.api.fluent.v0 as api
-from ansys.api.fluent.v0 import batch_ops_pb2, batch_ops_pb2_grpc
 from ansys.fluent.core.services._protocols import ServiceProtocol
 
 network_logger: logging.Logger = logging.getLogger("pyfluent.networking")
@@ -38,15 +36,14 @@ network_logger: logging.Logger = logging.getLogger("pyfluent.networking")
 class BatchOpsService(ServiceProtocol):
     """Class wrapping the batch operations service of Fluent (v0 proto API)."""
 
-    _api_module = api
-    _proto_module = batch_ops_pb2
-
     def __init__(
         self,
         intercept_channel,
         metadata: list[tuple[str, str]],
     ) -> None:
         """__init__ method of BatchOpsService class."""
+        from ansys.api.fluent.v0 import batch_ops_pb2_grpc
+
         self._stub = batch_ops_pb2_grpc.BatchOpsStub(intercept_channel)
         self._metadata = metadata
         self._proto_files: list[ModuleType] | None = None
@@ -54,11 +51,13 @@ class BatchOpsService(ServiceProtocol):
 
     def _ensure_proto_files(self) -> None:
         """Lazily populate the list of all known proto file descriptors."""
+        import ansys.api.fluent.v0 as api_module
+
         if self._proto_files is not None:
             return
         owner_proto_files = [
             mod
-            for _, mod in inspect.getmembers(self._api_module, inspect.ismodule)
+            for _, mod in inspect.getmembers(api_module, inspect.ismodule)
             if hasattr(mod, "DESCRIPTOR")
         ]
         loaded_proto_files = [
@@ -118,8 +117,10 @@ class BatchOpsService(ServiceProtocol):
         stream of ``ExecuteResponse`` messages.  Each response is deserialized
         into the appropriate proto message type before being returned.
         """
+        from ansys.api.fluent.v0 import batch_ops_pb2
+
         requests = (
-            self._proto_module.ExecuteRequest(
+            batch_ops_pb2.ExecuteRequest(
                 package=op._package,
                 service=op._service_name,
                 method=op._method,

--- a/src/ansys/fluent/core/data_model_cache.py
+++ b/src/ansys/fluent/core/data_model_cache.py
@@ -28,9 +28,11 @@ from contextlib import contextmanager
 import copy
 from enum import Enum
 from threading import RLock
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ansys.api.fluent.v0.variant_pb2 import Variant
+if TYPE_CHECKING:
+    from ansys.api.fluent.v0.variant_pb2 import Variant
+
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 
 StateType = (
@@ -231,7 +233,7 @@ class DataModelCache:
         rules: str,
         source: dict[str, StateType],
         key: str,
-        state: Variant,
+        state: "Variant",
         updater_fn,
         rules_str: str,
         version,
@@ -323,7 +325,7 @@ class DataModelCache:
         source: dict[str, StateType],
         internal_names_as_keys: bool,
         key: str,
-        state: Variant,
+        state: "Variant",
         type_: str,
         iname: str,
     ) -> str:
@@ -349,7 +351,7 @@ class DataModelCache:
         return new_key
 
     def update_cache(
-        self, rules: str, state: Variant, deleted_paths: list[str], version=None
+        self, rules: str, state: "Variant", deleted_paths: list[str], version=None
     ):
         """Update datamodel cache from streamed state.
 

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -28,7 +28,6 @@ import warnings
 from deprecated.sphinx import deprecated
 import numpy as np
 
-from ansys.api.fluent.v1.field_data_pb2 import DataLocation
 from ansys.fluent.core import PyFluentDeprecationWarning
 from ansys.fluent.core.fields.field_data_interfaces import (
     BaseFieldInfo,
@@ -152,14 +151,7 @@ class BatchFieldData:
         scalar_field_data = self.data[
             (
                 ("type", "scalar-field"),
-                (
-                    "dataLocation",
-                    (
-                        DataLocation.DATA_LOCATION_NODES
-                        if node_value
-                        else DataLocation.DATA_LOCATION_ELEMENTS
-                    ),
-                ),
+                ("dataLocation", 1 if node_value else 0),
                 ("boundaryValues", boundary_value),
             )
         ]
@@ -605,14 +597,7 @@ class Batch(FieldBatch):
         for batch in self._scalar_field_batches:
             scalar_field_tag = (
                 ("type", "scalar-field"),
-                (
-                    "dataLocation",
-                    (
-                        DataLocation.DATA_LOCATION_NODES
-                        if batch.node_value
-                        else DataLocation.DATA_LOCATION_ELEMENTS
-                    ),
-                ),
+                ("dataLocation", 1 if batch.node_value else 0),
                 ("boundaryValues", batch.boundary_value),
             )
             field_data_surface = field_data.setdefault(scalar_field_tag, {})

--- a/src/ansys/fluent/core/file_session.py
+++ b/src/ansys/fluent/core/file_session.py
@@ -28,7 +28,7 @@ import warnings
 from deprecated.sphinx import deprecated
 import numpy as np
 
-from ansys.api.fluent.v0.field_data_pb2 import DataLocation
+from ansys.api.fluent.v1.field_data_pb2 import DataLocation
 from ansys.fluent.core import PyFluentDeprecationWarning
 from ansys.fluent.core.fields.field_data_interfaces import (
     BaseFieldInfo,
@@ -154,7 +154,11 @@ class BatchFieldData:
                 ("type", "scalar-field"),
                 (
                     "dataLocation",
-                    DataLocation.Nodes if node_value else DataLocation.Elements,
+                    (
+                        DataLocation.DATA_LOCATION_NODES
+                        if node_value
+                        else DataLocation.DATA_LOCATION_ELEMENTS
+                    ),
                 ),
                 ("boundaryValues", boundary_value),
             )
@@ -603,7 +607,11 @@ class Batch(FieldBatch):
                 ("type", "scalar-field"),
                 (
                     "dataLocation",
-                    DataLocation.Nodes if batch.node_value else DataLocation.Elements,
+                    (
+                        DataLocation.DATA_LOCATION_NODES
+                        if batch.node_value
+                        else DataLocation.DATA_LOCATION_ELEMENTS
+                    ),
                 ),
                 ("boundaryValues", batch.boundary_value),
             )

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -25,6 +25,7 @@
 
 from collections.abc import Callable
 from enum import Enum
+from functools import cached_property
 import json
 import logging
 import os
@@ -186,8 +187,6 @@ class BaseSession:
         )
         self._datamodel_events.start()
 
-        self._batch_ops_service = fluent_connection._service_factory.batch_ops
-
         if event_type:
             self.events = fluent_connection._service_factory._get_events_manager(
                 event_type=event_type,
@@ -216,6 +215,11 @@ class BaseSession:
         )
         for obj in filter(None, (self._datamodel_events, self.transcript, self.events)):
             self._fluent_connection.register_finalizer_cb(obj.stop)
+
+    @cached_property
+    def _batch_ops_service(self):
+        """gRPC service for batch operations (loaded on first use)."""
+        return self._fluent_connection._service_factory.batch_ops
 
     @deprecate_function(version="v0.38.0", new_func="is_active")
     def is_server_healthy(self) -> bool:

--- a/tests/test_file_session.py
+++ b/tests/test_file_session.py
@@ -324,7 +324,7 @@ def test_batch_request_single_phase_merges_multiple_fields_per_surface():
 
     scalar_field_tag = (
         ("type", "scalar-field"),
-        ("dataLocation", 1),
+        ("dataLocation", 0),
         ("boundaryValues", False),
     )
     assert set(data()[scalar_field_tag][5]) == {"SV_T", "SV_P"}
@@ -713,7 +713,7 @@ def test_batch_request_single_phase_deprecated():
     # Scalar Field Data
     scalar_field_tag = (
         ("type", "scalar-field"),
-        ("dataLocation", 1),
+        ("dataLocation", 0),
         ("boundaryValues", False),
     )
     scalar_data = data()[scalar_field_tag]
@@ -763,7 +763,7 @@ def test_batch_request_multi_phase_deprecated():
     # Scalar Field Data
     scalar_field_tag = (
         ("type", "scalar-field"),
-        ("dataLocation", 1),
+        ("dataLocation", 0),
         ("boundaryValues", False),
     )
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,6 +25,7 @@ from concurrent import futures
 import os
 from pathlib import Path
 import platform
+import sys
 import tempfile
 import time
 
@@ -1165,3 +1166,31 @@ def test_context_manager_with_session_switch(new_meshing_session_wo_exit):
         solver = meshing.switch_to_solver()
         assert not meshing.is_active()
         assert solver.is_active()
+
+
+def test_v0_not_imported_in_v1_session(new_solver_session):
+    solver = new_solver_session
+    case_file = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    examples.download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+
+    assert solver.is_active()
+
+    solver.settings.file.read_case_data(file_name=case_file)
+
+    assert solver.application_runtime.get_app_mode() == pyfluent.FluentMode.SOLVER
+
+    scalar_field_data_request = pyfluent.ScalarFieldDataRequest(
+        field_name="pressure",
+        surfaces=["cold-inlet"],
+    )
+
+    scalar_data = solver.fields.field_data.get_field_data(scalar_field_data_request)
+    assert scalar_data is not None
+
+    assert round(solver.fields.reduction.area(locations=["cold-inlet"]), 5) == 0.00389
+
+    for module_name in sys.modules.keys():
+        if solver.get_fluent_version() >= FluentVersion.v271:
+            assert not module_name.startswith("ansys.fluent.core.solver.v0")
+        else:
+            assert not module_name.startswith("ansys.fluent.core.solver.v1")


### PR DESCRIPTION
## Context
Earlier even when using Fluent 27R1, v0 proto files were getting imported though not used.

## Change Summary
Updated the design so that when v1 is active only v1 is imported and the v0 is not imported at all.

## Impact
None to users. The test shows that even after some operations with v1, v0 is not getting imported.
