### PR TITLE
feat: Direct construction of Meshing workflow objects

### DIFF
--- a/doc/changelog.d/5353.added.md
+++ b/doc/changelog.d/5353.added.md
@@ -1,0 +1,1 @@
+Direct construction of Meshing wprkflow objects

--- a/doc/changelog.d/5353.added.md
+++ b/doc/changelog.d/5353.added.md
@@ -1,1 +1,1 @@
-Direct construction of Meshing wprkflow objects
+Direct construction of Meshing workflow objects

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -37,6 +37,14 @@ from ansys.fluent.core.fields.field_data_interfaces import *
 from ansys.fluent.core.get_build_details import *
 from ansys.fluent.core.launcher.launch_options import *
 from ansys.fluent.core.launcher.launcher import *
+from ansys.fluent.core.meshing.meshing_workflow_new import (
+    CreateNewWorkflow,
+    FaultTolerantMeshing,
+    LoadExistingWorkflow,
+    TopologyBasedMeshing,
+    TwoDimensionalMeshing,
+    WatertightMeshing,
+)
 from ansys.fluent.core.parametric import *
 from ansys.fluent.core.pyfluent_warnings import *
 from ansys.fluent.core.search import *

--- a/src/ansys/fluent/core/meshing/meshing_workflow_new.py
+++ b/src/ansys/fluent/core/meshing/meshing_workflow_new.py
@@ -31,8 +31,36 @@ import os
 
 from ansys.fluent.core._types import PathType
 from ansys.fluent.core.services.object_model import PyMenu
+from ansys.fluent.core.session import Meshing, PureMeshing
+from ansys.fluent.core.session._shared import _make_datamodel_module
+from ansys.fluent.core.session.meshing import BaseMeshing
 from ansys.fluent.core.utils.fluent_version import FluentVersion
 from ansys.fluent.core.workflow_new import Workflow
+
+
+def _validate_meshing_session(session: BaseMeshing) -> bool:
+    """Check if the session is a meshing session.
+
+    Parameters
+    ----------
+    session : BaseMeshing
+        The session to check.
+
+    Returns
+    -------
+    bool
+        True if the session is a meshing session, False otherwise.
+
+    Raises
+    ------
+    TypeError
+        If the session is not an instance of BaseMeshing.
+    """
+    if not isinstance(session, BaseMeshing):
+        raise TypeError(
+            f"Expected a BaseMeshing session, got {type(session).__name__} instead."
+        )
+    return True
 
 
 class MeshingWorkflow(Workflow):
@@ -41,32 +69,29 @@ class MeshingWorkflow(Workflow):
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        name: str,
-        fluent_version: FluentVersion,
+        session: BaseMeshing,
+        workflow_type: str,
         initialize: bool = True,
     ) -> None:
         """Initialize MeshingWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        name: str
-            Workflow name to initialize it.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : BaseMeshing
+            The meshing session.
+        workflow_type: str
+            Workflow type to initialize it.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
         """
+        _validate_meshing_session(session)
+        self._meshing = session.meshing
         super().__init__(
-            workflow=workflow, command_source=meshing, fluent_version=fluent_version
+            workflow=_make_datamodel_module(session, "meshing_workflow"),
+            command_source=self._meshing,
+            fluent_version=session.get_fluent_version(),
         )
-        self._meshing = meshing
-        self._name = name
+        self._name = workflow_type
         if initialize:
             self._new_workflow(name=self._name)
         self._initialized = True
@@ -77,29 +102,23 @@ class WatertightMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         initialize: bool = True,
     ) -> None:
         """Initialize WatertightMeshingWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : PureMeshing | Meshing
+            The meshing session.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
         super().__init__(
-            workflow=workflow,
-            meshing=meshing,
-            name="Watertight Geometry",
-            fluent_version=fluent_version,
+            session=session,
+            workflow_type="Watertight Geometry",
             initialize=initialize,
         )
 
@@ -109,40 +128,28 @@ class FaultTolerantMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        part_management: PyMenu,
-        pm_file_management: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         initialize: bool = True,
     ) -> None:
         """Initialize FaultTolerantMeshingWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        part_management : PyMenu
