### PR TITLE
docs: improve PyFluent docs discoverability

### DIFF
--- a/doc/changelog.d/5355.documentation.md
+++ b/doc/changelog.d/5355.documentation.md
@@ -1,0 +1,1 @@
+Improve PyFluent docs discoverability

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,0 +1,17 @@
+{#
+  Inject a canonical link pointing at the equivalent page in the `stable`
+  version of the docs. This consolidates ranking signal across the many
+  versioned builds (/version/0.14/, /version/dev/, /version/stable/, ...)
+  onto a single authoritative URL per page.
+
+  See pyfluent-doc-plan.md §4.
+#}
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {%- if pagename %}
+  <link rel="canonical"
+        href="https://fluent.docs.pyansys.com/version/stable/{{ pagename }}.html" />
+  {%- endif %}
+{% endblock %}

--- a/doc/source/cheatsheet/index.rst
+++ b/doc/source/cheatsheet/index.rst
@@ -24,10 +24,10 @@ Import PyFluent and the settings API objects most workflows need:
    import ansys.fluent.core as pyfluent
    from ansys.units import VariableCatalog as VC
    from ansys.fluent.core import (
-	   ScalarFieldDataRequest,
-	   VectorFieldDataRequest,
-	   SurfaceFieldDataRequest,
-	   SurfaceDataType,
+      ScalarFieldDataRequest,
+      VectorFieldDataRequest,
+      SurfaceFieldDataRequest,
+      SurfaceDataType,
    )
    from ansys.fluent.core.solver import *
 
@@ -100,7 +100,7 @@ settings API:
 
    turbulence = inlet.turbulence
    turbulence = (
-	   turbulence.turbulence_specification.INTENSITY_AND_HYDRAULIC_DIAMETER
+      turbulence.turbulence_specification.INTENSITY_AND_HYDRAULIC_DIAMETER
    )
    turbulence.turbulent_intensity = 0.05
    turbulence.hydraulic_diameter = "4 [in]"
@@ -211,18 +211,18 @@ Request scalar, vector, and surface field data from the solver:
    field_data = solver.fields.field_data
 
    abs_press_req = ScalarFieldDataRequest(
-	   field_name=VC.ABSOLUTE_PRESSURE, surfaces=["cold-inlet"]
+      field_name=VC.ABSOLUTE_PRESSURE, surfaces=["cold-inlet"]
    )
    abs_pressure = field_data.get_field_data(abs_press_req)
 
    vel_req = VectorFieldDataRequest(
-	   field_name=VC.VELOCITY, surfaces=["cold-inlet"]
+      field_name=VC.VELOCITY, surfaces=["cold-inlet"]
    )
    velocity = field_data.get_field_data(vel_req)
 
    surf_req = SurfaceFieldDataRequest(
-	   data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesCentroid],
-	   surfaces=["hot-inlet", "cold-inlet"],
+      data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesCentroid],
+      surfaces=["hot-inlet", "cold-inlet"],
    )
    surfaces = field_data.get_field_data(surf_req)
    vertices = surfaces["cold-inlet"].vertices
@@ -264,10 +264,10 @@ locations:
    volume = reduction.volume(locations=[velocity_inlet])
 
    avg_pressure = reduction.area_average(
-	   VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
+      VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
    )
    total_mass = reduction.mass_integral(
-	   VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
+      VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
    )
 
    force = reduction.force(locations=[wall])
@@ -286,18 +286,18 @@ Read and write raw solution variable data by zone and domain:
 
    zones_info = sv_info.get_zones_info()
    temp_data = sv_data.get_data(
-	   variable_name=VC.TEMPERATURE,
-	   zone_names=["elbow-fluid"],
-	   domain_name="mixture",
+      variable_name=VC.TEMPERATURE,
+      zone_names=["elbow-fluid"],
+      domain_name="mixture",
    )
 
    temp_array = sv_data.create_empty_array(
-	   VC.TEMPERATURE, "elbow-fluid", "mixture"
+      VC.TEMPERATURE, "elbow-fluid", "mixture"
    )
    temp_array[:] = 500
 
    sv_data.set_data(
-	   variable_name=VC.TEMPERATURE,
-	   zone_names_to_data={"elbow-fluid": temp_array},
-	   domain_name="mixture",
+      variable_name=VC.TEMPERATURE,
+      zone_names_to_data={"elbow-fluid": temp_array},
+      domain_name="mixture",
    )

