### PR TITLE
chore: Add retries to Fluent image pull.

### DIFF
--- a/.ci/pull_fluent_image.py
+++ b/.ci/pull_fluent_image.py
@@ -3,17 +3,37 @@ Pull a Fluent Docker image based on the FLUENT_IMAGE_TAG environment variable.
 """
 
 import subprocess
+import time
 
 from ansys.fluent.core import config
 from ansys.fluent.core.docker.utils import get_ghcr_fluent_image_name
 
 
 def pull_fluent_image():
-    """Pull Fluent Docker image and clean up dangling images."""
+    """Pull Fluent Docker image and clean up dangling images.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the cleanup script fails to execute.
+    """
+    max_retries = 3
     fluent_image_tag = config.fluent_image_tag
     image_name = get_ghcr_fluent_image_name(fluent_image_tag)
     separator = "@" if fluent_image_tag.startswith("sha256") else ":"
     full_image_name = f"{image_name}{separator}{fluent_image_tag}"
+    for attempt in range(max_retries):
+        try:
+            subprocess.run(["docker", "pull", full_image_name], check=True)
+            break  # Success! Exit the loop.
+        except subprocess.CalledProcessError as e:
+            if attempt < max_retries - 1:
+                print(
+                    f"Pull failed due to rate limits. Retrying in 2 seconds... (Attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(2)
+            else:
+                raise e
     subprocess.run(["docker", "pull", full_image_name], check=True)
     subprocess.run(["docker", "image", "prune", "-f"], check=True)
 

--- a/.ci/pull_fluent_image.py
+++ b/.ci/pull_fluent_image.py
@@ -34,7 +34,6 @@ def pull_fluent_image():
                 time.sleep(2)
             else:
                 raise e
-    subprocess.run(["docker", "pull", full_image_name], check=True)
     subprocess.run(["docker", "image", "prune", "-f"], check=True)
 
 

--- a/.github/workflows/test-run-dev-version-nightly.yml
+++ b/.github/workflows/test-run-dev-version-nightly.yml
@@ -74,11 +74,13 @@ jobs:
       - name: Pull Fluent docker image
         run: make docker-pull
         env:
+          FLUENT_STABLE_IMAGE_DEV: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Run API codegen
         run: make api-codegen
         env:
+          FLUENT_STABLE_IMAGE_DEV: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
 
       - name: Print Fluent version info
@@ -99,6 +101,7 @@ jobs:
           make unittest-all-${VERSION}
         env:
           VERSION: ${{ env.FLUENT_VERSION }}
+          FLUENT_STABLE_IMAGE_DEV: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
           FLUENT_IMAGE_TAG: ${{ vars.FLUENT_STABLE_IMAGE_DEV }}
         continue-on-error: true
 

--- a/doc/changelog.d/5357.maintenance.md
+++ b/doc/changelog.d/5357.maintenance.md
@@ -1,0 +1,1 @@
+Add retries to Fluent image pull.


### PR DESCRIPTION
Add retries to Fluent image pull as sometimes the image pulling is failing with `TooManyRequestsError`.
