### PR TITLE
chore: Add a separate workflow in ci to promote Fluent image.

### DIFF
--- a/.github/workflows/promote_candidate_fluent_image.yml
+++ b/.github/workflows/promote_candidate_fluent_image.yml
@@ -1,4 +1,4 @@
-name: Test Run Dev Version Nightly
+name: Promote Candidate Fluent Image
 
 on:
   schedule: # UTC at 0300
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: test-run-dev-version-nightly-${{ github.workflow }}-${{ github.ref }}
+  group: promote-candidate-fluent-image-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -22,11 +22,12 @@ env:
   PYFLUENT_WATCHDOG_DEBUG: "OFF"
   PYFLUENT_HIDE_LOG_SECRETS: 1
   PYTHON_VERSION: "3.12"
+  FLUENT_IMAGE_TAG: v27.1.latest
   FLUENT_VERSION: 271
 
 jobs:
   test:
-    name: Unit Testing
+    name: Run Tests to Promote Candidate Fluent Image
     runs-on: [self-hosted, pyfluent]
 
     steps:
@@ -74,12 +75,12 @@ jobs:
       - name: Pull Fluent docker image
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
       - name: Run API codegen
         run: make api-codegen
         env:
-          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
 
       - name: Print Fluent version info
         env:
@@ -99,8 +100,17 @@ jobs:
           make unittest-all-${VERSION}
         env:
           VERSION: ${{ env.FLUENT_VERSION }}
-          FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
+          FLUENT_IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
         continue-on-error: true
+
+      - name: Update Fluent image
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_ACCESS_TOKEN }}
+          IMAGE_TAG: ${{ env.FLUENT_IMAGE_TAG }}
+        if: github.ref == 'refs/heads/main' && steps.unittest.outcome == 'success'
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ansys/fluent:${IMAGE_TAG} | sed 's/.*@//')
+          gh variable set FLUENT_STABLE_IMAGE_DEV --body $DIGEST
 
       - name: Clean Docker Data
         run: make docker-clean-all-except-supported-images

--- a/doc/changelog.d/5350.maintenance.md
+++ b/doc/changelog.d/5350.maintenance.md
@@ -1,0 +1,1 @@
+Add a separate workflow in ci to promote Fluent image.


### PR DESCRIPTION
## Context
The updating of the Fluent candidate image was part of the Nightly Dev Test run. So if the latest Fluent image is broken, the Stable image (that is used by all other PyFluent cis) will not update but a downside to this is that the Nightly tests will also fail without any issues in PyFluent.

## Change Summary
Two completely separate workflows in ci:
1. Nightly Dev Test run (existing) -> Only updated to run with the stable Fluent image
2. Promote Fluent Candidate Image -> Runs exactly the same set of tests as Nightly Dev Run, but only extra step is that it updates the stable Fluent image.

## Rationale
This will help us identify any issues with PyFluent separately via the Nightly Dev tests and keep it separate from the issues arrising due to updating of the Fluent image.