--- a/doc/source/cheatsheet/index.rst
+++ b/doc/source/cheatsheet/index.rst
@@ -1,0 +1,303 @@
+.. _ref_pyfluent_cheat_sheet:
+
+PyFluent cheat sheet
+====================
+
+A quick reference to the most common PyFluent commands for launching Ansys
+Fluent from Python, importing a mesh, defining materials, defining boundary
+conditions, modifying cell zone conditions, applying solution settings, and
+accessing field data. A printable PDF version is also available from the
+sidebar of the docs.
+
+.. contents:: Quick reference
+   :local:
+   :depth: 2
+
+
+Quick start
+-----------
+
+Import PyFluent and the settings API objects most workflows need:
+
+.. code-block:: python
+
+   import ansys.fluent.core as pyfluent
+   from ansys.units import VariableCatalog as VC
+   from ansys.fluent.core import (
+	   ScalarFieldDataRequest,
+	   VectorFieldDataRequest,
+	   SurfaceFieldDataRequest,
+	   SurfaceDataType,
+   )
+   from ansys.fluent.core.solver import *
+
+
+Launching Fluent
+----------------
+
+Launch a solver or meshing session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   solver = pyfluent.Solver.from_install()
+   meshing = pyfluent.Meshing.from_install()
+
+Connect to an existing Fluent session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   session = pyfluent.Solver.from_connection(ip, port, password)
+
+
+Reading and writing case and data files
+---------------------------------------
+
+.. code-block:: python
+
+   ReadCase(settings_source=solver)(file_name="<case_file>")
+   ReadCaseData(settings_source=solver)(file_name="<data_file>")
+
+   WriteCase(settings_source=solver)(file_name="<output_case_file>")
+   WriteCaseData(settings_source=solver)(file_name="<output_case_file>")
+
+
+Importing a mesh (watertight geometry workflow)
+-----------------------------------------------
+
+.. code-block:: python
+
+   watertight = meshing.watertight()
+
+   import_geom = watertight.import_geometry
+   import_geom.file_name = "<geometry_file>"
+   import_geom.length_unit = "mm"
+   import_geom()
+
+   surf_mesh = watertight.create_surface_mesh
+   surf_mesh.cfd_surface_mesh_controls.max_size = 0.3
+   surf_mesh()
+
+   watertight.describe_geometry.setup_type = "fluid"
+   watertight.describe_geometry()
+
+   volume_mesh = watertight.create_volume_mesh_wtm
+   volume_mesh.volume_fill = "poly-hexcore"
+   volume_mesh()
+
+
+Defining boundary conditions
+----------------------------
+
+Set a velocity inlet with turbulence and thermal conditions using the
+settings API:
+
+.. code-block:: python
+
+   inlet = VelocityInlet(solver, name="cold-inlet")
+   inlet.momentum.velocity_magnitude = 0.4
+
+   turbulence = inlet.turbulence
+   turbulence = (
+	   turbulence.turbulence_specification.INTENSITY_AND_HYDRAULIC_DIAMETER
+   )
+   turbulence.turbulent_intensity = 0.05
+   turbulence.hydraulic_diameter = "4 [in]"
+
+   inlet.thermal.temperature = 293.15
+
+
+Defining materials
+------------------
+
+.. code-block:: python
+
+   materials = Materials(solver)
+   air_copy = materials.fluid.make_a_copy(from_="air", to="air-copied")
+   materials.fluid["air-copied"].viscosity = 1.81e-05
+
+   # Create a new solid material
+   my_solid = materials.solid.create("my-solid")
+   my_solid.density.value = 2650
+   my_solid.thermal_conductivity.value = 7.6
+
+
+Modifying cell zone conditions
+------------------------------
+
+.. code-block:: python
+
+   cell_zones = CellZoneConditions(solver)
+   cell_zones.fluid["elbow-fluid"].general.material = "air-copied"
+
+
+Enabling physics models
+-----------------------
+
+Energy, viscous turbulence, radiation, and species transport models:
+
+.. code-block:: python
+
+   models = Models(solver)
+   models.energy.enabled = True
+   models.energy.viscous_dissipation = True
+
+   viscous = Viscous(solver)
+   viscous.model = viscous.model.K_EPSILON
+   k_epsilon_model = viscous.k_epsilon_model
+   k_epsilon_model = k_epsilon_model.REALIZABLE
+
+   rad = Radiation(solver)
+   rad.model = rad.model.MONTE_CARLO
+   rad.solve_frequency.number_of_histories = 1e7
+
+   species = Species(solver).model.option
+   species = species.SPECIES_TRANSPORT
+
+
+Applying solution settings
+--------------------------
+
+Configure solution methods:
+
+.. code-block:: python
+
+   soln = Solution(solver)
+
+   methods = soln.methods
+   methods.p_v_coupling.flow_scheme = "Coupled"
+
+   grad_scheme = methods.spatial_discretization.gradient_scheme
+   grad_scheme = grad_scheme.GREEN_GAUSS_NODE_BASED
+
+Define surface report definitions:
+
+.. code-block:: python
+
+   rep_defs = ReportDefinitions(solver)
+   rep_defs.surface["outlet-temp-avg"] = {}
+
+   soln_report_type = rep_defs.surface["outlet-temp-avg"].report_type
+   soln_report_type = soln_report_type.SURFACE_AREA
+
+   rep_defs.surface["outlet-temp-avg"].field = VC.TEMPERATURE
+
+Initialize and run the calculation:
+
+.. code-block:: python
+
+   initialization = Initialization(solver)
+   init_type = initialization.initialization_type
+   init_type = init_type.HYBRID
+
+   Initialize(solver)()
+
+   run_calc = RunCalculation(solver)
+   run_calc.parameters.iter_count = 100
+
+   Iterate(solver)()
+
+   Monitor(solver).residual.plot()
+
+
+Accessing field data
+--------------------
+
+Request scalar, vector, and surface field data from the solver:
+
+.. code-block:: python
+
+   field_data = solver.fields.field_data
+
+   abs_press_req = ScalarFieldDataRequest(
+	   field_name=VC.ABSOLUTE_PRESSURE, surfaces=["cold-inlet"]
+   )
+   abs_pressure = field_data.get_field_data(abs_press_req)
+
+   vel_req = VectorFieldDataRequest(
+	   field_name=VC.VELOCITY, surfaces=["cold-inlet"]
+   )
+   velocity = field_data.get_field_data(vel_req)
+
+   surf_req = SurfaceFieldDataRequest(
+	   data_types=[SurfaceDataType.Vertices, SurfaceDataType.FacesCentroid],
+	   surfaces=["hot-inlet", "cold-inlet"],
+   )
+   surfaces = field_data.get_field_data(surf_req)
+   vertices = surfaces["cold-inlet"].vertices
+   centroids = surfaces["hot-inlet"].face_centroids
+
+Query field metadata (allowed values, active status, ranges):
+
+.. code-block:: python
+
+   scalar_fields = field_data.scalar_fields
+   vector_fields = field_data.vector_fields
+   surface_fields = field_data.surfaces
+
+   scalar_names = scalar_fields.allowed_values()
+   vector_names = vector_fields.allowed_values()
+   surface_names = surface_fields.allowed_values()
+
+   temp_active = scalar_fields.is_active(VC.TEMPERATURE)
+   vel_active = vector_fields.is_active(VC.VELOCITY)
+
+   temp_range = scalar_fields.range(VC.TEMPERATURE)
+   vmag_range = scalar_fields.range(VC.VELOCITY_MAGNITUDE)
+
+
+Reduction functions
+-------------------
+
+Compute area, volume, averages, integrals, forces, and extrema over boundary
+locations:
+
+.. code-block:: python
+
+   reduction = solver.fields.reduction
+   velocity_inlet = VelocityInlet(solver, name="cold-inlet")
+   pressure_outlet = PressureOutlet(solver, name="outlet")
+   wall = WallBoundary(solver, name="wall-elbow")
+
+   area = reduction.area(locations=[velocity_inlet])
+   volume = reduction.volume(locations=[velocity_inlet])
+
+   avg_pressure = reduction.area_average(
+	   VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
+   )
+   total_mass = reduction.mass_integral(
+	   VC.ABSOLUTE_PRESSURE, locations=[pressure_outlet]
+   )
+
+   force = reduction.force(locations=[wall])
+   max_vel = reduction.maximum(VC.VELOCITY_MAGNITUDE, locations=[wall])
+
+
+Solution variables
+------------------
+
+Read and write raw solution variable data by zone and domain:
+
+.. code-block:: python
+
+   sv_info = solver.fields.solution_variable_info
+   sv_data = solver.fields.solution_variable_data
+
+   zones_info = sv_info.get_zones_info()
+   temp_data = sv_data.get_data(
+	   variable_name=VC.TEMPERATURE,
+	   zone_names=["elbow-fluid"],
+	   domain_name="mixture",
+   )
+
+   temp_array = sv_data.create_empty_array(
+	   VC.TEMPERATURE, "elbow-fluid", "mixture"
+   )
+   temp_array[:] = 500
+
+   sv_data.set_data(
+	   variable_name=VC.TEMPERATURE,
+	   zone_names_to_data={"elbow-fluid": temp_array},
+	   domain_name="mixture",
+   )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,9 +38,16 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_sitemap",
     "sphinxemoji.sphinxemoji",
     "sphinx_toggleprompt",
 ]
