### PR TITLE
fix: issue with interruptible commands on interrupt.

### DIFF
--- a/doc/changelog.d/5339.fixed.md
+++ b/doc/changelog.d/5339.fixed.md
@@ -1,0 +1,1 @@
+Issue with interruptible commands on interrupt.

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -179,6 +179,7 @@ class Solver(BaseSession, settings_root.root if TYPE_CHECKING else object):
                 flproxy=self._settings_service,
                 version=self._version,
                 interrupt=Solver._interrupt,
+                is_interruptible_command=Solver._is_interruptible_command,
                 file_transfer_service=self._file_transfer_service,
                 scheme_eval=self.scheme.eval,
             )
@@ -232,14 +233,24 @@ class Solver(BaseSession, settings_root.root if TYPE_CHECKING else object):
 
     @classmethod
     def _interrupt(cls, command):
-        interruptible_commands = [
+        _interruptible_commands = [
             "solution/run-calculation/iterate",
             "solution/run-calculation/calculate",
             "solution/run-calculation/dual-time-iterate",
         ]
         if config.support_solver_interrupt:
-            if command.path in interruptible_commands:
+            if command.path in _interruptible_commands:
                 command._root.solution.run_calculation.interrupt()
+
+    @classmethod
+    def _is_interruptible_command(cls, command) -> bool:
+        """Return True when *command* is a solver command that can be interrupted."""
+        _interruptible_commands = [
+            "solution/run-calculation/iterate",
+            "solution/run-calculation/calculate",
+            "solution/run-calculation/dual-time-iterate",
+        ]
+        return command.path in _interruptible_commands
 
     @property
     def system_coupling(self) -> SystemCoupling:

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -2271,8 +2271,10 @@ class Command(BaseCommand):
             self._root._on_interrupt(self)
             raise KeyboardInterrupt
         except RuntimeError as ex:
+            # TODO: Remove this Fluent specific logic during later refactoring.
             # RuntimeError("()") is Fluent's gRPC signal for a clean solver stop
-            # via interrupt(). Suppress it for interruptible commands so that
+            # via interrupt() or via manual stop from a GUI in connected instances.
+            # Suppress it for interruptible commands so that
             # workflow code following iterate()/calculate() continues normally.
             _is_interruptible = getattr(self._root, "_is_interruptible_command", None)
             if (
@@ -2300,8 +2302,10 @@ class CommandWithPositionalArgs(BaseCommand):
             self._root._on_interrupt(self)
             raise KeyboardInterrupt
         except RuntimeError as ex:
+            # TODO: Remove this Fluent specific logic during later refactoring.
             # RuntimeError("()") is Fluent's gRPC signal for a clean solver stop
-            # via interrupt(). Suppress it for interruptible commands so that
+            # via interrupt() or via manual stop from a GUI in connected instances.
+            # Suppress it for interruptible commands so that
             # workflow code following iterate()/calculate() continues normally.
             _is_interruptible = getattr(self._root, "_is_interruptible_command", None)
             if (

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -524,6 +524,10 @@ class Base:
         """Set interrupt method."""
         self._setattr("_on_interrupt", on_interrupt)
 
+    def _set_is_interruptible_command(self, is_interruptible_command):
+        """Set interruptible command checker."""
+        self._setattr("_is_interruptible_command", is_interruptible_command)
+
     def _set_file_transfer_service(self, file_transfer_service):
         """Set file_transfer_service."""
         self._setattr("_file_transfer_service", file_transfer_service)
@@ -2266,6 +2270,19 @@ class Command(BaseCommand):
         except KeyboardInterrupt:
             self._root._on_interrupt(self)
             raise KeyboardInterrupt
+        except RuntimeError as ex:
+            # RuntimeError("()") is Fluent's gRPC signal for a clean solver stop
+            # via interrupt(). Suppress it for interruptible commands so that
+            # workflow code following iterate()/calculate() continues normally.
+            _is_interruptible = getattr(self._root, "_is_interruptible_command", None)
+            if (
+                _is_interruptible is not None
+                and ex.args
+                and ex.args[0] == "()"
+                and _is_interruptible(self)
+            ):
+                return None
+            raise
 
 
 class CommandWithPositionalArgs(BaseCommand):
@@ -2282,6 +2299,19 @@ class CommandWithPositionalArgs(BaseCommand):
         except KeyboardInterrupt:
             self._root._on_interrupt(self)
             raise KeyboardInterrupt
+        except RuntimeError as ex:
+            # RuntimeError("()") is Fluent's gRPC signal for a clean solver stop
+            # via interrupt(). Suppress it for interruptible commands so that
+            # workflow code following iterate()/calculate() continues normally.
+            _is_interruptible = getattr(self._root, "_is_interruptible_command", None)
+            if (
+                _is_interruptible is not None
+                and ex.args
+                and ex.args[0] == "()"
+                and _is_interruptible(self)
+            ):
+                return None
+            raise
 
 
 class Query(Action):
@@ -2862,6 +2892,7 @@ def get_root(
     flproxy,
     version: str = "",
     interrupt: Any | None = None,
+    is_interruptible_command: Any | None = None,
     file_transfer_service: Any | None = None,
     scheme_eval=None,
 ) -> Group:
@@ -2873,6 +2904,11 @@ def get_root(
         Object that interfaces with the Fluent backend.
     interrupt: optional
         To interrupt interruptible commands.
+    is_interruptible_command : optional
+        Callable ``(command) -> bool`` that returns True when *command* is an
+        interruptible solver command (iterate, calculate, dual-time-iterate).
+        Used to suppress the ``RuntimeError("()")`` that Fluent returns via
+        gRPC when the solver is stopped cleanly by ``interrupt()``.
     file_transfer_service : optional
         File transfer service. Uploads/downloads files to/from the server.
     scheme_eval : Any
@@ -2909,6 +2945,8 @@ def get_root(
     root = root_cls()
     root.set_flproxy(flproxy)
     root._set_on_interrupt(interrupt)
+    if is_interruptible_command is not None:
+        root._set_is_interruptible_command(is_interruptible_command)
     root._set_file_transfer_service(file_transfer_service)
     _Alias.scheme_eval = scheme_eval
     _fix_parameter_list_return.scheme_eval = scheme_eval

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1202,7 +1202,7 @@ def test_iterate_with_interrupt(new_solver_session):
 
     assert "dummy-contour" in solver.settings.results.graphics.contour()
 
-    
+
 def test_v0_not_imported_in_v1_session(new_solver_session):
     solver = new_solver_session
     case_file = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -54,6 +54,10 @@ from ansys.fluent.core.pyfluent_warnings import PyFluentDeprecationWarning
 from ansys.fluent.core.session import BaseSession
 from ansys.fluent.core.solver import using
 from ansys.fluent.core.solver.flobject import InactiveObjectError
+from ansys.fluent.core.streaming_services.events_streaming import (
+    IterationEndedEventInfo,
+    SolverEvent,
+)
 from ansys.fluent.core.utils.execution import timeout_loop
 from ansys.fluent.core.utils.file_transfer_service import ContainerFileTransferStrategy
 from ansys.fluent.core.utils.fluent_version import FluentVersion
@@ -1165,3 +1169,34 @@ def test_context_manager_with_session_switch(new_meshing_session_wo_exit):
         solver = meshing.switch_to_solver()
         assert not meshing.is_active()
         assert solver.is_active()
+
+
+def test_iterate_with_interrupt(new_solver_session):
+    case_file = examples.download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    examples.download_file("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+
+    solver = new_solver_session
+    solver.settings.file.read_case(file_name=case_file)
+    solver.settings.solution.initialization.hybrid_initialize()
+
+    def on_iteration_ended(session, event_info: IterationEndedEventInfo) -> None:
+        if event_info.index >= 10:
+            # Signal Fluent to stop — Fluent stops cleanly
+            session.settings.solution.run_calculation.interrupt()
+
+    solver.events.register_callback(SolverEvent.ITERATION_ENDED, on_iteration_ended)
+
+    # Raises RuntimeError: () from Fluent when the solver is stopped
+    # cleanly via interrupt().  The RuntimeError is suppressed by the
+    # interruptible command guard in flobject.py, so workflow code
+    # following iterate()/calculate() continues normally.
+    solver.settings.solution.run_calculation.iterate(iter_count=100)
+
+    solver.settings.results.graphics.contour.create(name="dummy-contour")
+
+    solver.settings.results.graphics.contour["dummy-contour"] = {
+        "field": "pressure",
+        "surfaces_list": ["wall-elbow"],
+    }
+
+    assert "dummy-contour" in solver.settings.results.graphics.contour()


### PR DESCRIPTION
## Context
Calling `session.settings.solution.run_calculation.interrupt()` from within a SolverEvent.ITERATION_ENDED callback causes the concurrently-blocking `run_calculation.iterate()` gRPC call on the main thread to raise RuntimeError: () rather than returning normally — even though Fluent itself stops the solver cleanly and prints Done. Operation stopped.

The consequence is that any code following the iterate() call (writing case files, post-processing, etc.) is silently skipped. This makes event-driven convergence monitoring unreliable in practice.

## Change Summary
1. Pass is_interruptible from the solver to the settings root.
2. Use that to check if any interruptible commands raise `RuntimeError: ()`, and if so swallow the error.
3. Added test with the case in the particular bug to check the behavior for all Fluent versions.

## Rationale
Ideally Fluent should not raise an error in this case, but currently it is interrupting cleanly and raising an error with blank message unlike in other cases where the message strings are populated appropriately. Hence using that to handle this particular bug.

## Impact
Users will not face the situation as described, and will be able to develop similar workflows seamlessly.