-            Part management object.
-        pm_file_management : PyMenu
-            File management object in the part management object.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : PureMeshing | Meshing
+            The meshing session.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
         super().__init__(
-            workflow=workflow,
-            meshing=meshing,
-            name="Fault-tolerant Meshing",
-            fluent_version=fluent_version,
+            session=session,
+            workflow_type="Fault-tolerant Meshing",
             initialize=initialize,
         )
-        self._parent_workflow = workflow
-        self._part_management = part_management
-        self._pm_file_management = pm_file_management
+        self._parent_workflow = _make_datamodel_module(session, "meshing_workflow")
+        self._part_management = session.PartManagement
+        self._pm_file_management = session.PMFileManagement
 
     @property
     def parts(self) -> PyMenu | None:
@@ -196,29 +203,23 @@ class TwoDimensionalMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         initialize: bool = True,
     ) -> None:
         """Initialize TwoDimensionalMeshingWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : PureMeshing | Meshing
+            Meshing session object.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
         super().__init__(
-            workflow=workflow,
-            meshing=meshing,
-            name="2D Meshing",
-            fluent_version=fluent_version,
+            session=session,
+            workflow_type="2D Meshing",
             initialize=initialize,
         )
 
@@ -228,29 +229,23 @@ class TopologyBasedMeshingWorkflow(MeshingWorkflow):
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         initialize: bool = True,
     ) -> None:
         """Initialize TopologyBasedMeshingWorkflow.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : PureMeshing | Meshing
+            Meshing session object.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
         super().__init__(
-            workflow=workflow,
-            meshing=meshing,
-            name="Topology Based Meshing",
-            fluent_version=fluent_version,
+            session=session,
+            workflow_type="Topology Based Meshing",
             initialize=initialize,
         )
 
@@ -264,68 +259,66 @@ class WorkflowMode(Enum):
     TOPOLOGY_BASED_MESHING_MODE = TopologyBasedMeshingWorkflow
 
 
-class LoadWorkflow(Workflow):
+class LoadedWorkflow(Workflow):
     """Provides a specialization of the workflow wrapper for a loaded workflow."""
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         file_path: PathType = None,
         initialize: bool = True,
     ) -> None:
-        """Initialize a ``LoadWorkflow`` instance.
+        """Initialize a ``LoadedWorkflow`` instance.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
+        session : PureMeshing | Meshing
+            Meshing session object.
         file_path: os.PathLike[str | bytes] | str | bytes
             Path to the saved workflow file.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
+        _validate_meshing_session(session)
         super().__init__(
-            workflow=workflow, command_source=meshing, fluent_version=fluent_version
+            workflow=_make_datamodel_module(session, "meshing_workflow"),
+            command_source=session.meshing,
+            fluent_version=session.get_fluent_version(),
         )
-        self._meshing = meshing
+        self._meshing = session.meshing
         if initialize:
             self._load_workflow(file_path=os.fspath(file_path))
 
 
-class CreateWorkflow(Workflow):
+class CreatedWorkflow(Workflow):
     """Provides a specialization of the workflow wrapper for a newly created
     workflow."""
 
     def __init__(
         self,
-        workflow: PyMenu,
-        meshing: PyMenu,
-        fluent_version: FluentVersion,
+        session: PureMeshing | Meshing,
         initialize: bool = True,
     ) -> None:
-        """Initialize a ``CreateWorkflow`` instance.
+        """Initialize a ``CreatedWorkflow`` instance.
 
         Parameters
         ----------