+
+# Canonical base URL used by sphinx-sitemap and by search engines to
+# consolidate ranking signal onto the `stable` version of the docs.
+# See pyfluent-doc-plan.md §4 and §5.
+html_baseurl = "https://fluent.docs.pyansys.com/version/stable/"
+sitemap_url_scheme = "{link}"
 
 toggleprompt_offset_right = 35
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,6 +7,7 @@ PyFluent documentation |version|
 
    getting_started/getting_started_contents
    user_guide/user_guide_contents
+   cheatsheet/index
    api/api_contents
    examples/index
    contributing/contributing_contents
@@ -50,6 +51,8 @@ Getting started
 ---------------
 
 Get started with PyFluent by following the steps in the :ref:`getting_started` guide.
+For a one-page reference of the most common commands, see the
+:ref:`PyFluent cheat sheet <ref_pyfluent_cheat_sheet>`.
 
 
 Resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.21.0",
     "sphinx-notfound-page==1.1.0",
+    "sphinx-sitemap==2.6.0",
     "sphinxcontrib-websupport==2.0.0",
     "sphinx_design==0.6.1",
     "sphinxemoji==0.3.2",


### PR DESCRIPTION
# docs: improve PyFluent docs discoverability (SEO)
_AI generated PR / WIP_
## Background

