### PR TITLE
chore: Safe parse docker images during clean up.

### DIFF
--- a/.ci/docker_data_cleaner.py
+++ b/.ci/docker_data_cleaner.py
@@ -34,18 +34,17 @@ def clean_docker_data():
             "docker",
             "images",
             "--format",
-            "{{.Repository}}:{{.Tag}} {{.Digest}}",
+            "{{.Repository}}:{{.Tag}}\t{{.Digest}}\t{{.ID}}",
             "--no-trunc",
         ]
     ).decode()
     for line in images_output.splitlines():
-        parts = line.strip().split(maxsplit=1)
-        if not parts:
+        image, image_sha, image_id = line.split("\t")
+        if not image:
             continue
-        image = parts[0]
-        image_sha = parts[1] if len(parts) > 1 else ""
         if image not in images_to_retain and image_sha != dev_image_sha:
-            subprocess.run(["docker", "rmi", "-f", image], check=True)
+            image_reference = image_id if image.endswith(":<none>") else image
+            subprocess.run(["docker", "rmi", "-f", image_reference], check=True)
 
     # Remove everything else (networks, volumes)
     subprocess.run(["docker", "system", "prune", "-f", "--volumes"], check=True)

--- a/.ci/docker_data_cleaner.py
+++ b/.ci/docker_data_cleaner.py
@@ -39,7 +39,11 @@ def clean_docker_data():
         ]
     ).decode()
     for line in images_output.splitlines():
-        image, image_sha = line.strip().split()
+        parts = line.strip().split(maxsplit=1)
+        if not parts:
+            continue
+        image = parts[0]
+        image_sha = parts[1] if len(parts) > 1 else ""
         if image not in images_to_retain and image_sha != dev_image_sha:
             subprocess.run(["docker", "rmi", "-f", image], check=True)
 

--- a/doc/changelog.d/5365.maintenance.md
+++ b/doc/changelog.d/5365.maintenance.md
@@ -1,0 +1,1 @@
+Safe parse docker images during clean up.


### PR DESCRIPTION
## Context
Some Docker image rows have no digest token, so the unpack at split() raised ValueError when only one field was present.

## Change Summary
Safe parsing to skip empty rows and use id when digest is missing else use digest.



The clean Docker image step was failing in the main branch:
https://github.com/ansys/pyfluent/actions/runs/33530740394/job/100106484971

This PR resolves it.