-        workflow : PyMenu
-            Underlying workflow object.
-        meshing : PyMenu
-            Meshing object.
-        fluent_version: FluentVersion
-            Version of Fluent in this session.
+        session : PureMeshing | Meshing
+            Meshing session object.
         initialize: bool
             Flag to initialize the workflow, defaults to True.
+            Set this to False if you are connecting to an existing meshing session which
+            has been initialized and want to avoid re-initializing the workflow.
         """
+        _validate_meshing_session(session)
         super().__init__(
-            workflow=workflow, command_source=meshing, fluent_version=fluent_version
+            workflow=_make_datamodel_module(session, "meshing_workflow"),
+            command_source=session.meshing,
+            fluent_version=session.get_fluent_version(),
         )
-        self._meshing = meshing
+        self._meshing = session.meshing
         if initialize:
             self._create_workflow()
 
@@ -371,7 +364,10 @@ def get_current_workflow(
     # Handle loaded workflows (not in the factory map)
     if workflow_type not in workflow_factories:
         # This is a loaded workflow
-        if current_workflow and current_workflow.__class__.__name__ == "LoadWorkflow":
+        if current_workflow and current_workflow.__class__.__name__ in [
+            "LoadWorkflow",
+            "LoadedWorkflow",
+        ]:
             return current_workflow
         return load_workflow_handle(initialize=False)
 
@@ -380,3 +376,24 @@ def get_current_workflow(
     return _get_current_workflow(current_workflow, workflow_type) or factory(
         initialize=False
     )
+
+
+# Public aliases
+
+WatertightMeshing = WatertightMeshingWorkflow
+"""Alias for :class:`WatertightMeshingWorkflow`."""
+
+FaultTolerantMeshing = FaultTolerantMeshingWorkflow
+"""Alias for :class:`FaultTolerantMeshingWorkflow`."""
+
+TwoDimensionalMeshing = TwoDimensionalMeshingWorkflow
+"""Alias for :class:`TwoDimensionalMeshingWorkflow`."""
+
+TopologyBasedMeshing = TopologyBasedMeshingWorkflow
+"""Alias for :class:`TopologyBasedMeshingWorkflow`."""
+
+CreateNewWorkflow = CreatedWorkflow
+"""Alias for :class:`CreatedWorkflow`."""
+
+LoadExistingWorkflow = LoadedWorkflow
+"""Alias for :class:`LoadedWorkflow`."""

--- a/src/ansys/fluent/core/session/base_meshing.py
+++ b/src/ansys/fluent/core/session/base_meshing.py
@@ -326,17 +326,21 @@ class BaseMeshing(BaseSession):
         """
         legacy = self._fallback_check(legacy)
         if legacy:
-            root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import WorkflowMode
+
+            self._current_workflow = WorkflowMode.WATERTIGHT_MESHING_MODE.value(
+                _make_datamodel_module(self, "workflow"),
+                self.meshing,
+                self.get_fluent_version(),
+                initialize,
+            )
         else:
-            root_module = "meshing_workflow"
             from ansys.fluent.core.meshing.meshing_workflow_new import WorkflowMode