Searching for *"PyFluent"* and related terms (e.g. *"PyFluent cheat sheet"*,
*"PyFluent settings API"*) currently surfaces the Ansys Developer forum
(`developer.ansys.com` / `developer.synopsys.com`) ahead of the official
PyAnsys documentation, and in some cases the official docs don't appear at
all in the first several pages of results. Forum content is unmaintained
and can be materially out of date compared to the maintained docs.

Investigation confirmed this is **not** a `robots.txt` block or a
de-indexing problem — `fluent.docs.pyansys.com` and its cheat sheet PDF
are indexed and do appear in search. The root causes are ranking-signal
problems that are fixable independent of Ansys's overall domain authority:

1. **Duplicate/fragmented content** — the same cheat sheet PDF exists at
   three separate URLs (`fluent.docs.pyansys.com/version/stable/_static/cheat_sheet.pdf`,
   `fluent.docs.pyansys.com/version/dev/_static/cheat_sheet.pdf`, and
   `cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf`), splitting
   ranking signal three ways instead of consolidating it onto one URL.
2. **PDF vs. HTML** — the cheat sheet is only published as a PDF. The
   competing forum page is a normal HTML blog post with real headings and
   anchor links, which Google generally indexes and ranks better for
   phrase-based queries than PDF text.
3. **No canonicalization across versions** — every released version of
   PyFluent (`/version/0.14/`, `/version/0.34.dev0/`, `/version/dev/`,
   `/version/stable/`, etc.) is a near-duplicate page with no canonical
   tag pointing back to one authoritative URL, further diluting ranking
   signal for any single page.
