### PR TITLE
ci: Avoid deleting the dev image in cleanup step

### DIFF
--- a/.ci/docker_data_cleaner.py
+++ b/.ci/docker_data_cleaner.py
@@ -34,14 +34,14 @@ def clean_docker_data():
             "docker",
             "images",
             "--format",
-            "{{.Repository}}:{{.Tag}} {{.ID}}",
+            "{{.Repository}}:{{.Tag}} {{.Digest}}",
             "--no-trunc",
         ]
     ).decode()
     for line in images_output.splitlines():
-        image, image_id = line.strip().split()
-        if image not in images_to_retain and image_id != dev_image_sha:
-            subprocess.run(["docker", "rmi", "-f", image_id], check=True)
+        image, image_sha = line.strip().split()
+        if image not in images_to_retain and image_sha != dev_image_sha:
+            subprocess.run(["docker", "rmi", "-f", image], check=True)
 
     # Remove everything else (networks, volumes)
     subprocess.run(["docker", "system", "prune", "-f", "--volumes"], check=True)

--- a/doc/changelog.d/5364.maintenance.md
+++ b/doc/changelog.d/5364.maintenance.md
@@ -1,0 +1,1 @@
+Avoid deleting the dev image in cleanup step


### PR DESCRIPTION
The dev image was unnecessarily cleaned up due to which it was downloaded a number of times possibly touching github's rate-limit.