-        self._current_workflow = WorkflowMode.WATERTIGHT_MESHING_MODE.value(
-            _make_datamodel_module(self, root_module),
-            self.meshing,
-            self.get_fluent_version(),
-            initialize,
-        )
+
+            self._current_workflow = WorkflowMode.WATERTIGHT_MESHING_MODE.value(
+                self,
+                initialize,
+            )
         return self._current_workflow
 
     def _fault_tolerant_workflow(
@@ -360,19 +364,23 @@ class BaseMeshing(BaseSession):
         """
         legacy = self._fallback_check(legacy)
         if legacy:
-            root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import WorkflowMode
+
+            self._current_workflow = WorkflowMode.FAULT_TOLERANT_MESHING_MODE.value(
+                _make_datamodel_module(self, "workflow"),
+                self.meshing,
+                self.PartManagement,
+                self.PMFileManagement,
+                self.get_fluent_version(),
+                initialize,
+            )
         else:
-            root_module = "meshing_workflow"
             from ansys.fluent.core.meshing.meshing_workflow_new import WorkflowMode
-        self._current_workflow = WorkflowMode.FAULT_TOLERANT_MESHING_MODE.value(
-            _make_datamodel_module(self, root_module),
-            self.meshing,
-            self.PartManagement,
-            self.PMFileManagement,
-            self.get_fluent_version(),
-            initialize,
-        )
+
+            self._current_workflow = WorkflowMode.FAULT_TOLERANT_MESHING_MODE.value(
+                self,
+                initialize,
+            )
         return self._current_workflow
 
     def _two_dimensional_meshing_workflow(
@@ -396,17 +404,21 @@ class BaseMeshing(BaseSession):
         """
         legacy = self._fallback_check(legacy)
         if legacy:
-            root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import WorkflowMode
+
+            self._current_workflow = WorkflowMode.TWO_DIMENSIONAL_MESHING_MODE.value(
+                _make_datamodel_module(self, "workflow"),
+                self.meshing,
+                self.get_fluent_version(),
+                initialize,
+            )
         else:
-            root_module = "meshing_workflow"
             from ansys.fluent.core.meshing.meshing_workflow_new import WorkflowMode
-        self._current_workflow = WorkflowMode.TWO_DIMENSIONAL_MESHING_MODE.value(
-            _make_datamodel_module(self, root_module),
-            self.meshing,
-            self.get_fluent_version(),
-            initialize,
-        )
+
+            self._current_workflow = WorkflowMode.TWO_DIMENSIONAL_MESHING_MODE.value(
+                self,
+                initialize,
+            )
         return self._current_workflow
 
     def _topology_based_meshing_workflow(
@@ -430,18 +442,21 @@ class BaseMeshing(BaseSession):
         """
         legacy = self._fallback_check(legacy)
         if legacy:
-            root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import WorkflowMode
+
+            self._current_workflow = WorkflowMode.TOPOLOGY_BASED_MESHING_MODE.value(
+                _make_datamodel_module(self, "workflow"),
+                self.meshing,
+                self.get_fluent_version(),
+                initialize,
+            )
         else:
-            root_module = "meshing_workflow"
             from ansys.fluent.core.meshing.meshing_workflow_new import WorkflowMode
 
-        self._current_workflow = WorkflowMode.TOPOLOGY_BASED_MESHING_MODE.value(
-            _make_datamodel_module(self, root_module),
-            self.meshing,
-            self.get_fluent_version(),
-            initialize,
-        )
+            self._current_workflow = WorkflowMode.TOPOLOGY_BASED_MESHING_MODE.value(
+                self,
+                initialize,
+            )
         return self._current_workflow
 
     def load_workflow(
@@ -449,7 +464,7 @@ class BaseMeshing(BaseSession):
         file_path: PathType,
         legacy: bool | None = None,
         initialize: bool = True,
-    ) -> "_meshing_workflow.LoadWorkflow | meshing_workflow_new.LoadWorkflow":
+    ) -> "_meshing_workflow.LoadWorkflow | meshing_workflow_new.LoadedWorkflow":
         """Load a previously saved meshing workflow from file.
 
         Restores workflow configuration including tasks, settings, and state.
@@ -473,23 +488,19 @@ class BaseMeshing(BaseSession):
         """
         legacy = self._fallback_check(legacy)
         if legacy:
-            root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import LoadWorkflow
 
             self._current_workflow = LoadWorkflow(
-                _make_datamodel_module(self, root_module),
+                _make_datamodel_module(self, "workflow"),
                 self.meshing,
                 os.fspath(file_path),
                 self.get_fluent_version(),
             )
         else:
-            root_module = "meshing_workflow"
-            from ansys.fluent.core.meshing.meshing_workflow_new import LoadWorkflow
+            from ansys.fluent.core.meshing.meshing_workflow_new import LoadedWorkflow
 
-            self._current_workflow = LoadWorkflow(
-                _make_datamodel_module(self, root_module),
-                self.meshing,
-                self.get_fluent_version(),
+            self._current_workflow = LoadedWorkflow(
+                self,
                 os.fspath(file_path),
                 initialize,
             )
@@ -522,9 +533,9 @@ class BaseMeshing(BaseSession):
             from ansys.fluent.core.meshing.meshing_workflow import CreateWorkflow
         else:
             root_module = "meshing_workflow"
-            from ansys.fluent.core.meshing.meshing_workflow_new import CreateWorkflow
+            from ansys.fluent.core.meshing.meshing_workflow_new import CreatedWorkflow
 
-        self._current_workflow = CreateWorkflow(
+        self._current_workflow = CreatedWorkflow(
             _make_datamodel_module(self, root_module),
             self.meshing,
             self.get_fluent_version(),

--- a/src/ansys/fluent/core/session/base_meshing.py
+++ b/src/ansys/fluent/core/session/base_meshing.py
@@ -531,16 +531,21 @@ class BaseMeshing(BaseSession):
         if legacy:
             root_module = "workflow"
             from ansys.fluent.core.meshing.meshing_workflow import CreateWorkflow
+
+            self._current_workflow = CreateWorkflow(
+                _make_datamodel_module(self, root_module),
+                self.meshing,
+                self.get_fluent_version(),
+                initialize,
+            )
         else:
             root_module = "meshing_workflow"
             from ansys.fluent.core.meshing.meshing_workflow_new import CreatedWorkflow
 
-        self._current_workflow = CreatedWorkflow(
-            _make_datamodel_module(self, root_module),
-            self.meshing,
-            self.get_fluent_version(),
-            initialize,
-        )
+            self._current_workflow = CreatedWorkflow(
+                self,
+                initialize,
+            )
         return self._current_workflow
 
     def _get_current_workflow(

--- a/tests/test_server_meshing_workflow.py
+++ b/tests/test_server_meshing_workflow.py
@@ -24,7 +24,25 @@
 from conftest import SKIP_UNKNOWN
 import pytest
 
-from ansys.fluent.core import FluentVersion, PyFluentUserWarning, examples
+from ansys.fluent.core import (
+    CreateNewWorkflow,
+    FaultTolerantMeshing,
+    FluentVersion,
+    LoadExistingWorkflow,
+    PyFluentUserWarning,
+    TopologyBasedMeshing,
+    TwoDimensionalMeshing,
+    WatertightMeshing,
+    examples,
+)
+from ansys.fluent.core.meshing.meshing_workflow_new import (
+    CreatedWorkflow,
+    FaultTolerantMeshingWorkflow,
+    LoadedWorkflow,
+    TopologyBasedMeshingWorkflow,
+    TwoDimensionalMeshingWorkflow,
+    WatertightMeshingWorkflow,
+)
 from ansys.fluent.core.services.object_model import PyMenu
 
 
@@ -2059,3 +2077,64 @@ def test_switching_workflow_interface(new_meshing_session):
     lw = new_meshing_session.load_workflow(file_path=saved_workflow_path)
     wt2 = new_meshing_session.watertight()
     del wt1, ft, tw, cw, lw, wt2
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_direct_construction(new_meshing_session):
+    """WatertightMeshing(session=meshing) should work identically to
+    meshing.watertight() and so on."""
+
+    meshing = new_meshing_session
+    watertight = WatertightMeshing(session=meshing)
+
+    assert isinstance(watertight, WatertightMeshingWorkflow)
+    assert meshing.current_workflow is watertight
+    assert watertight.import_geometry
+
+    fault_tolerant = FaultTolerantMeshing(session=meshing)
+    assert isinstance(fault_tolerant, FaultTolerantMeshingWorkflow)
+    assert meshing.current_workflow is fault_tolerant
+    assert fault_tolerant.import_cad_and_part_management
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_direct_construction_of_create_workflow(new_meshing_session):
+    """CreateNewWorkflow(session=meshing) should work identically to
+    meshing.create_workflow() and so on."""
+
+    meshing = new_meshing_session
+    create_workflow = CreateNewWorkflow(session=meshing)
+
+    assert isinstance(create_workflow, CreatedWorkflow)
+    assert meshing.current_workflow is create_workflow
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_direct_construction_of_load_workflow(new_meshing_session):
+    """LoadExistingWorkflow(session=meshing) should work identically to
+    meshing.load_workflow() and so on."""
+
+    meshing = new_meshing_session
+    saved_workflow_path = examples.download_file(
+        "sample_watertight_workflow.wft", "pyfluent/meshing_workflows"
+    )
+    loaded_workflow = LoadExistingWorkflow(
+        session=meshing, file_path=saved_workflow_path
+    )
+
+    assert isinstance(loaded_workflow, LoadedWorkflow)
+    assert meshing.current_workflow is loaded_workflow
+    assert "set_up_rotational_periodic_boundaries" in loaded_workflow.task_names()
+
+
+@pytest.mark.fluent_version(">=26.1")
+def test_invalid_session(new_solver_session):
+    """Passing a solver session to a meshing workflow constructor should raise TypeError."""
+    with pytest.raises(TypeError):
+        _ = WatertightMeshing(session=new_solver_session)
+    with pytest.raises(TypeError):
+        _ = FaultTolerantMeshing(session=new_solver_session)
+    with pytest.raises(TypeError):
+        _ = CreateNewWorkflow(session=new_solver_session)
+    with pytest.raises(TypeError):
+        _ = LoadExistingWorkflow(session=new_solver_session)

--- a/tests/test_server_meshing_workflow.py
+++ b/tests/test_server_meshing_workflow.py
@@ -2079,7 +2079,7 @@ def test_switching_workflow_interface(new_meshing_session):
     del wt1, ft, tw, cw, lw, wt2
 
 
-@pytest.mark.fluent_version(">=26.1")
+@pytest.mark.fluent_version(">=27.1")
 def test_direct_construction(new_meshing_session):
     """WatertightMeshing(session=meshing) should work identically to
     meshing.watertight() and so on."""

--- a/tests/test_server_meshing_workflow.py
+++ b/tests/test_server_meshing_workflow.py
@@ -2088,12 +2088,10 @@ def test_direct_construction(new_meshing_session):
     watertight = WatertightMeshing(session=meshing)
 
     assert isinstance(watertight, WatertightMeshingWorkflow)
-    assert meshing.current_workflow is watertight
     assert watertight.import_geometry
 
     fault_tolerant = FaultTolerantMeshing(session=meshing)
     assert isinstance(fault_tolerant, FaultTolerantMeshingWorkflow)
-    assert meshing.current_workflow is fault_tolerant
     assert fault_tolerant.import_cad_and_part_management
 
 
@@ -2106,7 +2104,6 @@ def test_direct_construction_of_create_workflow(new_meshing_session):
     create_workflow = CreateNewWorkflow(session=meshing)
 
     assert isinstance(create_workflow, CreatedWorkflow)
-    assert meshing.current_workflow is create_workflow
 
 
 @pytest.mark.fluent_version(">=26.1")
@@ -2123,7 +2120,6 @@ def test_direct_construction_of_load_workflow(new_meshing_session):
     )
 
     assert isinstance(loaded_workflow, LoadedWorkflow)
-    assert meshing.current_workflow is loaded_workflow
     assert "set_up_rotational_periodic_boundaries" in loaded_workflow.task_names()
 
 


### PR DESCRIPTION
Meshing workflow objects can be directly constructed from session.

For example:
```python
from ansys.fluent.core import WatertightMeshing
watertight = WatertightMeshing(session=session)
```