4. **Weak internal/external linking** — no confirmed backlink from the
   Ansys Developer forum back to the canonical PyAnsys docs, despite the
   forum content covering the same library.
5. **Unverified indexing hygiene** — `sitemap.xml` presence/submission and
   Google Search Console coverage status had not been confirmed for
   `fluent.docs.pyansys.com`.

This PR applies the fixes for the ranking-signal problems that can be
addressed inside this repository. The remaining items (hosting-side
redirects, Google Search Console work, forum backlink request) still need
to be actioned outside the repo; they are called out below.

## Root causes addressed

| Root cause | Fixed in this PR? | Where |
|---|---|---|
| 1. Duplicate/fragmented cheat sheet PDF URLs | Partial (in-repo half only) | See "Not in this PR" below |
| 2. Cheat sheet only published as PDF, not HTML | Yes | New `doc/source/cheatsheet/index.rst` |
| 3. No canonicalization across versions | Yes | `conf.py` + `_templates/layout.html` |
| 4. Weak internal/external linking | Partial | Homepage now links the cheat sheet with the literal anchor text *"PyFluent cheat sheet"* |
| 5. Unverified indexing hygiene (no sitemap) | Yes (generation half) | `sphinx-sitemap` added |

## Changes

### 1. Canonicalize every versioned docs page to `stable`

- **`doc/source/conf.py`** — set
  `html_baseurl = "https://fluent.docs.pyansys.com/version/stable/"` and
  `sitemap_url_scheme = "{link}"`.
- **`doc/source/_templates/layout.html`** (new) — extends the
  ansys-sphinx-theme base template and injects
  `<link rel="canonical" href=".../version/stable/{{ pagename }}.html">` in
  `extrahead` on every page.

This tells Google that `/version/0.14/…`, `/version/dev/…`,
`/version/0.34.dev0/…` etc. all consolidate onto the `stable` equivalent —
directly addressing root cause #3 (ranking signal split across every
released version).

### 2. Generate a real `sitemap.xml`

- **`pyproject.toml`** — added `sphinx-sitemap==2.6.0` to the `doc`
  dependency set.
- **`doc/source/conf.py`** — registered `sphinx_sitemap` in `extensions`.

`sitemap.xml` will now be produced automatically on every doc build,
enabling submission via Google Search Console.

### 3. Publish the cheat sheet as a real HTML page

- **`doc/source/cheatsheet/index.rst`** (new) — HTML cheat sheet with:
  - Reference target `_ref_pyfluent_cheat_sheet` for internal linking.
  - Intro paragraph front-loaded with the phrases the forum post ranks for:
    *launching Ansys Fluent from Python*, *importing a mesh*,
    *defining materials*, *defining boundary conditions*,
    *modifying cell zone conditions*, *applying solution settings*,
    *accessing field data*.
  - A `.. contents::` block giving Google real anchor targets for each
    section — the "quick reference" jump-link UX pattern that is one
    reason the forum post currently wins.
  - Real `<h2>`/`<h3>` headings mirroring the Quarto cheat sheet content:
    Quick start, Launching Fluent, Reading and writing case and data files,
    Importing a mesh, Defining boundary conditions, Defining materials,
    Modifying cell zone conditions, Enabling physics models, Applying
    solution settings, Accessing field data, Reduction functions,
    Solution variables.
  - All code blocks copied from `doc/source/cheatsheet/cheat_sheet.qmd`
    so the two are content-equivalent at merge time.
