### PR TITLE
fix: Token parser for CaseReader.

### DIFF
--- a/doc/changelog.d/5358.fixed.md
+++ b/doc/changelog.d/5358.fixed.md
@@ -1,0 +1,1 @@
+Token parser for CaseReader.

--- a/src/ansys/fluent/core/file_reader/lispy.py
+++ b/src/ansys/fluent/core/file_reader/lispy.py
@@ -127,13 +127,22 @@ class InputPort:
             if self.line == "":
                 self.line = self.file.readline()
                 # Capture multiline string and replace newline characters with
-                # "<newline>" before passing to tokenizer
-                if count_unescaped_quotes(self.line) % 2:
-                    while True:
-                        next_line = self.file.readline()
-                        self.line = self.line.rstrip() + "<newline>" + next_line
-                        if count_unescaped_quotes(next_line) > 0:
-                            break
+                # "<newline>" before passing to tokenizer.
+                # Keep merging subsequent lines while the *cumulative* count
+                # of unescaped quotes across the whole buffer is odd (i.e.
+                # some string is still open). A newly merged line can both
+                # close one string and open another, which nets out to an
+                # even quote count for that line alone while the buffer as a
+                # whole is still unterminated, so we must recheck the total
+                # each time rather than just the newly read line.
+                while self.line != "" and count_unescaped_quotes(self.line) % 2:
+                    next_line = self.file.readline()
+                    if next_line == "":
+                        # Reached end of input while looking for the
+                        # closing quote of an unterminated string; stop
+                        # instead of looping forever.
+                        break
+                    self.line = self.line.rstrip() + "<newline>" + next_line
             if self.line == "":
                 return eof_object
             tok, self.line = re.match(InputPort.tokenizer, self.line).groups()

--- a/tests/test_lispy.py
+++ b/tests/test_lispy.py
@@ -44,6 +44,19 @@ scm_pys = (
     ("(x 1)", ["x", 1]),
     ('(x . "1.0 [m/s]")', ("x", '"1.0 [m/s]"')),
     ("(define x 1)", ["define", "x", 1]),
+    # A line nested within a multi-line buffer closes one string
+    # and opens another. This results in an even quote count for that specific
+    # line alone, but the cumulative buffer count remains odd.
+    #
+    # How the parser processes it line by line:
+    # Line 1: '("string1\n'           -> Buffer quotes: 1 (Odd)  -> Keeps reading
+    # Line 2: ' string2"\n "string3\n' -> Line quotes: 2 (Even)  -> Buffer quotes: 3 (Odd) -> Keeps reading
+    # Line 3: ' string4")'            -> Line quotes: 1 (Odd)   -> Buffer quotes: 4 (Even) -> Finishes string
+    (
+        '("string1\n string2"\n "string3\n string4")',
+        ['"string1\n string2"', '"string3\n string4"'],
+        '("string1\n string2" "string3\n string4")',
+    ),
 )
 
 extra_scm_pys = (

--- a/tests/test_lispy.py
+++ b/tests/test_lispy.py
@@ -44,6 +44,11 @@ scm_pys = (
     ("(x 1)", ["x", 1]),
     ('(x . "1.0 [m/s]")', ("x", '"1.0 [m/s]"')),
     ("(define x 1)", ["define", "x", 1]),
+)
+
+extra_scm_pys = (
+    ("(define x)", ["define", "x", None]),
+    ('(define "x")', []),
     # A line nested within a multi-line buffer closes one string
     # and opens another. This results in an even quote count for that specific
     # line alone, but the cumulative buffer count remains odd.
@@ -55,13 +60,7 @@ scm_pys = (
     (
         '("string1\n string2"\n "string3\n string4")',
         ['"string1\n string2"', '"string3\n string4"'],
-        '("string1\n string2" "string3\n string4")',
     ),
-)
-
-extra_scm_pys = (
-    ("(define x)", ["define", "x", None]),
-    ('(define "x")', []),
 )
 
 


### PR DESCRIPTION
## Context
The hang was an infinite loop in InputPort.next_token(), triggered by the specific .cas.h5 file's monitor/monitorsets data, where a file-name value (.\...tgk-1c.out) is written wrapped across **two line breaks** in a row (once for old-props, once for the real value).
 
Root cause: the multiline-string-continuation code only checked whether the newly merged line had any quote character (count_unescaped_quotes(next_line) > 0), not whether the merged buffer's quote count as a whole had become **even** (fully balanced). 

In the file attached in the bug description, the line merged in first both closes the original dangling string and opens a new one — its own quote count nets even, so the merge loop stopped one line too early. That left a literal, un-replaced newline character stuck inside the buffer, which the tokenizer's regex could never cross, causing it to return an empty token forever without the buffer ever changing — a true infinite loop.

## Change Summary
The merge loop now keeps pulling in more lines as long as the cumulative quote count across the whole buffer is odd (re-checking the full buffer each time), plus the earlier EOF guard to fail fast on truly malformed/truncated input.

## Rationale
This fix was needed as the Fluent reads this case perfectly.

## Impact
None, just the case-reader performs perfectly for these scenarios as given.
