### PR TITLE
fix: Maximum Fluent version's compatibility.

### DIFF
--- a/doc/changelog.d/5380.fixed.md
+++ b/doc/changelog.d/5380.fixed.md
@@ -1,0 +1,1 @@
+Maximum Fluent version's compatibility.

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -30,8 +30,10 @@ import os
 from pathlib import Path
 import platform
 from typing import Any
+import warnings
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core.exceptions import PyFluentUserWarning
 from ansys.fluent.core.module_config import config
 
 __all__ = ("FluentVersion",)
@@ -103,15 +105,40 @@ class FluentVersion(Enum):
     @classmethod
     def _missing_(cls, version: Any):
         if isinstance(version, (int, float, str)):
+            original_version = version
             version = str(version)
-            if len(version) == 3:
+            if len(version) == 3 and version.isdigit():
                 version = version[:2] + "." + version[2:]
-            version += ".0"
-            for member in cls:
-                if version == member.value:
-                    return member
+            try:
+                version_parts = tuple(int(part) for part in version.split(".")[:2])
+            except ValueError as ex:
+                raise AnsysVersionNotFound(original_version) from ex
+            if len(version_parts) == 2:
+                normalized_version = f"{version_parts[0]}.{version_parts[1]}.0"
+                for member in cls:
+                    if normalized_version == member.value:
+                        return member
 
-        raise AnsysVersionNotFound(version[:-2])
+                newest_member = max(
+                    cls,
+                    key=lambda member: tuple(
+                        int(part) for part in member.value.split(".")[:2]
+                    ),
+                )
+                newest_parts = tuple(
+                    int(part) for part in newest_member.value.split(".")[:2]
+                )
+                if version_parts > newest_parts:
+                    warnings.warn(
+                        f"Fluent version {original_version} is newer than the newest "
+                        f"version known by PyFluent ({newest_member.value}). PyFluent "
+                        f"will use {newest_member.value} compatibility behavior.",
+                        PyFluentUserWarning,
+                        stacklevel=2,
+                    )
+                    return newest_member
+
+        raise AnsysVersionNotFound(version)
 
     @classmethod
     def get_latest_installed(cls):

--- a/tests/test_fluent_version.py
+++ b/tests/test_fluent_version.py
@@ -23,6 +23,7 @@
 
 import pytest
 
+from ansys.fluent.core.exceptions import PyFluentUserWarning
 from ansys.fluent.core.utils.fluent_version import (
     AnsysVersionNotFound,
     FluentVersion,
@@ -55,6 +56,9 @@ def test_version_not_found():
 
     with pytest.raises(AnsysVersionNotFound):
         FluentVersion(22)
+
+    with pytest.warns(PyFluentUserWarning, match="newer than"):
+        assert FluentVersion("28.2.0") == max(FluentVersion)
 
 
 def test_get_latest_installed(helpers, fs):


### PR DESCRIPTION
## Context
While trying to connect PyFluent with newer Fluent versions (more than in the list of compatible versions), we used to throw an error that it is not supported.

## Change Summary
1. Updated FluentVersion._missing_() so versions newer than the highest known version emit PyFluentUserWarning and use the highest known FluentVersion

2. Older or unsupported intermediate versions still raise AnsysVersionNotFound.

3. Added a focused test for FluentVersion("28.2.0")

## Rationale
To support newer Fluent release without updating the compatibility list urgently.