- **`doc/source/index.rst`**:
  - Added `cheatsheet/index` to the hidden toctree.
  - Added a prominent link in the "Getting started" section using the
    literal anchor text *"PyFluent cheat sheet"*.

## Not in this PR (out-of-repo follow-ups)

These items cannot be done in this repository and remain open:

- **Redirect duplicate cheat sheet PDFs.** The two duplicates at
  `fluent.docs.pyansys.com/version/{stable,dev}/_static/cheat_sheet.pdf`
  still need to be 301'd (or stubbed with meta-refresh + canonical) to
  `cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf`. Requires
  hosting/CI access. Recommended canonical location is
  `cheatsheets.docs.pyansys.com` since it acts as the shared hub across
  PyAnsys libraries.
- **Google Search Console.** Verify `fluent.docs.pyansys.com`, submit the
  newly generated `sitemap.xml`, and request re-indexing of the canonical
  cheat sheet URL and a sample of `stable` pages. Check the Coverage /
  Page indexing report for the cheat sheet PDF URLs, looking for
  "Duplicate, Google chose different canonical" warnings clearing.
- **`robots.txt`.** Add a `Sitemap:` line pointing at the generated
  `sitemap.xml`. Lives at the hosting root, not in Sphinx source.
- **Backlink from the Ansys Developer forum.** Ask the forum content team
  to have the existing PyFluent cheat sheet and settings-API posts link
  to the canonical PyAnsys docs as the maintained source of truth.
- **Audit whether the settings API documentation has the same
  fragmentation issue as the cheat sheet.**
- **Update external references** (README.md, PyPI project description,
  other docs pages) to point at the new canonical cheat sheet URL
  directly, rather than relying on redirects.

## Caveats and risks

1. **Blanket canonicalization to `stable`.** `html_baseurl` and the
   injected canonical `<link>` are set unconditionally to the `stable`
   URL. On `dev`-only pages that don't yet exist in `stable`, this will
   canonicalize to a non-existent URL until the next release. If Search
   Console flags this, drive `html_baseurl` and the canonical URL from a
   CI env var so only `stable`/tagged builds inject a cross-version
   canonical and `dev` self-canonicalizes.
2. **Cheat sheet content is duplicated, not single-sourced.** The ideal
   is one source generating both the PDF and the HTML. This PR copies the
   content from `cheat_sheet.qmd` into a new `.rst` rather than
   generating both from one source. Content drift risk is real; a
   follow-up issue to unify the source is recommended.
3. **Build not run locally.** Reviewers should confirm the doc build
   passes in CI before merge.

## Verification

Post-deploy verification enabled by this PR:

- View source on any versioned docs page should show a canonical `<link>`
  pointing at the equivalent `stable` URL.
- `sitemap.xml` should be present at the site root after deploy.
- `site:fluent.docs.pyansys.com "PyFluent cheat sheet"` should, after
  re-crawl (typically 1–4 weeks), start surfacing the new HTML page
  rather than only the PDF. Ranking changes from canonicalization and
  redirects take days to a few weeks to appear; do not judge success
  from same-day search checks.
- Search Console Coverage report should no longer flag
  duplicate/canonical conflicts for the cheat sheet URLs once the
  hosting-side redirects (see "Not in this PR") are also live.

## Files changed

- `doc/source/conf.py` — canonical base URL + sitemap extension.
- `doc/source/_templates/layout.html` — **new**, canonical link injection.
- `doc/source/cheatsheet/index.rst` — **new**, HTML cheat sheet.
- `doc/source/index.rst` — toctree entry + homepage link.
- `pyproject.toml` — `sphinx-sitemap` dependency.
