### PR TITLE
fix: Maximum Fluent version's compatibility.

### DIFF
--- a/doc/changelog.d/5381.fixed.md
+++ b/doc/changelog.d/5381.fixed.md
@@ -1,0 +1,1 @@
+Maximum Fluent version's compatibility.

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -124,7 +124,8 @@ class FluentVersion(Enum):
                     return member
 
             latest = next(iter(cls))
-            if _version_to_integer(requested_version) > latest.number:
+            version_as_int = _version_to_integer(requested_version) # requires no-raise
+            if version_as_int is None or _version_to_integer(requested_version) > latest.number:
                 warnings.warn(
                     f"Fluent version '{requested_version}' is newer than the highest "
                     f"supported version '{latest.value}'; using '{latest.value}' instead.",

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -127,7 +127,8 @@ class FluentVersion(Enum):
             version_as_int = _version_to_integer(requested_version) # requires no-raise
             if version_as_int is None or _version_to_integer(requested_version) > latest.number:
                 warnings.warn(
-                    f"Fluent version '{requested_version}' is newer than the highest "
+                    # should actually handle the two different scenarios separately
+                    f"Fluent version '{requested_version}' is either unrecognized or newer than the highest "
                     f"supported version '{latest.value}'; using '{latest.value}' instead.",
                     PyFluentUserWarning,
                     stacklevel=2,

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -88,8 +88,10 @@ def _version_to_integer(version: Any) -> int:
     try:
         parts = str(version).split(".")
         return int(parts[0] + parts[1]) if len(parts) > 1 else int(parts[0])
-     except Exception:
-        pass # or explicitly return None
+    except Exception:
+        return (
+            None  # Return None instead of raising an exception for unrecognized formats
+        )
 
 
 @total_ordering
@@ -127,8 +129,11 @@ class FluentVersion(Enum):
                     return member
 
             latest = next(iter(cls))
-            version_as_int = _version_to_integer(requested_version) # requires no-raise
-            if version_as_int is None or _version_to_integer(requested_version) > latest.number:
+            version_as_int = _version_to_integer(requested_version)  # requires no-raise
+            if (
+                version_as_int is None
+                or _version_to_integer(requested_version) > latest.number
+            ):
                 warnings.warn(
                     # should actually handle the two different scenarios separately
                     f"Fluent version '{requested_version}' is either unrecognized or newer than the highest "

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -83,15 +83,13 @@ def get_version_for_file_name(version: str | None = None, session=None):
     return "".join(version.split(".")[0:2])
 
 
-def _version_to_integer(version: Any) -> int:
+def _version_to_integer(version: Any) -> int | None:
     """Convert a Fluent version to its integer representation."""
     try:
         parts = str(version).split(".")
         return int(parts[0] + parts[1]) if len(parts) > 1 else int(parts[0])
-    except Exception:
-        return (
-            None  # Return None instead of raising an exception for unrecognized formats
-        )
+    except ValueError:
+        return None
 
 
 @total_ordering
@@ -130,12 +128,17 @@ class FluentVersion(Enum):
 
             latest = next(iter(cls))
             version_as_int = _version_to_integer(requested_version)
-            if (
-                version_as_int is None
-                or _version_to_integer(requested_version) > latest.number
-            ):
+            if version_as_int is None:
                 warnings.warn(
-                    f"Fluent version '{requested_version}' is either unrecognized or newer than the highest "
+                    f"Fluent version '{requested_version}' is unrecognized; using the "
+                    f"highest supported version '{latest.value}' instead.",
+                    PyFluentUserWarning,
+                    stacklevel=2,
+                )
+                return latest
+            if version_as_int > latest.number:
+                warnings.warn(
+                    f"Fluent version '{requested_version}' is newer than the highest "
                     f"supported version '{latest.value}'; using '{latest.value}' instead.",
                     PyFluentUserWarning,
                     stacklevel=2,

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -85,8 +85,11 @@ def get_version_for_file_name(version: str | None = None, session=None):
 
 def _version_to_integer(version: Any) -> int:
     """Convert a Fluent version to its integer representation."""
-    parts = str(version).split(".")
-    return int(parts[0] + parts[1]) if len(parts) > 1 else int(parts[0])
+    try:
+        parts = str(version).split(".")
+        return int(parts[0] + parts[1]) if len(parts) > 1 else int(parts[0])
+     except Exception:
+        pass # or explicitly return None
 
 
 @total_ordering

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -129,7 +129,7 @@ class FluentVersion(Enum):
                     return member
 
             latest = next(iter(cls))
-            version_as_int = _version_to_integer(requested_version)  # requires no-raise
+            version_as_int = _version_to_integer(requested_version)
             if (
                 version_as_int is None
                 or _version_to_integer(requested_version) > latest.number

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -135,7 +135,6 @@ class FluentVersion(Enum):
                 or _version_to_integer(requested_version) > latest.number
             ):
                 warnings.warn(
-                    # should actually handle the two different scenarios separately
                     f"Fluent version '{requested_version}' is either unrecognized or newer than the highest "
                     f"supported version '{latest.value}'; using '{latest.value}' instead.",
                     PyFluentUserWarning,

--- a/src/ansys/fluent/core/utils/fluent_version.py
+++ b/src/ansys/fluent/core/utils/fluent_version.py
@@ -30,8 +30,10 @@ import os
 from pathlib import Path
 import platform
 from typing import Any
+import warnings
 
 import ansys.fluent.core as pyfluent
+from ansys.fluent.core.exceptions import PyFluentUserWarning
 from ansys.fluent.core.module_config import config
 
 __all__ = ("FluentVersion",)
@@ -81,6 +83,12 @@ def get_version_for_file_name(version: str | None = None, session=None):
     return "".join(version.split(".")[0:2])
 
 
+def _version_to_integer(version: Any) -> int:
+    """Convert a Fluent version to its integer representation."""
+    parts = str(version).split(".")
+    return int(parts[0] + parts[1]) if len(parts) > 1 else int(parts[0])
+
+
 @total_ordering
 class FluentVersion(Enum):
     """An enumeration over supported Fluent versions.
@@ -103,15 +111,29 @@ class FluentVersion(Enum):
     @classmethod
     def _missing_(cls, version: Any):
         if isinstance(version, (int, float, str)):
-            version = str(version)
-            if len(version) == 3:
-                version = version[:2] + "." + version[2:]
-            version += ".0"
+            requested_version = str(version)
+            normalized_version = requested_version
+            if len(normalized_version) == 3 and "." not in normalized_version:
+                normalized_version = (
+                    normalized_version[:2] + "." + normalized_version[2:]
+                )
+            if normalized_version.count(".") == 1:
+                normalized_version += ".0"
             for member in cls:
-                if version == member.value:
+                if normalized_version == member.value:
                     return member
 
-        raise AnsysVersionNotFound(version[:-2])
+            latest = next(iter(cls))
+            if _version_to_integer(requested_version) > latest.number:
+                warnings.warn(
+                    f"Fluent version '{requested_version}' is newer than the highest "
+                    f"supported version '{latest.value}'; using '{latest.value}' instead.",
+                    PyFluentUserWarning,
+                    stacklevel=2,
+                )
+                return latest
+
+        raise AnsysVersionNotFound(version)
 
     @classmethod
     def get_latest_installed(cls):

--- a/tests/test_fluent_version.py
+++ b/tests/test_fluent_version.py
@@ -67,6 +67,11 @@ def test_newer_version_uses_latest(version):
         assert FluentVersion(version) == FluentVersion.v271
 
 
+def test_unrecognized_version_uses_latest():
+    with pytest.warns(PyFluentUserWarning, match="'invalid' is unrecognized"):
+        assert FluentVersion("invalid") == FluentVersion.v271
+
+
 def test_get_latest_installed(helpers, fs):
     helpers.mock_awp_vars()
     with pytest.raises(FileNotFoundError):

--- a/tests/test_fluent_version.py
+++ b/tests/test_fluent_version.py
@@ -23,6 +23,7 @@
 
 import pytest
 
+from ansys.fluent.core.exceptions import PyFluentUserWarning
 from ansys.fluent.core.utils.fluent_version import (
     AnsysVersionNotFound,
     FluentVersion,
@@ -54,7 +55,16 @@ def test_version_not_found():
         FluentVersion("24.1.0")
 
     with pytest.raises(AnsysVersionNotFound):
+        FluentVersion("26.2.0")
+
+    with pytest.raises(AnsysVersionNotFound):
         FluentVersion(22)
+
+
+@pytest.mark.parametrize("version", ["27.2.0", 27.2, 272])
+def test_newer_version_uses_latest(version):
+    with pytest.warns(PyFluentUserWarning, match="newer than"):
+        assert FluentVersion(version) == FluentVersion.v271
 
 
 def test_get_latest_installed(helpers, fs):


### PR DESCRIPTION
## Context
While trying to connect PyFluent with newer Fluent versions (more than in the list of compatible versions), we used to throw an error that it is not supported.

## Change Summary
1. Updated FluentVersion._missing_() so versions newer than the highest known version emit PyFluentUserWarning and use the highest known FluentVersion

2. Older or unsupported intermediate versions still raise AnsysVersionNotFound.

3. Added a focused test for FluentVersion("28.2.0")

## Rationale
To support newer Fluent release without updating the compatibility list urgently.
