### PR TITLE
chore: Bump 'nltk' version to fix vulnerability.

### DIFF
--- a/doc/changelog.d/5378.maintenance.md
+++ b/doc/changelog.d/5378.maintenance.md
@@ -1,0 +1,1 @@
+Bump 'nltk' version to fix vulnerability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ include = ["src/ansys/fluent/core/generated/"]
 reader = ["h5py>=3.15.1"]
 ui-jupyter = ["ipywidgets>=8.1.8"]
 ui = ["panel>=1.8.1"]
-search = ["nltk>=3.9.3"]
+search = ["nltk>=3.10.3"]
 tests = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",


### PR DESCRIPTION
Bump 'nltk' version to fix vulnerability.

3.9.3 -> 3.10.3
